### PR TITLE
Register event and venue CPTs with custom statuses

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Central plugin orchestrator.
+ *
+ * @package Groups
+ */
+
+namespace Groups;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Plugin class — singleton orchestrator that wires up all sub-components.
+ */
+class Plugin {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Plugin|null
+	 */
+	private static ?Plugin $instance = null;
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return Plugin
+	 */
+	public static function get_instance(): Plugin {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor — private, use get_instance().
+	 */
+	private function __construct() {
+		$this->init_components();
+	}
+
+	/**
+	 * Initialise plugin components.
+	 */
+	private function init_components(): void {
+		new Post_Types\Event();
+		new Post_Types\Venue();
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/post-types/class-event.php
+++ b/wp-content/plugins/wordpress-groups/includes/post-types/class-event.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Event custom post type registration.
+ *
+ * @package Groups\Post_Types
+ */
+
+namespace Groups\Post_Types;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the `event` CPT and its custom statuses.
+ */
+class Event {
+
+	/**
+	 * Post type key.
+	 *
+	 * @var string
+	 */
+	const POST_TYPE = 'event';
+
+	/**
+	 * Custom statuses for events.
+	 *
+	 * @var array<string, string>
+	 */
+	const STATUSES = [
+		'event-draft'     => 'Draft',
+		'event-scheduled' => 'Scheduled',
+		'event-active'    => 'Active',
+		'event-past'      => 'Past',
+		'event-cancelled' => 'Cancelled',
+	];
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', [ $this, 'register_post_type' ] );
+		add_action( 'init', [ $this, 'register_post_statuses' ] );
+	}
+
+	/**
+	 * Register the event post type.
+	 */
+	public function register_post_type(): void {
+		$labels = [
+			'name'                  => __( 'Events', 'wordpress-groups' ),
+			'singular_name'        => __( 'Event', 'wordpress-groups' ),
+			'add_new'              => __( 'Add New', 'wordpress-groups' ),
+			'add_new_item'         => __( 'Add New Event', 'wordpress-groups' ),
+			'edit_item'            => __( 'Edit Event', 'wordpress-groups' ),
+			'new_item'             => __( 'New Event', 'wordpress-groups' ),
+			'view_item'            => __( 'View Event', 'wordpress-groups' ),
+			'view_items'           => __( 'View Events', 'wordpress-groups' ),
+			'search_items'         => __( 'Search Events', 'wordpress-groups' ),
+			'not_found'            => __( 'No events found.', 'wordpress-groups' ),
+			'not_found_in_trash'   => __( 'No events found in Trash.', 'wordpress-groups' ),
+			'all_items'            => __( 'All Events', 'wordpress-groups' ),
+			'archives'             => __( 'Event Archives', 'wordpress-groups' ),
+			'attributes'           => __( 'Event Attributes', 'wordpress-groups' ),
+			'insert_into_item'     => __( 'Insert into event', 'wordpress-groups' ),
+			'uploaded_to_this_item' => __( 'Uploaded to this event', 'wordpress-groups' ),
+			'menu_name'            => __( 'Events', 'wordpress-groups' ),
+		];
+
+		$args = [
+			'labels'              => $labels,
+			'public'              => true,
+			'publicly_queryable'  => true,
+			'show_ui'             => true,
+			'show_in_menu'        => true,
+			'show_in_rest'        => true,
+			'rest_base'           => 'events',
+			'menu_position'       => 5,
+			'menu_icon'           => 'dashicons-calendar-alt',
+			'supports'            => [ 'title', 'editor', 'thumbnail', 'excerpt', 'custom-fields' ],
+			'has_archive'         => true,
+			'rewrite'             => [ 'slug' => 'event' ],
+			'capability_type'     => 'post',
+			'map_meta_cap'        => true,
+		];
+
+		register_post_type( self::POST_TYPE, $args );
+	}
+
+	/**
+	 * Register custom post statuses for events.
+	 */
+	public function register_post_statuses(): void {
+		foreach ( self::STATUSES as $status => $label ) {
+			register_post_status(
+				$status,
+				[
+					'label'                     => __( $label, 'wordpress-groups' ),
+					'public'                    => true,
+					'exclude_from_search'       => false,
+					'show_in_admin_all_list'    => true,
+					'show_in_admin_status_list' => true,
+					/* translators: %s: Number of posts. */
+					'label_count'               => _n_noop(
+						$label . ' <span class="count">(%s)</span>',
+						$label . ' <span class="count">(%s)</span>',
+						'wordpress-groups'
+					),
+				]
+			);
+		}
+	}
+
+	/**
+	 * Get all custom status slugs.
+	 *
+	 * @return string[]
+	 */
+	public static function get_statuses(): array {
+		return array_keys( self::STATUSES );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/post-types/class-venue.php
+++ b/wp-content/plugins/wordpress-groups/includes/post-types/class-venue.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Venue custom post type registration.
+ *
+ * @package Groups\Post_Types
+ */
+
+namespace Groups\Post_Types;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the `venue` CPT.
+ */
+class Venue {
+
+	/**
+	 * Post type key.
+	 *
+	 * @var string
+	 */
+	const POST_TYPE = 'venue';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', [ $this, 'register_post_type' ] );
+	}
+
+	/**
+	 * Register the venue post type.
+	 */
+	public function register_post_type(): void {
+		$labels = [
+			'name'                  => __( 'Venues', 'wordpress-groups' ),
+			'singular_name'        => __( 'Venue', 'wordpress-groups' ),
+			'add_new'              => __( 'Add New', 'wordpress-groups' ),
+			'add_new_item'         => __( 'Add New Venue', 'wordpress-groups' ),
+			'edit_item'            => __( 'Edit Venue', 'wordpress-groups' ),
+			'new_item'             => __( 'New Venue', 'wordpress-groups' ),
+			'view_item'            => __( 'View Venue', 'wordpress-groups' ),
+			'view_items'           => __( 'View Venues', 'wordpress-groups' ),
+			'search_items'         => __( 'Search Venues', 'wordpress-groups' ),
+			'not_found'            => __( 'No venues found.', 'wordpress-groups' ),
+			'not_found_in_trash'   => __( 'No venues found in Trash.', 'wordpress-groups' ),
+			'all_items'            => __( 'All Venues', 'wordpress-groups' ),
+			'archives'             => __( 'Venue Archives', 'wordpress-groups' ),
+			'attributes'           => __( 'Venue Attributes', 'wordpress-groups' ),
+			'insert_into_item'     => __( 'Insert into venue', 'wordpress-groups' ),
+			'uploaded_to_this_item' => __( 'Uploaded to this venue', 'wordpress-groups' ),
+			'menu_name'            => __( 'Venues', 'wordpress-groups' ),
+		];
+
+		$args = [
+			'labels'              => $labels,
+			'public'              => true,
+			'publicly_queryable'  => true,
+			'show_ui'             => true,
+			'show_in_menu'        => true,
+			'show_in_rest'        => true,
+			'rest_base'           => 'venues',
+			'menu_position'       => 6,
+			'menu_icon'           => 'dashicons-location',
+			'supports'            => [ 'title', 'editor', 'thumbnail' ],
+			'has_archive'         => true,
+			'rewrite'             => [ 'slug' => 'venue' ],
+			'capability_type'     => 'post',
+			'map_meta_cap'        => true,
+		];
+
+		register_post_type( self::POST_TYPE, $args );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/post-types/test-event.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/post-types/test-event.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Tests for the Event CPT registration.
+ *
+ * @package Groups\Tests
+ */
+
+namespace Groups\Tests\Post_Types;
+
+use Groups\Post_Types\Event;
+use WP_UnitTestCase;
+
+/**
+ * @coversDefaultClass \Groups\Post_Types\Event
+ */
+class Test_Event extends WP_UnitTestCase {
+
+	/**
+	 * Set up each test — ensure the CPT and statuses are registered.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// Trigger registration if not already done.
+		$event = new Event();
+		$event->register_post_type();
+		$event->register_post_statuses();
+	}
+
+	/**
+	 * @covers ::register_post_type
+	 */
+	public function test_event_post_type_is_registered(): void {
+		$this->assertTrue( post_type_exists( 'event' ) );
+	}
+
+	/**
+	 * @covers ::register_post_type
+	 */
+	public function test_event_cpt_is_public(): void {
+		$post_type = get_post_type_object( 'event' );
+
+		$this->assertTrue( $post_type->public );
+	}
+
+	/**
+	 * @covers ::register_post_type
+	 */
+	public function test_event_cpt_shows_in_rest(): void {
+		$post_type = get_post_type_object( 'event' );
+
+		$this->assertTrue( $post_type->show_in_rest );
+	}
+
+	/**
+	 * @covers ::register_post_type
+	 */
+	public function test_event_cpt_supports(): void {
+		$this->assertTrue( post_type_supports( 'event', 'title' ) );
+		$this->assertTrue( post_type_supports( 'event', 'editor' ) );
+		$this->assertTrue( post_type_supports( 'event', 'thumbnail' ) );
+		$this->assertTrue( post_type_supports( 'event', 'excerpt' ) );
+		$this->assertTrue( post_type_supports( 'event', 'custom-fields' ) );
+	}
+
+	/**
+	 * @covers ::register_post_statuses
+	 */
+	public function test_custom_statuses_are_registered(): void {
+		$expected = [
+			'event-draft',
+			'event-scheduled',
+			'event-active',
+			'event-past',
+			'event-cancelled',
+		];
+
+		foreach ( $expected as $status ) {
+			$status_obj = get_post_status_object( $status );
+			$this->assertNotNull( $status_obj, "Status '{$status}' should be registered." );
+			$this->assertTrue( $status_obj->public, "Status '{$status}' should be public." );
+		}
+	}
+
+	/**
+	 * @covers ::get_statuses
+	 */
+	public function test_get_statuses_returns_all_status_slugs(): void {
+		$statuses = Event::get_statuses();
+
+		$this->assertCount( 5, $statuses );
+		$this->assertContains( 'event-draft', $statuses );
+		$this->assertContains( 'event-scheduled', $statuses );
+		$this->assertContains( 'event-active', $statuses );
+		$this->assertContains( 'event-past', $statuses );
+		$this->assertContains( 'event-cancelled', $statuses );
+	}
+
+	/**
+	 * @covers ::register_post_type
+	 */
+	public function test_event_cpt_has_archive(): void {
+		$post_type = get_post_type_object( 'event' );
+
+		$this->assertTrue( $post_type->has_archive );
+	}
+
+	/**
+	 * Test that an event post can be created with a custom status.
+	 */
+	public function test_can_create_event_with_custom_status(): void {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'   => 'event',
+				'post_status' => 'event-scheduled',
+				'post_title'  => 'Test Event',
+			]
+		);
+
+		$this->assertIsInt( $post_id );
+		$this->assertEquals( 'event-scheduled', get_post_status( $post_id ) );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/post-types/test-venue.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/post-types/test-venue.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Tests for the Venue CPT registration.
+ *
+ * @package Groups\Tests
+ */
+
+namespace Groups\Tests\Post_Types;
+
+use Groups\Post_Types\Venue;
+use WP_UnitTestCase;
+
+/**
+ * @coversDefaultClass \Groups\Post_Types\Venue
+ */
+class Test_Venue extends WP_UnitTestCase {
+
+	/**
+	 * Set up each test — ensure the CPT is registered.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$venue = new Venue();
+		$venue->register_post_type();
+	}
+
+	/**
+	 * @covers ::register_post_type
+	 */
+	public function test_venue_post_type_is_registered(): void {
+		$this->assertTrue( post_type_exists( 'venue' ) );
+	}
+
+	/**
+	 * @covers ::register_post_type
+	 */
+	public function test_venue_cpt_is_public(): void {
+		$post_type = get_post_type_object( 'venue' );
+
+		$this->assertTrue( $post_type->public );
+	}
+
+	/**
+	 * @covers ::register_post_type
+	 */
+	public function test_venue_cpt_shows_in_rest(): void {
+		$post_type = get_post_type_object( 'venue' );
+
+		$this->assertTrue( $post_type->show_in_rest );
+	}
+
+	/**
+	 * @covers ::register_post_type
+	 */
+	public function test_venue_cpt_supports(): void {
+		$this->assertTrue( post_type_supports( 'venue', 'title' ) );
+		$this->assertTrue( post_type_supports( 'venue', 'editor' ) );
+		$this->assertTrue( post_type_supports( 'venue', 'thumbnail' ) );
+	}
+
+	/**
+	 * @covers ::register_post_type
+	 */
+	public function test_venue_cpt_does_not_support_excerpt(): void {
+		$this->assertFalse( post_type_supports( 'venue', 'excerpt' ) );
+	}
+
+	/**
+	 * @covers ::register_post_type
+	 */
+	public function test_venue_cpt_has_archive(): void {
+		$post_type = get_post_type_object( 'venue' );
+
+		$this->assertTrue( $post_type->has_archive );
+	}
+
+	/**
+	 * Test that a venue post can be created.
+	 */
+	public function test_can_create_venue(): void {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'   => 'venue',
+				'post_status' => 'publish',
+				'post_title'  => 'Test Venue',
+			]
+		);
+
+		$this->assertIsInt( $post_id );
+		$this->assertEquals( 'publish', get_post_status( $post_id ) );
+		$this->assertEquals( 'venue', get_post_type( $post_id ) );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/wordpress-groups.php
+++ b/wp-content/plugins/wordpress-groups/wordpress-groups.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Plugin Name: WordPress Groups
+ * Description: WordPress community groups platform for events.wordpress.org.
+ * Version: 0.1.0
+ * Requires at least: 6.7
+ * Requires PHP: 8.3
+ * Network: true
+ * Text Domain: wordpress-groups
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'GROUPS_PLUGIN_DIR', __DIR__ );
+define( 'GROUPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define( 'GROUPS_PLUGIN_VERSION', '0.1.0' );
+
+// WordPress.org autoloader.
+if ( function_exists( 'WordPressdotorg\Autoload\register_class_path' ) ) {
+	\WordPressdotorg\Autoload\register_class_path( 'Groups', __DIR__ . '/includes' );
+} else {
+	// Fallback autoloader for standalone development.
+	spl_autoload_register( function ( $class ) {
+		$prefix = 'Groups\\';
+		if ( strncmp( $prefix, $class, strlen( $prefix ) ) !== 0 ) {
+			return;
+		}
+
+		$relative = substr( $class, strlen( $prefix ) );
+		$parts    = explode( '\\', $relative );
+		$filename = 'class-' . strtolower( str_replace( '_', '-', array_pop( $parts ) ) ) . '.php';
+		$path     = __DIR__ . '/includes/'
+			. ( $parts ? strtolower( implode( '/', array_map( fn( $p ) => str_replace( '_', '-', $p ), $parts ) ) ) . '/' : '' )
+			. $filename;
+
+		if ( file_exists( $path ) ) {
+			require_once $path;
+		}
+	} );
+}
+
+// Boot the plugin.
+require_once __DIR__ . '/includes/class-plugin.php';
+Groups\Plugin::get_instance();


### PR DESCRIPTION
## Summary
- Registers `event` CPT with five custom statuses (`event-draft`, `event-scheduled`, `event-active`, `event-past`, `event-cancelled`) via `register_post_status()`
- Registers `venue` CPT with standard `publish`/`draft` statuses
- Adds plugin bootstrap (`wordpress-groups.php`) with constants, fallback autoloader, and `Plugin` orchestrator class
- Includes PHPUnit test stubs for both CPTs covering registration, REST visibility, supports, and custom status creation

## Test plan
- [ ] Activate plugin and verify `event` and `venue` appear in the admin menu
- [ ] Confirm `show_in_rest` is enabled for both CPTs (check `/wp-json/wp/v2/events` and `/wp-json/wp/v2/venues`)
- [ ] Create an event post with `event-scheduled` status and verify it persists
- [ ] Run PHPUnit tests: `wp-env run tests-cli --env-cwd=wp-content/plugins/wordpress-groups phpunit`

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)