### PR TITLE
Add database schema for network-wide custom tables

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/database/class-schema.php
+++ b/wp-content/plugins/wordpress-groups/includes/database/class-schema.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Database schema for network-wide custom tables.
+ *
+ * @package Groups\Database
+ */
+
+namespace Groups\Database;
+
+/**
+ * Manages creation and versioning of the two network-wide custom tables:
+ * - groups_analytics_daily
+ * - groups_activity_log
+ */
+class Schema {
+
+	/**
+	 * Current schema version.
+	 */
+	const VERSION = 1;
+
+	/**
+	 * Option key for storing the schema version (network option).
+	 */
+	const VERSION_OPTION = 'groups_db_version';
+
+	/**
+	 * Create or update both custom tables using dbDelta.
+	 */
+	public static function create_tables() {
+		global $wpdb;
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		$charset_collate = $wpdb->get_charset_collate();
+		$base_prefix     = $wpdb->base_prefix;
+
+		$sql = self::get_schema( $base_prefix, $charset_collate );
+
+		dbDelta( $sql );
+
+		self::update_schema_version( self::VERSION );
+	}
+
+	/**
+	 * Return the full SQL schema for both tables.
+	 *
+	 * @param string $base_prefix     The network base prefix.
+	 * @param string $charset_collate The charset collate string.
+	 * @return string SQL statements separated by semicolons.
+	 */
+	public static function get_schema( $base_prefix, $charset_collate ) {
+		$analytics_table = "{$base_prefix}groups_analytics_daily";
+		$activity_table  = "{$base_prefix}groups_activity_log";
+
+		return "CREATE TABLE {$analytics_table} (
+	id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+	date DATE NOT NULL,
+	blog_id BIGINT UNSIGNED NOT NULL,
+	metric VARCHAR(50) NOT NULL,
+	value BIGINT NOT NULL DEFAULT 0,
+	PRIMARY KEY  (id),
+	UNIQUE KEY date_blog_metric (date, blog_id, metric),
+	KEY blog_id (blog_id)
+) {$charset_collate};
+CREATE TABLE {$activity_table} (
+	id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+	blog_id BIGINT UNSIGNED NOT NULL,
+	user_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
+	action VARCHAR(50) NOT NULL,
+	object_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
+	meta LONGTEXT,
+	created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY  (id),
+	KEY blog_id_created (blog_id, created_at),
+	KEY action_created (action, created_at)
+) {$charset_collate};";
+	}
+
+	/**
+	 * Get the stored schema version.
+	 *
+	 * @return int The stored version, or 0 if not set.
+	 */
+	public static function get_schema_version() {
+		return (int) get_site_option( self::VERSION_OPTION, 0 );
+	}
+
+	/**
+	 * Update the stored schema version.
+	 *
+	 * @param int $version The version number to store.
+	 */
+	public static function update_schema_version( $version ) {
+		update_site_option( self::VERSION_OPTION, (int) $version );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/database/test-schema.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/database/test-schema.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tests for the database schema creation.
+ *
+ * @package Groups\Tests\Database
+ */
+
+namespace Groups\Tests\Database;
+
+use Groups\Database\Schema;
+use WP_UnitTestCase;
+
+/**
+ * @group database
+ */
+class Test_Schema extends WP_UnitTestCase {
+
+	/**
+	 * Test that both custom tables are created after calling create_tables().
+	 */
+	public function test_create_tables() {
+		global $wpdb;
+
+		Schema::create_tables();
+
+		$analytics_table = $wpdb->base_prefix . 'groups_analytics_daily';
+		$activity_table  = $wpdb->base_prefix . 'groups_activity_log';
+
+		// Verify tables exist by querying SHOW TABLES.
+		$tables = $wpdb->get_col( 'SHOW TABLES' );
+
+		$this->assertContains( $analytics_table, $tables, 'groups_analytics_daily table should exist.' );
+		$this->assertContains( $activity_table, $tables, 'groups_activity_log table should exist.' );
+	}
+
+	/**
+	 * Test that the analytics_daily table has the expected columns.
+	 */
+	public function test_analytics_daily_columns() {
+		global $wpdb;
+
+		Schema::create_tables();
+
+		$table   = $wpdb->base_prefix . 'groups_analytics_daily';
+		$columns = $wpdb->get_results( "DESCRIBE {$table}" );
+		$col_names = wp_list_pluck( $columns, 'Field' );
+
+		$expected = array( 'id', 'date', 'blog_id', 'metric', 'value' );
+		foreach ( $expected as $col ) {
+			$this->assertContains( $col, $col_names, "Column {$col} should exist in groups_analytics_daily." );
+		}
+	}
+
+	/**
+	 * Test that the activity_log table has the expected columns.
+	 */
+	public function test_activity_log_columns() {
+		global $wpdb;
+
+		Schema::create_tables();
+
+		$table   = $wpdb->base_prefix . 'groups_activity_log';
+		$columns = $wpdb->get_results( "DESCRIBE {$table}" );
+		$col_names = wp_list_pluck( $columns, 'Field' );
+
+		$expected = array( 'id', 'blog_id', 'user_id', 'action', 'object_id', 'meta', 'created_at' );
+		foreach ( $expected as $col ) {
+			$this->assertContains( $col, $col_names, "Column {$col} should exist in groups_activity_log." );
+		}
+	}
+
+	/**
+	 * Test that the schema version is stored after table creation.
+	 */
+	public function test_schema_version_stored() {
+		Schema::create_tables();
+
+		$version = Schema::get_schema_version();
+		$this->assertSame( Schema::VERSION, $version, 'Schema version should be stored as a network option.' );
+	}
+
+	/**
+	 * Test get_schema_version returns 0 when not set.
+	 */
+	public function test_schema_version_default() {
+		delete_site_option( Schema::VERSION_OPTION );
+
+		$this->assertSame( 0, Schema::get_schema_version(), 'Schema version should default to 0.' );
+	}
+
+	/**
+	 * Test update_schema_version stores the correct value.
+	 */
+	public function test_update_schema_version() {
+		Schema::update_schema_version( 5 );
+
+		$this->assertSame( 5, Schema::get_schema_version() );
+	}
+
+	/**
+	 * Test that create_tables is idempotent (can be called multiple times).
+	 */
+	public function test_create_tables_idempotent() {
+		Schema::create_tables();
+		Schema::create_tables();
+
+		global $wpdb;
+		$tables = $wpdb->get_col( 'SHOW TABLES' );
+
+		$analytics_table = $wpdb->base_prefix . 'groups_analytics_daily';
+		$activity_table  = $wpdb->base_prefix . 'groups_activity_log';
+
+		$this->assertContains( $analytics_table, $tables );
+		$this->assertContains( $activity_table, $tables );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/wordpress-groups.php
+++ b/wp-content/plugins/wordpress-groups/wordpress-groups.php
@@ -6,12 +6,14 @@
  * Requires at least: 6.7
  * Requires PHP: 8.3
  * Network: true
+ * Author: WordPress.org Meta Team
  * Text Domain: wordpress-groups
  */
 
 defined( 'ABSPATH' ) || exit;
 
 define( 'GROUPS_PLUGIN_DIR', __DIR__ );
+define( 'GROUPS_PLUGIN_FILE', __FILE__ );
 define( 'GROUPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'GROUPS_PLUGIN_VERSION', '0.1.0' );
 
@@ -38,6 +40,17 @@ if ( function_exists( 'WordPressdotorg\Autoload\register_class_path' ) ) {
 		}
 	} );
 }
+
+/**
+ * Create database tables on network activation.
+ */
+function groups_activate( $network_wide ) {
+	if ( $network_wide ) {
+		require_once __DIR__ . '/includes/database/class-schema.php';
+		\Groups\Database\Schema::create_tables();
+	}
+}
+register_activation_hook( __FILE__, 'groups_activate' );
 
 // Boot the plugin.
 require_once __DIR__ . '/includes/class-plugin.php';


### PR DESCRIPTION
## Summary
- Adds `Groups\Database\Schema` class that uses `dbDelta()` to create two network-wide tables: `groups_analytics_daily` (pre-aggregated daily metrics per group) and `groups_activity_log` (audit trail of significant actions)
- Schema version tracked via `groups_db_version` network option with `get_schema_version()` / `update_schema_version()` methods
- Tables created on plugin network activation via `register_activation_hook`
- Bootstraps the `wordpress-groups` plugin entry point (referenced by `.wp-env.json`)

## Tables
- **`{base_prefix}groups_analytics_daily`** — `(id, date, blog_id, metric, value)` with unique key on `(date, blog_id, metric)`
- **`{base_prefix}groups_activity_log`** — `(id, blog_id, user_id, action, object_id, meta, created_at)` with indexes on `(blog_id, created_at)` and `(action, created_at)`

## Test plan
- [ ] PHPUnit tests verify both tables are created with correct columns
- [ ] Schema version is stored and retrievable as a network option
- [ ] `create_tables()` is idempotent (safe to call multiple times)
- [ ] Default schema version returns 0 when unset

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)