### PR TITLE
Plugin scaffold: autoloader, constants, Plugin class

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/blocks/class-block-registrar.php
+++ b/wp-content/plugins/wordpress-groups/includes/blocks/class-block-registrar.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Block auto-registration.
+ *
+ * @package Groups\Blocks
+ */
+
+namespace Groups\Blocks;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Discovers and registers all blocks found in the plugin's `blocks/` directory.
+ *
+ * Each subdirectory of `blocks/` that contains a `block.json` file is
+ * registered via `register_block_type()` on the `init` action.
+ */
+class Block_Registrar {
+
+	/**
+	 * Hook into WordPress to register blocks on init.
+	 */
+	public function register(): void {
+		add_action( 'init', array( $this, 'register_blocks' ) );
+	}
+
+	/**
+	 * Scan the blocks directory and register each block.
+	 */
+	public function register_blocks(): void {
+		$blocks_dir = GROUPS_PLUGIN_DIR . 'blocks';
+
+		if ( ! is_dir( $blocks_dir ) ) {
+			return;
+		}
+
+		$entries = scandir( $blocks_dir );
+
+		if ( ! is_array( $entries ) ) {
+			return;
+		}
+
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+
+			$block_path = $blocks_dir . '/' . $entry;
+
+			if ( is_dir( $block_path ) && file_exists( $block_path . '/block.json' ) ) {
+				register_block_type( $block_path );
+			}
+		}
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Central plugin orchestrator.
+ *
+ * @package Groups
+ */
+
+namespace Groups;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main plugin class.
+ *
+ * Uses the singleton pattern so that subsystems can reference the same
+ * instance via `Plugin::get_instance()`.
+ */
+class Plugin {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Plugin|null
+	 */
+	private static ?Plugin $instance = null;
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return Plugin
+	 */
+	public static function get_instance(): Plugin {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Private constructor to enforce singleton.
+	 */
+	private function __construct() {}
+
+	/**
+	 * Initialise the plugin.
+	 *
+	 * Called on `plugins_loaded`. Registers hooks for all subsystems.
+	 */
+	public function init(): void {
+		$this->register_post_types();
+		$this->register_taxonomies();
+		$this->register_rest_routes();
+		$this->register_blocks();
+		$this->register_admin_pages();
+	}
+
+	/**
+	 * Register custom post types.
+	 *
+	 * Stub — implemented in issue #2.
+	 */
+	private function register_post_types(): void {
+		// TODO: Register event and venue CPTs (issue #2).
+	}
+
+	/**
+	 * Register custom taxonomies.
+	 *
+	 * Stub — implemented in a later issue.
+	 */
+	private function register_taxonomies(): void {
+		// TODO: Register taxonomies.
+	}
+
+	/**
+	 * Register REST API routes.
+	 *
+	 * Stub — implemented in issue #5.
+	 */
+	private function register_rest_routes(): void {
+		// TODO: Register REST controllers (issue #5).
+	}
+
+	/**
+	 * Register blocks.
+	 *
+	 * Delegates to the Block_Registrar which auto-discovers block
+	 * directories inside the plugin's `blocks/` folder.
+	 */
+	private function register_blocks(): void {
+		$registrar = new Blocks\Block_Registrar();
+		$registrar->register();
+	}
+
+	/**
+	 * Register admin pages and meta boxes.
+	 *
+	 * Stub — implemented in a later issue.
+	 */
+	private function register_admin_pages(): void {
+		// TODO: Register admin pages.
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/shim-autoloader.php
+++ b/wp-content/plugins/wordpress-groups/includes/shim-autoloader.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Shim for \WordPressdotorg\Autoload\register_class_path().
+ *
+ * This file is only loaded when the wporg-mu-plugins autoloader is not
+ * available (e.g. local development without the mu-plugin). It delegates to
+ * the minimal fallback defined in the bootstrap file.
+ *
+ * @package Groups
+ */
+
+namespace WordPressdotorg\Autoload;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register an autoload class path using the WordPress.org naming convention.
+ *
+ * @param string $prefix Root namespace prefix.
+ * @param string $dir    Absolute directory path.
+ */
+function register_class_path( string $prefix, string $dir ): void {
+	\_groups_register_class_path_fallback( $prefix, $dir );
+}

--- a/wp-content/plugins/wordpress-groups/phpunit.xml.dist
+++ b/wp-content/plugins/wordpress-groups/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="tests/phpunit/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+>
+	<testsuites>
+		<testsuite name="WordPress Groups">
+			<directory suffix=".php">tests/phpunit/</directory>
+		</testsuite>
+	</testsuites>
+
+	<filter>
+		<whitelist>
+			<directory suffix=".php">includes/</directory>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/bootstrap.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/bootstrap.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPUnit bootstrap for the WordPress Groups plugin.
+ *
+ * Loads the WordPress test suite and activates the plugin.
+ *
+ * @package Groups\Tests
+ */
+
+// Assume the WP test suite is available via the WP_TESTS_DIR env variable
+// or the default wp-env location.
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir ) {
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+	echo "Could not find {$_tests_dir}/includes/functions.php — is WP_TESTS_DIR set?\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	exit( 1 );
+}
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
+
+/**
+ * Manually load the plugin for testing.
+ */
+tests_add_filter(
+	'muplugins_loaded',
+	static function (): void {
+		require dirname( __DIR__, 2 ) . '/wordpress-groups.php';
+	}
+);
+
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/test-plugin.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/test-plugin.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Basic plugin loading tests.
+ *
+ * @package Groups\Tests
+ */
+
+/**
+ * Verify the plugin loads correctly and essential classes are available.
+ */
+class Test_Plugin extends WP_UnitTestCase {
+
+	/**
+	 * The Groups\Plugin class should exist after the plugin is loaded.
+	 */
+	public function test_plugin_class_exists(): void {
+		$this->assertTrue( class_exists( \Groups\Plugin::class ) );
+	}
+
+	/**
+	 * The singleton should return the same instance.
+	 */
+	public function test_plugin_singleton(): void {
+		$a = \Groups\Plugin::get_instance();
+		$b = \Groups\Plugin::get_instance();
+
+		$this->assertSame( $a, $b );
+	}
+
+	/**
+	 * The GROUPS_VERSION constant should be defined.
+	 */
+	public function test_version_constant_defined(): void {
+		$this->assertTrue( defined( 'GROUPS_VERSION' ) );
+	}
+
+	/**
+	 * The GROUPS_PLUGIN_DIR constant should be defined and point to the
+	 * plugin directory.
+	 */
+	public function test_plugin_dir_constant(): void {
+		$this->assertTrue( defined( 'GROUPS_PLUGIN_DIR' ) );
+		$this->assertDirectoryExists( GROUPS_PLUGIN_DIR );
+	}
+
+	/**
+	 * The Block_Registrar class should be autoloadable.
+	 */
+	public function test_block_registrar_class_exists(): void {
+		$this->assertTrue( class_exists( \Groups\Blocks\Block_Registrar::class ) );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/wordpress-groups.php
+++ b/wp-content/plugins/wordpress-groups/wordpress-groups.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Plugin Name: WordPress Groups
+ * Plugin URI:  https://events.wordpress.org/
+ * Description: Community group management for the WordPress.org Events network.
+ * Version:     0.1.0
+ * Requires at least: 6.7
+ * Requires PHP: 8.3
+ * Author:      WordPress.org Meta Team
+ * License:     GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain: wordpress-groups
+ * Network:     true
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'GROUPS_VERSION', '0.1.0' );
+define( 'GROUPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'GROUPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+/*
+ * Load the WordPress.org autoloader.
+ *
+ * In production, this is provided by wporg-mu-plugins. For environments where
+ * the mu-plugin has not been loaded yet, define a minimal fallback so that the
+ * plugin can still register its class path.
+ */
+if ( ! function_exists( '\WordPressdotorg\Autoload\register_class_path' ) ) {
+	/**
+	 * Minimal fallback autoloader compatible with the WordPress.org convention.
+	 *
+	 * Maps a root namespace to a directory using the `class-{name}.php` file
+	 * naming pattern.
+	 *
+	 * @param string $prefix Root namespace prefix (no leading backslash).
+	 * @param string $dir    Absolute path to the directory containing classes.
+	 */
+	function _groups_register_class_path_fallback( string $prefix, string $dir ): void {
+		$prefix = rtrim( $prefix, '\\' ) . '\\';
+		$dir    = rtrim( $dir, '/' ) . '/';
+
+		spl_autoload_register(
+			function ( string $class ) use ( $prefix, $dir ): void {
+				if ( 0 !== strpos( $class, $prefix ) ) {
+					return;
+				}
+
+				$relative = substr( $class, strlen( $prefix ) );
+				$parts    = explode( '\\', $relative );
+				$name     = array_pop( $parts );
+
+				$path = $dir;
+				if ( $parts ) {
+					$path .= strtolower( implode( '/', str_replace( '_', '-', $parts ) ) ) . '/';
+				}
+				$path .= 'class-' . strtolower( str_replace( '_', '-', $name ) ) . '.php';
+
+				if ( file_exists( $path ) ) {
+					require_once $path;
+				}
+			}
+		);
+	}
+
+	// Shim the namespaced function so other code can call it transparently.
+	require_once __DIR__ . '/includes/shim-autoloader.php';
+}
+
+\WordPressdotorg\Autoload\register_class_path( 'Groups', __DIR__ . '/includes' );
+
+/**
+ * Initialise the plugin on `plugins_loaded`.
+ */
+add_action(
+	'plugins_loaded',
+	static function (): void {
+		\Groups\Plugin::get_instance()->init();
+	}
+);


### PR DESCRIPTION
## Summary

- Adds the `wordpress-groups` plugin bootstrap (`wordpress-groups.php`) with `Network: true` header, `GROUPS_VERSION` / `GROUPS_PLUGIN_DIR` / `GROUPS_PLUGIN_URL` constants, and WordPress.org autoloader integration
- Includes an inline fallback autoloader (`shim-autoloader.php`) for environments where wporg-mu-plugins is not loaded, using the standard `class-{name}.php` naming convention
- Creates the `Groups\Plugin` singleton class as the central orchestrator, with stub methods for post types, taxonomies, REST routes, admin pages, and block registration
- Adds `Groups\Blocks\Block_Registrar` that auto-discovers and registers all `blocks/*/block.json` directories on `init`
- Includes PHPUnit configuration (`phpunit.xml.dist`), test bootstrap, and basic tests verifying the plugin loads, constants are defined, and the singleton works correctly

## Test plan

- [ ] Verify plugin activates network-wide without errors in wp-env
- [ ] Confirm `GROUPS_VERSION`, `GROUPS_PLUGIN_DIR`, and `GROUPS_PLUGIN_URL` are defined after activation
- [ ] Confirm `Groups\Plugin::get_instance()` returns a singleton
- [ ] Confirm `Groups\Blocks\Block_Registrar` class is autoloaded
- [ ] Run PHPUnit tests: all 5 tests pass

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)