### PR TITLE
Add Event model with datetime meta and status transitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 build/
+.claude/worktrees/
+serialized-humming-stardust.md

--- a/wp-content/plugins/wordpress-groups/includes/models/class-event.php
+++ b/wp-content/plugins/wordpress-groups/includes/models/class-event.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Event model — business logic for event CRUD and status transitions.
+ *
+ * @package Groups\Models
+ */
+
+namespace Groups\Models;
+
+use Groups\Post_Types\Event as Event_Post_Type;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles event creation, updates, retrieval, and status transitions.
+ */
+class Event {
+
+	/**
+	 * Post meta keys for event data.
+	 *
+	 * @var string[]
+	 */
+	const META_KEYS = [
+		'start_utc'        => '_event_start_utc',
+		'end_utc'          => '_event_end_utc',
+		'timezone'         => '_event_timezone',
+		'venue_id'         => '_event_venue_id',
+		'online_link'      => '_event_online_link',
+		'attendee_limit'   => '_event_attendee_limit',
+		'waitlist_enabled' => '_event_waitlist_enabled',
+	];
+
+	/**
+	 * Valid status transitions.
+	 *
+	 * Keys are the current status, values are arrays of allowed next statuses.
+	 *
+	 * @var array<string, string[]>
+	 */
+	const TRANSITIONS = [
+		'event-draft'     => [ 'event-scheduled', 'event-cancelled' ],
+		'event-scheduled' => [ 'event-active', 'event-cancelled', 'event-draft' ],
+		'event-active'    => [ 'event-past', 'event-cancelled' ],
+		'event-past'      => [],
+		'event-cancelled' => [ 'event-draft' ],
+	];
+
+	/**
+	 * Create a new event post with metadata.
+	 *
+	 * @param array $args {
+	 *     Event arguments.
+	 *
+	 *     @type string $title            Event title. Required.
+	 *     @type string $content          Event description. Optional.
+	 *     @type string $status           Post status. Default 'event-draft'.
+	 *     @type string $start_utc        Start datetime in UTC (Y-m-d H:i:s). Required.
+	 *     @type string $end_utc          End datetime in UTC (Y-m-d H:i:s). Required.
+	 *     @type string $timezone         Timezone identifier (e.g. 'America/New_York'). Required.
+	 *     @type int    $venue_id         Venue post ID. Optional.
+	 *     @type string $online_link      Online meeting link. Optional.
+	 *     @type int    $attendee_limit   Maximum attendees. Optional.
+	 *     @type bool   $waitlist_enabled Whether waitlist is enabled. Optional.
+	 * }
+	 * @return int|\WP_Error Post ID on success, WP_Error on failure.
+	 */
+	public static function create( array $args ): int|\WP_Error {
+		if ( empty( $args['title'] ) ) {
+			return new \WP_Error( 'missing_title', __( 'Event title is required.', 'wordpress-groups' ) );
+		}
+
+		if ( empty( $args['start_utc'] ) || empty( $args['end_utc'] ) ) {
+			return new \WP_Error( 'missing_datetime', __( 'Event start and end datetimes are required.', 'wordpress-groups' ) );
+		}
+
+		if ( empty( $args['timezone'] ) ) {
+			return new \WP_Error( 'missing_timezone', __( 'Event timezone is required.', 'wordpress-groups' ) );
+		}
+
+		$post_data = [
+			'post_type'   => Event_Post_Type::POST_TYPE,
+			'post_title'  => sanitize_text_field( $args['title'] ),
+			'post_content' => wp_kses_post( $args['content'] ?? '' ),
+			'post_status' => $args['status'] ?? 'event-draft',
+		];
+
+		$post_id = wp_insert_post( $post_data, true );
+
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		self::update_meta( $post_id, $args );
+
+		return $post_id;
+	}
+
+	/**
+	 * Update an existing event post and its metadata.
+	 *
+	 * @param int   $post_id The event post ID.
+	 * @param array $args    Event arguments to update. Same keys as create().
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function update( int $post_id, array $args ): true|\WP_Error {
+		$post = get_post( $post_id );
+
+		if ( ! $post || Event_Post_Type::POST_TYPE !== $post->post_type ) {
+			return new \WP_Error( 'invalid_event', __( 'Invalid event post ID.', 'wordpress-groups' ) );
+		}
+
+		$post_data = [ 'ID' => $post_id ];
+
+		if ( isset( $args['title'] ) ) {
+			$post_data['post_title'] = sanitize_text_field( $args['title'] );
+		}
+
+		if ( isset( $args['content'] ) ) {
+			$post_data['post_content'] = wp_kses_post( $args['content'] );
+		}
+
+		if ( count( $post_data ) > 1 ) {
+			$result = wp_update_post( $post_data, true );
+
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+
+		self::update_meta( $post_id, $args );
+
+		return true;
+	}
+
+	/**
+	 * Get event data including all metadata.
+	 *
+	 * @param int $post_id The event post ID.
+	 * @return array|\WP_Error Event data array on success, WP_Error on failure.
+	 */
+	public static function get( int $post_id ): array|\WP_Error {
+		$post = get_post( $post_id );
+
+		if ( ! $post || Event_Post_Type::POST_TYPE !== $post->post_type ) {
+			return new \WP_Error( 'invalid_event', __( 'Invalid event post ID.', 'wordpress-groups' ) );
+		}
+
+		$data = [
+			'id'      => $post->ID,
+			'title'   => $post->post_title,
+			'content' => $post->post_content,
+			'status'  => $post->post_status,
+		];
+
+		foreach ( self::META_KEYS as $key => $meta_key ) {
+			$data[ $key ] = get_post_meta( $post_id, $meta_key, true );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Transition an event to a new status.
+	 *
+	 * Validates that the transition is allowed before applying it.
+	 *
+	 * @param int    $post_id    The event post ID.
+	 * @param string $new_status The target status.
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function transition_status( int $post_id, string $new_status ): true|\WP_Error {
+		$post = get_post( $post_id );
+
+		if ( ! $post || Event_Post_Type::POST_TYPE !== $post->post_type ) {
+			return new \WP_Error( 'invalid_event', __( 'Invalid event post ID.', 'wordpress-groups' ) );
+		}
+
+		$old_status        = $post->post_status;
+		$valid_transitions = self::get_valid_transitions( $old_status );
+
+		if ( ! in_array( $new_status, $valid_transitions, true ) ) {
+			return new \WP_Error(
+				'invalid_transition',
+				sprintf(
+					/* translators: 1: old status, 2: new status */
+					__( 'Cannot transition from "%1$s" to "%2$s".', 'wordpress-groups' ),
+					$old_status,
+					$new_status
+				)
+			);
+		}
+
+		$result = wp_update_post(
+			[
+				'ID'          => $post_id,
+				'post_status' => $new_status,
+			],
+			true
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		/**
+		 * Fires after an event status transition.
+		 *
+		 * @param int    $post_id    The event post ID.
+		 * @param string $old_status The previous status.
+		 * @param string $new_status The new status.
+		 */
+		do_action( 'groups_event_status_transition', $post_id, $old_status, $new_status );
+
+		return true;
+	}
+
+	/**
+	 * Get the valid next statuses for a given current status.
+	 *
+	 * @param string $current_status The current event status.
+	 * @return string[] Array of valid next statuses.
+	 */
+	public static function get_valid_transitions( string $current_status ): array {
+		return self::TRANSITIONS[ $current_status ] ?? [];
+	}
+
+	/**
+	 * Update event post meta from an args array.
+	 *
+	 * @param int   $post_id The event post ID.
+	 * @param array $args    Arguments containing meta values.
+	 */
+	private static function update_meta( int $post_id, array $args ): void {
+		$meta_map = [
+			'start_utc'        => '_event_start_utc',
+			'end_utc'          => '_event_end_utc',
+			'timezone'         => '_event_timezone',
+			'venue_id'         => '_event_venue_id',
+			'online_link'      => '_event_online_link',
+			'attendee_limit'   => '_event_attendee_limit',
+			'waitlist_enabled' => '_event_waitlist_enabled',
+		];
+
+		foreach ( $meta_map as $arg_key => $meta_key ) {
+			if ( isset( $args[ $arg_key ] ) ) {
+				update_post_meta( $post_id, $meta_key, $args[ $arg_key ] );
+			}
+		}
+	}
+}

--- a/wp-content/plugins/wordpress-groups/phpunit.xml.dist
+++ b/wp-content/plugins/wordpress-groups/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="tests/phpunit/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+>
+	<testsuites>
+		<testsuite name="WordPress Groups">
+			<directory suffix=".php">tests/phpunit/</directory>
+		</testsuite>
+	</testsuites>
+
+	<filter>
+		<whitelist>
+			<directory suffix=".php">includes/</directory>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/bootstrap.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/bootstrap.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPUnit bootstrap for the WordPress Groups plugin.
+ *
+ * Loads the WordPress test suite and activates the plugin.
+ *
+ * @package Groups\Tests
+ */
+
+// Assume the WP test suite is available via the WP_TESTS_DIR env variable
+// or the default wp-env location.
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir ) {
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+	echo "Could not find {$_tests_dir}/includes/functions.php — is WP_TESTS_DIR set?\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	exit( 1 );
+}
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
+
+/**
+ * Manually load the plugin for testing.
+ */
+tests_add_filter(
+	'muplugins_loaded',
+	static function (): void {
+		require dirname( __DIR__, 2 ) . '/wordpress-groups.php';
+	}
+);
+
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/models/test-event.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/models/test-event.php
@@ -1,0 +1,378 @@
+<?php
+/**
+ * Tests for the Event model.
+ *
+ * @package Groups\Tests
+ */
+
+namespace Groups\Tests\Models;
+
+use Groups\Models\Event;
+use Groups\Post_Types\Event as Event_Post_Type;
+use WP_UnitTestCase;
+
+/**
+ * @coversDefaultClass \Groups\Models\Event
+ */
+class Test_Event extends WP_UnitTestCase {
+
+	/**
+	 * Ensure the event CPT and statuses are registered before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$event_cpt = new Event_Post_Type();
+		$event_cpt->register_post_type();
+		$event_cpt->register_post_statuses();
+	}
+
+	/**
+	 * Helper to get default valid event args.
+	 *
+	 * @param array $overrides Optional overrides.
+	 * @return array
+	 */
+	private function get_event_args( array $overrides = [] ): array {
+		return array_merge(
+			[
+				'title'     => 'Monthly WordPress Meetup',
+				'content'   => 'Join us for our monthly meetup!',
+				'start_utc' => '2026-04-15 18:00:00',
+				'end_utc'   => '2026-04-15 20:00:00',
+				'timezone'  => 'America/New_York',
+			],
+			$overrides
+		);
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_event_returns_post_id(): void {
+		$post_id = Event::create( $this->get_event_args() );
+
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_event_stores_datetime_meta(): void {
+		$args    = $this->get_event_args();
+		$post_id = Event::create( $args );
+
+		$this->assertSame( '2026-04-15 18:00:00', get_post_meta( $post_id, '_event_start_utc', true ) );
+		$this->assertSame( '2026-04-15 20:00:00', get_post_meta( $post_id, '_event_end_utc', true ) );
+		$this->assertSame( 'America/New_York', get_post_meta( $post_id, '_event_timezone', true ) );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_event_stores_optional_meta(): void {
+		$args = $this->get_event_args(
+			[
+				'venue_id'         => 42,
+				'online_link'      => 'https://meet.example.com/room',
+				'attendee_limit'   => 50,
+				'waitlist_enabled' => true,
+			]
+		);
+
+		$post_id = Event::create( $args );
+
+		$this->assertEquals( 42, get_post_meta( $post_id, '_event_venue_id', true ) );
+		$this->assertSame( 'https://meet.example.com/room', get_post_meta( $post_id, '_event_online_link', true ) );
+		$this->assertEquals( 50, get_post_meta( $post_id, '_event_attendee_limit', true ) );
+		$this->assertEquals( true, get_post_meta( $post_id, '_event_waitlist_enabled', true ) );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_event_defaults_to_draft_status(): void {
+		$post_id = Event::create( $this->get_event_args() );
+
+		$this->assertSame( 'event-draft', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_event_with_custom_status(): void {
+		$post_id = Event::create( $this->get_event_args( [ 'status' => 'event-scheduled' ] ) );
+
+		$this->assertSame( 'event-scheduled', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_event_requires_title(): void {
+		$args = $this->get_event_args( [ 'title' => '' ] );
+		$result = Event::create( $args );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'missing_title', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_event_requires_datetime(): void {
+		$args = $this->get_event_args();
+		unset( $args['start_utc'], $args['end_utc'] );
+
+		$result = Event::create( $args );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'missing_datetime', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_event_requires_timezone(): void {
+		$args = $this->get_event_args();
+		unset( $args['timezone'] );
+
+		$result = Event::create( $args );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'missing_timezone', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function test_update_event_title(): void {
+		$post_id = Event::create( $this->get_event_args() );
+
+		$result = Event::update( $post_id, [ 'title' => 'Updated Meetup Title' ] );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'Updated Meetup Title', get_post( $post_id )->post_title );
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function test_update_event_meta(): void {
+		$post_id = Event::create( $this->get_event_args() );
+
+		Event::update( $post_id, [ 'start_utc' => '2026-04-16 19:00:00' ] );
+
+		$this->assertSame( '2026-04-16 19:00:00', get_post_meta( $post_id, '_event_start_utc', true ) );
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function test_update_invalid_event_returns_error(): void {
+		$result = Event::update( 999999, [ 'title' => 'Nope' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_event', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::get
+	 */
+	public function test_get_returns_event_data(): void {
+		$args    = $this->get_event_args(
+			[
+				'venue_id'    => 7,
+				'online_link' => 'https://zoom.us/j/123',
+			]
+		);
+		$post_id = Event::create( $args );
+
+		$data = Event::get( $post_id );
+
+		$this->assertIsArray( $data );
+		$this->assertSame( $post_id, $data['id'] );
+		$this->assertSame( 'Monthly WordPress Meetup', $data['title'] );
+		$this->assertSame( 'Join us for our monthly meetup!', $data['content'] );
+		$this->assertSame( 'event-draft', $data['status'] );
+		$this->assertSame( '2026-04-15 18:00:00', $data['start_utc'] );
+		$this->assertSame( '2026-04-15 20:00:00', $data['end_utc'] );
+		$this->assertSame( 'America/New_York', $data['timezone'] );
+		$this->assertEquals( 7, $data['venue_id'] );
+		$this->assertSame( 'https://zoom.us/j/123', $data['online_link'] );
+	}
+
+	/**
+	 * @covers ::get
+	 */
+	public function test_get_invalid_event_returns_error(): void {
+		$result = Event::get( 999999 );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_event', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::transition_status
+	 * @covers ::get_valid_transitions
+	 */
+	public function test_valid_transition_draft_to_scheduled(): void {
+		$post_id = Event::create( $this->get_event_args() );
+
+		$result = Event::transition_status( $post_id, 'event-scheduled' );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'event-scheduled', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * @covers ::transition_status
+	 */
+	public function test_valid_transition_draft_to_cancelled(): void {
+		$post_id = Event::create( $this->get_event_args() );
+
+		$result = Event::transition_status( $post_id, 'event-cancelled' );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'event-cancelled', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * @covers ::transition_status
+	 */
+	public function test_valid_transition_scheduled_to_active(): void {
+		$post_id = Event::create( $this->get_event_args( [ 'status' => 'event-scheduled' ] ) );
+
+		$result = Event::transition_status( $post_id, 'event-active' );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'event-active', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * @covers ::transition_status
+	 */
+	public function test_valid_transition_scheduled_to_draft(): void {
+		$post_id = Event::create( $this->get_event_args( [ 'status' => 'event-scheduled' ] ) );
+
+		$result = Event::transition_status( $post_id, 'event-draft' );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'event-draft', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * @covers ::transition_status
+	 */
+	public function test_valid_transition_active_to_past(): void {
+		$post_id = Event::create( $this->get_event_args( [ 'status' => 'event-active' ] ) );
+
+		$result = Event::transition_status( $post_id, 'event-past' );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'event-past', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * @covers ::transition_status
+	 */
+	public function test_valid_transition_cancelled_to_draft(): void {
+		$post_id = Event::create( $this->get_event_args( [ 'status' => 'event-cancelled' ] ) );
+
+		$result = Event::transition_status( $post_id, 'event-draft' );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'event-draft', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * @covers ::transition_status
+	 */
+	public function test_invalid_transition_draft_to_active_fails(): void {
+		$post_id = Event::create( $this->get_event_args() );
+
+		$result = Event::transition_status( $post_id, 'event-active' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_transition', $result->get_error_code() );
+		$this->assertSame( 'event-draft', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * @covers ::transition_status
+	 */
+	public function test_invalid_transition_past_is_terminal(): void {
+		$post_id = Event::create( $this->get_event_args( [ 'status' => 'event-past' ] ) );
+
+		$result = Event::transition_status( $post_id, 'event-draft' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_transition', $result->get_error_code() );
+		$this->assertSame( 'event-past', get_post_status( $post_id ) );
+	}
+
+	/**
+	 * @covers ::transition_status
+	 */
+	public function test_invalid_transition_cancelled_to_scheduled_fails(): void {
+		$post_id = Event::create( $this->get_event_args( [ 'status' => 'event-cancelled' ] ) );
+
+		$result = Event::transition_status( $post_id, 'event-scheduled' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_transition', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::transition_status
+	 */
+	public function test_transition_fires_action_hook(): void {
+		$post_id = Event::create( $this->get_event_args() );
+		$fired   = false;
+
+		add_action(
+			'groups_event_status_transition',
+			function ( $id, $old, $new ) use ( $post_id, &$fired ) {
+				$fired = true;
+				$this->assertSame( $post_id, $id );
+				$this->assertSame( 'event-draft', $old );
+				$this->assertSame( 'event-scheduled', $new );
+			},
+			10,
+			3
+		);
+
+		Event::transition_status( $post_id, 'event-scheduled' );
+
+		$this->assertTrue( $fired, 'The groups_event_status_transition action should have fired.' );
+	}
+
+	/**
+	 * @covers ::transition_status
+	 */
+	public function test_transition_invalid_post_returns_error(): void {
+		$result = Event::transition_status( 999999, 'event-scheduled' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_event', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::get_valid_transitions
+	 */
+	public function test_get_valid_transitions_returns_correct_statuses(): void {
+		$this->assertSame( [ 'event-scheduled', 'event-cancelled' ], Event::get_valid_transitions( 'event-draft' ) );
+		$this->assertSame( [ 'event-active', 'event-cancelled', 'event-draft' ], Event::get_valid_transitions( 'event-scheduled' ) );
+		$this->assertSame( [ 'event-past', 'event-cancelled' ], Event::get_valid_transitions( 'event-active' ) );
+		$this->assertSame( [], Event::get_valid_transitions( 'event-past' ) );
+		$this->assertSame( [ 'event-draft' ], Event::get_valid_transitions( 'event-cancelled' ) );
+	}
+
+	/**
+	 * @covers ::get_valid_transitions
+	 */
+	public function test_get_valid_transitions_unknown_status_returns_empty(): void {
+		$this->assertSame( [], Event::get_valid_transitions( 'nonexistent-status' ) );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Groups\Models\Event` class with `create()`, `update()`, `get()`, `transition_status()`, and `get_valid_transitions()` methods
- Stores event datetimes as UTC MySQL format strings (`Y-m-d H:i:s`) in post meta with `_event_` prefix
- Implements validated status transition state machine (draft/scheduled/active/past/cancelled) with `groups_event_status_transition` action hook
- Includes plugin scaffold (bootstrap, autoloader, Plugin class, Event CPT with custom statuses) as dependencies for the model

## Meta keys
`_event_start_utc`, `_event_end_utc`, `_event_timezone`, `_event_venue_id`, `_event_online_link`, `_event_attendee_limit`, `_event_waitlist_enabled`

## Test plan
- [ ] Event creation stores correct post data and all meta keys
- [ ] Event creation validates required fields (title, datetimes, timezone)
- [ ] Event update modifies title, content, and meta independently
- [ ] `get()` returns complete event data including all meta
- [ ] All valid status transitions succeed (draft->scheduled, scheduled->active, etc.)
- [ ] Invalid transitions return WP_Error (draft->active, past->anything, cancelled->scheduled)
- [ ] `groups_event_status_transition` action fires with correct arguments
- [ ] Terminal status (event-past) has no valid transitions

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)