### PR TITLE
Add HTML email framework with branded template system

### DIFF
--- a/wp-content/plugins/wordpress-groups/email-templates/application-status.html
+++ b/wp-content/plugins/wordpress-groups/email-templates/application-status.html
@@ -1,0 +1,49 @@
+<h1 style="margin: 0 0 24px 0; font-size: 24px; font-weight: 700; color: #1e1e1e; line-height: 1.3;">
+	Application Update
+</h1>
+
+<p style="margin: 0 0 20px 0;">
+	Hi {{user_name}},
+</p>
+
+<p style="margin: 0 0 20px 0;">
+	There's an update on your application for <strong>{{group_name}}</strong>.
+</p>
+
+<!-- Status Card -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 0 28px 0;">
+	<tr>
+		<td class="info-box" style="background-color: #f0f6fc; border-left: 4px solid #3858E9; border-radius: 0 8px 8px 0; padding: 20px 24px;">
+			<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+				<tr>
+					<td style="padding-bottom: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;">
+						<span style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #3858E9;">Application Status</span>
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;">
+						<span style="display: inline-block; padding: 6px 16px; border-radius: 20px; background-color: #3858E9; color: #ffffff; font-size: 14px; font-weight: 600;">{{status}}</span>
+					</td>
+				</tr>
+				<tr>
+					<td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 15px; color: #1e1e1e; line-height: 1.5;">
+						{{status_message}}
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+
+<p style="margin: 0 0 24px 0;">
+	If you have questions about this update, you can reach out to the WordPress Community Team through the link below.
+</p>
+
+<!-- CTA Button -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 28px 0;">
+	<tr>
+		<td style="border-radius: 8px; background-color: #3858E9;" class="cta-button">
+			<a href="{{dashboard_url}}" target="_blank" style="display: inline-block; padding: 14px 32px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none; border-radius: 8px;">View Your Dashboard</a>
+		</td>
+	</tr>
+</table>

--- a/wp-content/plugins/wordpress-groups/email-templates/base.html
+++ b/wp-content/plugins/wordpress-groups/email-templates/base.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="x-apple-disable-message-reformatting">
+	<meta name="color-scheme" content="light dark">
+	<meta name="supported-color-schemes" content="light dark">
+	<title>{{email_subject}}</title>
+	<!--[if mso]>
+	<noscript>
+		<xml>
+			<o:OfficeDocumentSettings>
+				<o:AllowPNG/>
+				<o:PixelsPerInch>96</o:PixelsPerInch>
+			</o:OfficeDocumentSettings>
+		</xml>
+	</noscript>
+	<![endif]-->
+	<style>
+		:root {
+			color-scheme: light dark;
+			supported-color-schemes: light dark;
+		}
+
+		/* Reset */
+		body, table, td, a {
+			-webkit-text-size-adjust: 100%;
+			-ms-text-size-adjust: 100%;
+		}
+		table, td {
+			mso-table-lspace: 0pt;
+			mso-table-rspace: 0pt;
+		}
+		img {
+			-ms-interpolation-mode: bicubic;
+			border: 0;
+			height: auto;
+			line-height: 100%;
+			outline: none;
+			text-decoration: none;
+		}
+		table {
+			border-collapse: collapse !important;
+		}
+		body {
+			height: 100% !important;
+			margin: 0 !important;
+			padding: 0 !important;
+			width: 100% !important;
+		}
+
+		/* iOS blue links */
+		a[x-apple-data-detectors] {
+			color: inherit !important;
+			text-decoration: none !important;
+			font-size: inherit !important;
+			font-family: inherit !important;
+			font-weight: inherit !important;
+			line-height: inherit !important;
+		}
+
+		/* Gmail blue links */
+		u + #body a {
+			color: inherit;
+			text-decoration: none;
+			font-size: inherit;
+			font-family: inherit;
+			font-weight: inherit;
+			line-height: inherit;
+		}
+
+		/* Samsung Mail */
+		#MessageViewBody a {
+			color: inherit;
+			text-decoration: none;
+			font-size: inherit;
+			font-family: inherit;
+			font-weight: inherit;
+			line-height: inherit;
+		}
+
+		/* Responsive */
+		@media only screen and (max-width: 620px) {
+			.email-container {
+				width: 100% !important;
+				max-width: 100% !important;
+			}
+			.fluid {
+				max-width: 100% !important;
+				height: auto !important;
+				margin-left: auto !important;
+				margin-right: auto !important;
+			}
+			.stack-column,
+			.stack-column-center {
+				display: block !important;
+				width: 100% !important;
+				max-width: 100% !important;
+				direction: ltr !important;
+			}
+			.stack-column-center {
+				text-align: center !important;
+			}
+			.content-padding {
+				padding-left: 20px !important;
+				padding-right: 20px !important;
+			}
+			.header-padding {
+				padding-left: 20px !important;
+				padding-right: 20px !important;
+			}
+		}
+
+		/* Dark mode */
+		@media (prefers-color-scheme: dark) {
+			body,
+			.email-bg {
+				background-color: #1a1a2e !important;
+			}
+			.email-body {
+				background-color: #16213e !important;
+			}
+			.email-body td {
+				color: #e0e0e0 !important;
+			}
+			h1, h2, h3, h4 {
+				color: #ffffff !important;
+			}
+			p, li, span, td {
+				color: #e0e0e0 !important;
+			}
+			.email-header {
+				background-color: #0e1628 !important;
+			}
+			.email-footer td,
+			.email-footer a {
+				color: #9ca3af !important;
+			}
+			.divider {
+				border-top-color: #2d3748 !important;
+			}
+			.info-box {
+				background-color: #1e2a4a !important;
+				border-left-color: #3858E9 !important;
+			}
+			.info-box td {
+				color: #c5cee0 !important;
+			}
+			.cta-button {
+				background-color: #3858E9 !important;
+			}
+		}
+
+		[data-ogsc] .email-bg,
+		[data-ogsc] body {
+			background-color: #1a1a2e !important;
+		}
+		[data-ogsc] .email-body {
+			background-color: #16213e !important;
+		}
+		[data-ogsc] .email-header {
+			background-color: #0e1628 !important;
+		}
+	</style>
+</head>
+<body id="body" style="margin: 0; padding: 0; word-spacing: normal; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;">
+	<div role="article" aria-roledescription="email" aria-label="{{email_subject}}" lang="en" style="font-size: 16px; font-size: 1rem; font-size: max(16px, 1rem);">
+
+	<!-- Visually Hidden Preview Text -->
+	<div style="display: none; font-size: 1px; line-height: 1px; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden; mso-hide: all;">
+		{{preview_text}}
+	</div>
+
+	<!-- Email Background -->
+	<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" class="email-bg" style="background-color: #f0f0f5;">
+		<tr>
+			<td align="center" valign="top" style="padding: 30px 10px;">
+
+				<!--[if mso]>
+				<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" align="center">
+				<tr>
+				<td>
+				<![endif]-->
+
+				<!-- Email Container -->
+				<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" class="email-container" style="max-width: 600px; width: 100%; margin: 0 auto; border-radius: 12px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.06);">
+
+					<!-- Header -->
+					<tr>
+						<td class="email-header" style="background: linear-gradient(135deg, #0073AA 0%, #3858E9 100%); padding: 0;">
+							<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+								<tr>
+									<td class="header-padding" style="padding: 32px 40px; text-align: left;">
+										<!-- WordPress Logo + Wordmark -->
+										<table role="presentation" cellspacing="0" cellpadding="0" border="0">
+											<tr>
+												<td style="vertical-align: middle; padding-right: 14px;">
+													<!--[if mso]>
+													<img src="https://s.w.org/images/wmark-white.png" width="36" height="36" alt="" style="display: block;" />
+													<![endif]-->
+													<!--[if !mso]><!-->
+													<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 122.52 122.523" style="display: block;">
+														<g fill="#ffffff">
+															<path d="M8.708 61.26c0 20.802 12.089 38.779 29.619 47.298L13.258 39.872a52.354 52.354 0 0 0-4.55 21.388zM96.74 58.608c0-6.495-2.333-10.993-4.334-14.494-2.664-4.329-5.161-7.995-5.161-12.324 0-4.831 3.664-9.328 8.825-9.328.233 0 .454.029.681.042-9.35-8.566-21.807-13.796-35.489-13.796-18.36 0-34.513 9.42-43.91 23.688 1.233.037 2.395.063 3.382.063 5.497 0 14.006-.667 14.006-.667 2.833-.167 3.167 3.994.337 4.329 0 0-2.847.335-6.015.501L48.2 93.547l11.501-34.493-8.188-22.434c-2.83-.166-5.511-.501-5.511-.501-2.832-.166-2.5-4.496.332-4.329 0 0 8.679.667 13.843.667 5.496 0 14.006-.667 14.006-.667 2.835-.167 3.168 3.994.337 4.329 0 0-2.853.335-6.015.501l18.992 56.494 5.242-17.517c2.272-7.269 4.001-12.49 4.001-16.989z"/>
+															<path d="M62.184 65.857l-15.768 45.819a52.516 52.516 0 0 0 14.846 2.141c6.12 0 11.989-1.058 17.452-2.979a4.451 4.451 0 0 1-.374-.724L62.184 65.857zM107.376 36.046c.226 1.674.354 3.471.354 5.404 0 5.333-.996 11.328-3.996 18.824l-16.053 46.413c15.624-9.111 26.133-26.038 26.133-45.426.001-9.137-2.333-17.729-6.438-25.215z"/>
+															<path d="M61.262 0C27.483 0 0 27.481 0 61.26c0 33.783 27.483 61.263 61.262 61.263 33.778 0 61.265-27.48 61.265-61.263C122.526 27.481 95.04 0 61.262 0zm0 119.715c-32.23 0-58.453-26.223-58.453-58.455 0-32.23 26.222-58.451 58.453-58.451 32.229 0 58.45 26.221 58.45 58.451 0 32.232-26.221 58.455-58.45 58.455z"/>
+														</g>
+													</svg>
+													<!--<![endif]-->
+												</td>
+												<td style="vertical-align: middle;">
+													<span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 22px; font-weight: 700; color: #ffffff; letter-spacing: -0.2px;">WordPress.org</span>
+													<br>
+													<span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 13px; font-weight: 400; color: rgba(255,255,255,0.85); letter-spacing: 0.5px; text-transform: uppercase;">Community Groups</span>
+												</td>
+											</tr>
+										</table>
+									</td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+
+					<!-- Body -->
+					<tr>
+						<td class="email-body" style="background-color: #ffffff;">
+							<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+								<tr>
+									<td class="content-padding" style="padding: 40px 40px 32px 40px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 16px; line-height: 1.6; color: #1e1e1e;">
+										{{content}}
+									</td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+
+					<!-- Footer -->
+					<tr>
+						<td class="email-footer" style="background-color: #f8f9fa; border-top: 1px solid #e8e8e8;">
+							<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+								<tr>
+									<td class="content-padding" style="padding: 28px 40px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 13px; line-height: 1.5; color: #646970; text-align: center;">
+										<p style="margin: 0 0 12px 0;">
+											<a href="https://wordpress.org" style="color: #0073AA; text-decoration: none; font-weight: 500;">WordPress.org</a>
+											&nbsp;&nbsp;&middot;&nbsp;&nbsp;
+											<a href="https://events.wordpress.org" style="color: #0073AA; text-decoration: none; font-weight: 500;">Events</a>
+											&nbsp;&nbsp;&middot;&nbsp;&nbsp;
+											<a href="https://make.wordpress.org/community" style="color: #0073AA; text-decoration: none; font-weight: 500;">Community</a>
+											&nbsp;&nbsp;&middot;&nbsp;&nbsp;
+											<a href="https://learn.wordpress.org" style="color: #0073AA; text-decoration: none; font-weight: 500;">Learn</a>
+										</p>
+										<p style="margin: 0 0 12px 0; color: #a0a5aa; font-size: 12px;">
+											This email was sent by WordPress.org Community Groups.<br>
+											You received this because of your activity on WordPress.org.
+										</p>
+										<p style="margin: 0;">
+											<a href="{{unsubscribe_url}}" style="color: #a0a5aa; text-decoration: underline; font-size: 12px;">Manage email preferences</a>
+										</p>
+									</td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+
+				</table>
+				<!-- End Email Container -->
+
+				<!--[if mso]>
+				</td>
+				</tr>
+				</table>
+				<![endif]-->
+
+			</td>
+		</tr>
+	</table>
+
+	</div>
+</body>
+</html>

--- a/wp-content/plugins/wordpress-groups/email-templates/dormancy-alert.html
+++ b/wp-content/plugins/wordpress-groups/email-templates/dormancy-alert.html
@@ -1,0 +1,73 @@
+<h1 style="margin: 0 0 24px 0; font-size: 24px; font-weight: 700; color: #1e1e1e; line-height: 1.3;">
+	Dormancy Alert
+</h1>
+
+<p style="margin: 0 0 20px 0;">
+	Hi {{deputy_name}},
+</p>
+
+<p style="margin: 0 0 20px 0;">
+	The group <strong>{{group_name}}</strong> has had no events for <strong>{{days_inactive}} days</strong> and may need attention.
+</p>
+
+<!-- Alert Card -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 0 28px 0;">
+	<tr>
+		<td class="info-box" style="background-color: #fcf0f0; border-left: 4px solid #cc1818; border-radius: 0 8px 8px 0; padding: 20px 24px;">
+			<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+				<tr>
+					<td style="padding-bottom: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;">
+						<span style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #cc1818;">Inactivity Warning</span>
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 8px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 18px; font-weight: 600; color: #1e1e1e;">
+						{{group_name}}
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 4px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#9888;&#65039;&nbsp; Last event was <strong>{{days_inactive}} days ago</strong>
+					</td>
+				</tr>
+				<tr>
+					<td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						Groups with 90+ days of inactivity are automatically marked as dormant.
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+
+<h2 style="margin: 0 0 12px 0; font-size: 16px; font-weight: 700; color: #1e1e1e;">Recommended Actions</h2>
+
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 0 24px 0;">
+	<tr>
+		<td style="padding: 6px 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #1e1e1e;">
+			&#8226;&nbsp;&nbsp;Reach out to the organizer to check on the group's status
+		</td>
+	</tr>
+	<tr>
+		<td style="padding: 6px 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #1e1e1e;">
+			&#8226;&nbsp;&nbsp;Offer support or resources if the organizer needs help
+		</td>
+	</tr>
+	<tr>
+		<td style="padding: 6px 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #1e1e1e;">
+			&#8226;&nbsp;&nbsp;Consider assigning a mentor or co-organizer
+		</td>
+	</tr>
+</table>
+
+<!-- CTA Buttons -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 12px 0;">
+	<tr>
+		<td style="border-radius: 8px; background-color: #3858E9; padding-right: 12px;" class="cta-button">
+			<a href="{{group_url}}" target="_blank" style="display: inline-block; padding: 14px 28px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none; border-radius: 8px;">View Group</a>
+		</td>
+		<td style="border-radius: 8px; border: 2px solid #3858E9;">
+			<a href="{{dashboard_url}}" target="_blank" style="display: inline-block; padding: 12px 28px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 15px; font-weight: 600; color: #3858E9; text-decoration: none; border-radius: 8px;">Deputy Dashboard</a>
+		</td>
+	</tr>
+</table>

--- a/wp-content/plugins/wordpress-groups/email-templates/event-reminder.html
+++ b/wp-content/plugins/wordpress-groups/email-templates/event-reminder.html
@@ -1,0 +1,71 @@
+<h1 style="margin: 0 0 24px 0; font-size: 24px; font-weight: 700; color: #1e1e1e; line-height: 1.3;">
+	Your Event is Coming Up!
+</h1>
+
+<p style="margin: 0 0 20px 0;">
+	Hi {{user_name}},
+</p>
+
+<p style="margin: 0 0 20px 0;">
+	Just a friendly reminder that <strong>{{event_title}}</strong> is happening soon. Here are the details:
+</p>
+
+<!-- Event Details Card -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 0 28px 0;">
+	<tr>
+		<td class="info-box" style="background-color: #f0f6fc; border-left: 4px solid #3858E9; border-radius: 0 8px 8px 0; padding: 20px 24px;">
+			<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+				<tr>
+					<td style="padding-bottom: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;">
+						<span style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #3858E9;">Event Details</span>
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 8px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 18px; font-weight: 600; color: #1e1e1e;">
+						{{event_title}}
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 4px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#128197;&nbsp; {{event_date}} at {{event_time}}
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 4px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#128205;&nbsp; {{venue_name}}
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 4px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#128206;&nbsp; {{venue_address}}
+					</td>
+				</tr>
+				<tr>
+					<td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#128101;&nbsp; {{group_name}}
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+
+<!-- CTA Button -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 28px 0;">
+	<tr>
+		<td style="border-radius: 8px; background-color: #3858E9;" class="cta-button">
+			<a href="{{event_url}}" target="_blank" style="display: inline-block; padding: 14px 32px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none; border-radius: 8px;">View Event Details</a>
+		</td>
+	</tr>
+</table>
+
+<!-- Divider -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 0 20px 0;">
+	<tr>
+		<td class="divider" style="border-top: 1px solid #e8e8e8; font-size: 1px; line-height: 1px;">&nbsp;</td>
+	</tr>
+</table>
+
+<p style="margin: 0 0 8px 0; font-size: 14px; color: #646970;">
+	If your plans have changed, please update your RSVP to let the organizers know and free up your spot for someone on the waitlist.
+</p>

--- a/wp-content/plugins/wordpress-groups/email-templates/group-announcement.html
+++ b/wp-content/plugins/wordpress-groups/email-templates/group-announcement.html
@@ -1,0 +1,39 @@
+<h1 style="margin: 0 0 24px 0; font-size: 24px; font-weight: 700; color: #1e1e1e; line-height: 1.3;">
+	{{announcement_title}}
+</h1>
+
+<p style="margin: 0 0 20px 0;">
+	Hi {{user_name}},
+</p>
+
+<p style="margin: 0 0 8px 0; font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: #646970;">
+	Announcement from {{group_name}}
+</p>
+
+<!-- Announcement Content Card -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 0 28px 0;">
+	<tr>
+		<td class="info-box" style="background-color: #f0f6fc; border-left: 4px solid #3858E9; border-radius: 0 8px 8px 0; padding: 24px;">
+			<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+				<tr>
+					<td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 15px; line-height: 1.6; color: #1e1e1e;">
+						{{announcement_body}}
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+
+<!-- CTA Button -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 28px 0;">
+	<tr>
+		<td style="border-radius: 8px; background-color: #3858E9;" class="cta-button">
+			<a href="{{group_url}}" target="_blank" style="display: inline-block; padding: 14px 32px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none; border-radius: 8px;">Visit {{group_name}}</a>
+		</td>
+	</tr>
+</table>
+
+<p style="margin: 0; font-size: 13px; color: #a0a5aa;">
+	This announcement was sent to all members of {{group_name}}.
+</p>

--- a/wp-content/plugins/wordpress-groups/email-templates/rsvp-confirmation.html
+++ b/wp-content/plugins/wordpress-groups/email-templates/rsvp-confirmation.html
@@ -1,0 +1,84 @@
+<h1 style="margin: 0 0 24px 0; font-size: 24px; font-weight: 700; color: #1e1e1e; line-height: 1.3;">
+	{{#if_attending}}Your RSVP is Confirmed!{{/if_attending}}{{#if_waitlisted}}You're on the Waitlist{{/if_waitlisted}}
+</h1>
+
+<p style="margin: 0 0 20px 0;">
+	Hi {{user_name}},
+</p>
+
+{{#if_attending}}
+<p style="margin: 0 0 20px 0;">
+	Great news — you're confirmed for <strong>{{event_title}}</strong>! We look forward to seeing you there.
+</p>
+{{/if_attending}}
+
+{{#if_waitlisted}}
+<p style="margin: 0 0 20px 0;">
+	You've been added to the waitlist for <strong>{{event_title}}</strong>. If a spot opens up, we'll notify you right away and update your RSVP automatically.
+</p>
+{{/if_waitlisted}}
+
+<!-- Event Details Card -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 0 28px 0;">
+	<tr>
+		<td class="info-box" style="background-color: #f0f6fc; border-left: 4px solid #3858E9; border-radius: 0 8px 8px 0; padding: 20px 24px;">
+			<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+				<tr>
+					<td style="padding-bottom: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;">
+						<span style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #3858E9;">Event Details</span>
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 8px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 18px; font-weight: 600; color: #1e1e1e;">
+						{{event_title}}
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 4px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#128197;&nbsp; {{event_date}} at {{event_time}}
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 4px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#128205;&nbsp; {{venue_name}}
+					</td>
+				</tr>
+				<tr>
+					<td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#128101;&nbsp; {{group_name}}
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+
+<!-- Status Badge -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 28px 0;">
+	<tr>
+		<td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 13px; font-weight: 600; color: #ffffff; padding: 6px 16px; border-radius: 20px; {{#if_attending}}background-color: #00a32a;{{/if_attending}}{{#if_waitlisted}}background-color: #dba617;{{/if_waitlisted}}">
+			{{rsvp_status}}
+		</td>
+	</tr>
+</table>
+
+<!-- CTA Button -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 28px 0;">
+	<tr>
+		<td style="border-radius: 8px; background-color: #3858E9;" class="cta-button">
+			<a href="{{event_url}}" target="_blank" style="display: inline-block; padding: 14px 32px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none; border-radius: 8px;">View Event Details</a>
+		</td>
+	</tr>
+</table>
+
+{{#if_attending}}
+<p style="margin: 0 0 8px 0; font-size: 14px; color: #646970;">
+	If your plans change, please update your RSVP so others on the waitlist can attend.
+</p>
+{{/if_attending}}
+
+{{#if_waitlisted}}
+<p style="margin: 0 0 8px 0; font-size: 14px; color: #646970;">
+	You don't need to do anything — if a spot becomes available, you'll be moved to the attending list automatically and we'll send you a confirmation.
+</p>
+{{/if_waitlisted}}

--- a/wp-content/plugins/wordpress-groups/email-templates/welcome-organizer.html
+++ b/wp-content/plugins/wordpress-groups/email-templates/welcome-organizer.html
@@ -1,0 +1,120 @@
+<h1 style="margin: 0 0 24px 0; font-size: 24px; font-weight: 700; color: #1e1e1e; line-height: 1.3;">
+	Welcome, Organizer! &#127881;
+</h1>
+
+<p style="margin: 0 0 20px 0;">
+	Hi {{user_name}},
+</p>
+
+<p style="margin: 0 0 20px 0;">
+	Congratulations! Your group <strong>{{group_name}}</strong> has been approved and your site is ready. Welcome to the WordPress Community organizer family!
+</p>
+
+<!-- Quick Start Card -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 0 28px 0;">
+	<tr>
+		<td class="info-box" style="background-color: #f0f6fc; border-left: 4px solid #3858E9; border-radius: 0 8px 8px 0; padding: 20px 24px;">
+			<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+				<tr>
+					<td style="padding-bottom: 16px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;">
+						<span style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #3858E9;">Your Group Site</span>
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 4px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 18px; font-weight: 600; color: #1e1e1e;">
+						{{group_name}}
+					</td>
+				</tr>
+				<tr>
+					<td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #0073AA;">
+						<a href="{{site_url}}" style="color: #0073AA; text-decoration: none;">{{site_url}}</a>
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+
+<!-- Getting Started Tips -->
+<h2 style="margin: 0 0 16px 0; font-size: 18px; font-weight: 700; color: #1e1e1e;">Getting Started</h2>
+
+<p style="margin: 0 0 8px 0; font-size: 15px; color: #1e1e1e;">Here are a few things to do first:</p>
+
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 0 24px 0;">
+	<tr>
+		<td style="padding: 10px 0; border-bottom: 1px solid #f0f0f5; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;">
+			<table role="presentation" cellspacing="0" cellpadding="0" border="0">
+				<tr>
+					<td style="vertical-align: top; padding-right: 12px;">
+						<span style="display: inline-block; width: 28px; height: 28px; line-height: 28px; text-align: center; border-radius: 50%; background-color: #3858E9; color: #ffffff; font-size: 14px; font-weight: 700;">1</span>
+					</td>
+					<td style="vertical-align: middle; font-size: 15px; color: #1e1e1e;">
+						<strong>Create your first event</strong> — Choose a date, add details, and publish it on your group site.
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+	<tr>
+		<td style="padding: 10px 0; border-bottom: 1px solid #f0f0f5; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;">
+			<table role="presentation" cellspacing="0" cellpadding="0" border="0">
+				<tr>
+					<td style="vertical-align: top; padding-right: 12px;">
+						<span style="display: inline-block; width: 28px; height: 28px; line-height: 28px; text-align: center; border-radius: 50%; background-color: #3858E9; color: #ffffff; font-size: 14px; font-weight: 700;">2</span>
+					</td>
+					<td style="vertical-align: middle; font-size: 15px; color: #1e1e1e;">
+						<strong>Set up a venue</strong> — Add your usual meetup location so it's ready for future events.
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+	<tr>
+		<td style="padding: 10px 0; border-bottom: 1px solid #f0f0f5; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;">
+			<table role="presentation" cellspacing="0" cellpadding="0" border="0">
+				<tr>
+					<td style="vertical-align: top; padding-right: 12px;">
+						<span style="display: inline-block; width: 28px; height: 28px; line-height: 28px; text-align: center; border-radius: 50%; background-color: #3858E9; color: #ffffff; font-size: 14px; font-weight: 700;">3</span>
+					</td>
+					<td style="vertical-align: middle; font-size: 15px; color: #1e1e1e;">
+						<strong>Invite co-organizers</strong> — Share the load by adding trusted community members.
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+	<tr>
+		<td style="padding: 10px 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;">
+			<table role="presentation" cellspacing="0" cellpadding="0" border="0">
+				<tr>
+					<td style="vertical-align: top; padding-right: 12px;">
+						<span style="display: inline-block; width: 28px; height: 28px; line-height: 28px; text-align: center; border-radius: 50%; background-color: #3858E9; color: #ffffff; font-size: 14px; font-weight: 700;">4</span>
+					</td>
+					<td style="vertical-align: middle; font-size: 15px; color: #1e1e1e;">
+						<strong>Spread the word</strong> — Share your group page in local WordPress communities and on social media.
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+
+<!-- CTA Buttons -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 8px 0;">
+	<tr>
+		<td style="border-radius: 8px; background-color: #3858E9; margin-right: 12px;" class="cta-button">
+			<a href="{{dashboard_url}}" target="_blank" style="display: inline-block; padding: 14px 32px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none; border-radius: 8px;">Go to Your Dashboard</a>
+		</td>
+	</tr>
+</table>
+
+<!-- Divider -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 20px 0;">
+	<tr>
+		<td class="divider" style="border-top: 1px solid #e8e8e8; font-size: 1px; line-height: 1px;">&nbsp;</td>
+	</tr>
+</table>
+
+<p style="margin: 0; font-size: 14px; color: #646970;">
+	Need help getting started? Visit <a href="https://learn.wordpress.org" style="color: #0073AA; text-decoration: none; font-weight: 500;">Learn WordPress</a> for resources, or reach out to your assigned mentor or the Community Team on <a href="https://make.wordpress.org/community" style="color: #0073AA; text-decoration: none; font-weight: 500;">Make WordPress</a>.
+</p>

--- a/wp-content/plugins/wordpress-groups/includes/notifications/class-email-notifier.php
+++ b/wp-content/plugins/wordpress-groups/includes/notifications/class-email-notifier.php
@@ -89,9 +89,11 @@ class Email_Notifier {
 		 */
 		do_action( 'groups_before_email_send', $to, $subject, $template, $data );
 
-		$sent = wp_mail( $to, $subject, $html, $headers );
-
-		remove_filter( 'wp_mail_content_type', $set_html_content_type );
+		try {
+			$sent = wp_mail( $to, $subject, $html, $headers );
+		} finally {
+			remove_filter( 'wp_mail_content_type', $set_html_content_type );
+		}
 
 		/**
 		 * Fires after an email notification is sent.
@@ -109,10 +111,14 @@ class Email_Notifier {
 	/**
 	 * Generate a default unsubscribe URL for a given email address.
 	 *
+	 * Uses an HMAC token instead of exposing the raw email in the URL.
+	 *
 	 * @param string $email Recipient email address.
 	 * @return string Unsubscribe URL.
 	 */
 	private function get_default_unsubscribe_url( string $email ): string {
+		$token = self::generate_unsubscribe_token( $email );
+
 		/**
 		 * Filters the default unsubscribe URL.
 		 *
@@ -124,11 +130,61 @@ class Email_Notifier {
 			add_query_arg(
 				[
 					'action' => 'groups_email_preferences',
-					'email'  => rawurlencode( $email ),
+					'token'  => $token,
 				],
 				home_url( '/email-preferences/' )
 			),
 			$email
 		);
+	}
+
+	/**
+	 * Generate an HMAC-based unsubscribe token for an email address.
+	 *
+	 * The token encodes the email address securely using wp_hash() so that
+	 * the raw email is not exposed in the unsubscribe URL query string.
+	 *
+	 * @param string $email The email address to generate a token for.
+	 * @return string The HMAC token (base64url-encoded email + hash).
+	 */
+	public static function generate_unsubscribe_token( string $email ): string {
+		$hash = wp_hash( 'unsubscribe:' . $email, 'nonce' );
+
+		// Encode both email and hash together so the server can verify.
+		$payload = base64_encode( $email . '|' . $hash );
+
+		// Make URL-safe by replacing +/= characters.
+		return rtrim( strtr( $payload, '+/', '-_' ), '=' );
+	}
+
+	/**
+	 * Verify and extract the email address from an unsubscribe token.
+	 *
+	 * @param string $token The unsubscribe token to verify.
+	 * @return string|false The email address if valid, false otherwise.
+	 */
+	public static function verify_unsubscribe_token( string $token ): string|false {
+		// Restore base64 encoding.
+		$payload = base64_decode( strtr( $token, '-_', '+/' ) );
+
+		if ( false === $payload ) {
+			return false;
+		}
+
+		$parts = explode( '|', $payload, 2 );
+
+		if ( count( $parts ) !== 2 ) {
+			return false;
+		}
+
+		[ $email, $hash ] = $parts;
+
+		$expected_hash = wp_hash( 'unsubscribe:' . $email, 'nonce' );
+
+		if ( ! hash_equals( $expected_hash, $hash ) ) {
+			return false;
+		}
+
+		return $email;
 	}
 }

--- a/wp-content/plugins/wordpress-groups/includes/notifications/class-email-notifier.php
+++ b/wp-content/plugins/wordpress-groups/includes/notifications/class-email-notifier.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Email notification sender.
+ *
+ * Renders templates and sends HTML emails via wp_mail().
+ *
+ * @package Groups\Notifications
+ */
+
+namespace Groups\Notifications;
+
+/**
+ * Sends branded HTML email notifications using the template system.
+ */
+class Email_Notifier {
+
+	/**
+	 * Email template renderer.
+	 *
+	 * @var Email_Templates
+	 */
+	private Email_Templates $templates;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Email_Templates|null $templates Optional. Template renderer instance.
+	 */
+	public function __construct( ?Email_Templates $templates = null ) {
+		$this->templates = $templates ?? new Email_Templates();
+	}
+
+	/**
+	 * Send an HTML email using a named template.
+	 *
+	 * Renders the template with the provided data, sets the content type to HTML,
+	 * and sends via wp_mail().
+	 *
+	 * @param string       $to       Recipient email address.
+	 * @param string       $subject  Email subject line.
+	 * @param string       $template Template name (e.g. 'rsvp-confirmation').
+	 * @param array        $data     Associative array of placeholder => value pairs.
+	 * @param array|string $headers  Optional. Additional headers.
+	 * @return bool Whether the email was sent successfully.
+	 */
+	public function send( string $to, string $subject, string $template, array $data = [], array|string $headers = [] ): bool {
+		// Ensure email_subject and preview_text have defaults.
+		$data['email_subject'] = $data['email_subject'] ?? $subject;
+		$data['preview_text']  = $data['preview_text'] ?? $subject;
+
+		// Provide a default unsubscribe URL if not set.
+		if ( empty( $data['unsubscribe_url'] ) ) {
+			$data['unsubscribe_url'] = $this->get_default_unsubscribe_url( $to );
+		}
+
+		$html = $this->templates->render( $template, $data );
+
+		// Set content type to HTML via filter.
+		$set_html_content_type = static function (): string {
+			return 'text/html';
+		};
+
+		add_filter( 'wp_mail_content_type', $set_html_content_type );
+
+		// Set From header if not already provided.
+		$from_name  = apply_filters( 'groups_email_from_name', 'WordPress.org Community' );
+		$from_email = apply_filters( 'groups_email_from_address', 'noreply@wordpress.org' );
+
+		if ( is_array( $headers ) ) {
+			$has_from = false;
+			foreach ( $headers as $header ) {
+				if ( stripos( $header, 'from:' ) === 0 ) {
+					$has_from = true;
+					break;
+				}
+			}
+			if ( ! $has_from ) {
+				$headers[] = sprintf( 'From: %s <%s>', $from_name, $from_email );
+			}
+		}
+
+		/**
+		 * Fires before an email notification is sent.
+		 *
+		 * @param string $to       Recipient email.
+		 * @param string $subject  Email subject.
+		 * @param string $template Template name.
+		 * @param array  $data     Template data.
+		 */
+		do_action( 'groups_before_email_send', $to, $subject, $template, $data );
+
+		$sent = wp_mail( $to, $subject, $html, $headers );
+
+		remove_filter( 'wp_mail_content_type', $set_html_content_type );
+
+		/**
+		 * Fires after an email notification is sent.
+		 *
+		 * @param bool   $sent     Whether the email was sent successfully.
+		 * @param string $to       Recipient email.
+		 * @param string $subject  Email subject.
+		 * @param string $template Template name.
+		 */
+		do_action( 'groups_after_email_send', $sent, $to, $subject, $template );
+
+		return $sent;
+	}
+
+	/**
+	 * Generate a default unsubscribe URL for a given email address.
+	 *
+	 * @param string $email Recipient email address.
+	 * @return string Unsubscribe URL.
+	 */
+	private function get_default_unsubscribe_url( string $email ): string {
+		/**
+		 * Filters the default unsubscribe URL.
+		 *
+		 * @param string $url   The default unsubscribe URL.
+		 * @param string $email The recipient email address.
+		 */
+		return apply_filters(
+			'groups_email_unsubscribe_url',
+			add_query_arg(
+				[
+					'action' => 'groups_email_preferences',
+					'email'  => rawurlencode( $email ),
+				],
+				home_url( '/email-preferences/' )
+			),
+			$email
+		);
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/notifications/class-email-templates.php
+++ b/wp-content/plugins/wordpress-groups/includes/notifications/class-email-templates.php
@@ -30,6 +30,30 @@ class Email_Templates {
 	private ?string $base_template = null;
 
 	/**
+	 * Placeholders that are allowed to contain HTML.
+	 *
+	 * These values are sanitized with wp_kses_post() instead of esc_html().
+	 *
+	 * @var array<string>
+	 */
+	private const HTML_ALLOWED_PLACEHOLDERS = [
+		'content',
+		'announcement_body',
+		'status_message',
+	];
+
+	/**
+	 * Placeholders that appear in HTML attribute contexts (e.g. title, aria-label).
+	 *
+	 * These are escaped with esc_attr() in attribute positions by the base template.
+	 *
+	 * @var array<string>
+	 */
+	private const ATTR_CONTEXT_PLACEHOLDERS = [
+		'email_subject',
+	];
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string|null $template_dir Optional. Path to templates directory.
@@ -109,6 +133,13 @@ class Email_Templates {
 	/**
 	 * Substitute {{placeholder}} tokens in HTML with values from data array.
 	 *
+	 * Values are escaped based on their context:
+	 * - HTML-allowed placeholders (content, announcement_body, status_message)
+	 *   are sanitized with wp_kses_post() to allow safe HTML.
+	 * - Attribute-context placeholders (email_subject) are additionally replaced
+	 *   in attribute positions using esc_attr().
+	 * - All other values are escaped with esc_html() to prevent XSS.
+	 *
 	 * Any placeholders without matching data keys are left as-is.
 	 *
 	 * @param string $html The HTML containing placeholders.
@@ -117,8 +148,40 @@ class Email_Templates {
 	 */
 	private function substitute_placeholders( string $html, array $data ): string {
 		foreach ( $data as $key => $value ) {
-			if ( is_string( $value ) || is_numeric( $value ) ) {
-				$html = str_replace( '{{' . $key . '}}', (string) $value, $html );
+			if ( ! is_string( $value ) && ! is_numeric( $value ) ) {
+				continue;
+			}
+
+			$value = (string) $value;
+
+			if ( in_array( $key, self::HTML_ALLOWED_PLACEHOLDERS, true ) ) {
+				$escaped_value = wp_kses_post( $value );
+			} else {
+				$escaped_value = esc_html( $value );
+			}
+
+			// For placeholders that appear in attribute contexts (like <title> and aria-label),
+			// also substitute an attribute-safe version in those positions.
+			if ( in_array( $key, self::ATTR_CONTEXT_PLACEHOLDERS, true ) ) {
+				$attr_value = esc_attr( $value );
+				$placeholder = '{{' . $key . '}}';
+
+				// Replace in attribute contexts first (aria-label="...", title tag content).
+				$html = preg_replace(
+					'/(aria-label=["\'])' . preg_quote( $placeholder, '/' ) . '(["\'])/i',
+					'${1}' . str_replace( '\\', '\\\\', $attr_value ) . '${2}',
+					$html
+				);
+				$html = preg_replace(
+					'/(<title>)' . preg_quote( $placeholder, '/' ) . '(<\/title>)/i',
+					'${1}' . str_replace( '\\', '\\\\', $attr_value ) . '${2}',
+					$html
+				);
+
+				// Replace remaining occurrences with HTML-escaped version.
+				$html = str_replace( $placeholder, $escaped_value, $html );
+			} else {
+				$html = str_replace( '{{' . $key . '}}', $escaped_value, $html );
 			}
 		}
 

--- a/wp-content/plugins/wordpress-groups/includes/notifications/class-email-templates.php
+++ b/wp-content/plugins/wordpress-groups/includes/notifications/class-email-templates.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Email template loader and renderer.
+ *
+ * Loads HTML email templates from the email-templates directory,
+ * substitutes placeholders, and wraps content in the base template.
+ *
+ * @package Groups\Notifications
+ */
+
+namespace Groups\Notifications;
+
+/**
+ * Handles loading, rendering, and placeholder substitution for HTML email templates.
+ */
+class Email_Templates {
+
+	/**
+	 * Path to the email templates directory.
+	 *
+	 * @var string
+	 */
+	private string $template_dir;
+
+	/**
+	 * Cached base template HTML.
+	 *
+	 * @var string|null
+	 */
+	private ?string $base_template = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string|null $template_dir Optional. Path to templates directory.
+	 *                                  Defaults to the plugin's email-templates/ directory.
+	 */
+	public function __construct( ?string $template_dir = null ) {
+		$this->template_dir = $template_dir ?? dirname( __DIR__, 2 ) . '/email-templates';
+	}
+
+	/**
+	 * Render a named email template with placeholder data.
+	 *
+	 * Loads the content template file, substitutes all {{placeholder}} tokens
+	 * with values from $data, processes conditional blocks, and wraps the result
+	 * in the base template layout.
+	 *
+	 * @param string $template_name Template filename without path (e.g. 'rsvp-confirmation').
+	 * @param array  $data          Associative array of placeholder => value pairs.
+	 * @return string Fully rendered HTML email.
+	 *
+	 * @throws \InvalidArgumentException If the template file does not exist.
+	 */
+	public function render( string $template_name, array $data = [] ): string {
+		$content_html = $this->load_template( $template_name );
+		$content_html = $this->process_conditionals( $content_html, $data );
+		$content_html = $this->substitute_placeholders( $content_html, $data );
+
+		$base_html = $this->get_base_template();
+		$data['content'] = $content_html;
+		$base_html = $this->substitute_placeholders( $base_html, $data );
+
+		/**
+		 * Filters the fully rendered email HTML.
+		 *
+		 * @param string $html          The rendered email HTML.
+		 * @param string $template_name The template that was rendered.
+		 * @param array  $data          The data passed for placeholder substitution.
+		 */
+		return apply_filters( 'groups_email_rendered', $base_html, $template_name, $data );
+	}
+
+	/**
+	 * Load a template file and return its contents.
+	 *
+	 * @param string $template_name Template name (without .html extension).
+	 * @return string Template HTML content.
+	 *
+	 * @throws \InvalidArgumentException If the template file does not exist.
+	 */
+	private function load_template( string $template_name ): string {
+		// Sanitize template name to prevent directory traversal.
+		$template_name = sanitize_file_name( $template_name );
+		$file_path     = $this->template_dir . '/' . $template_name . '.html';
+
+		if ( ! file_exists( $file_path ) ) {
+			throw new \InvalidArgumentException(
+				sprintf( 'Email template "%s" not found at %s', $template_name, $file_path )
+			);
+		}
+
+		return file_get_contents( $file_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	}
+
+	/**
+	 * Get the base template HTML, loading it once and caching.
+	 *
+	 * @return string Base template HTML.
+	 */
+	private function get_base_template(): string {
+		if ( null === $this->base_template ) {
+			$this->base_template = $this->load_template( 'base' );
+		}
+
+		return $this->base_template;
+	}
+
+	/**
+	 * Substitute {{placeholder}} tokens in HTML with values from data array.
+	 *
+	 * Any placeholders without matching data keys are left as-is.
+	 *
+	 * @param string $html The HTML containing placeholders.
+	 * @param array  $data Associative array of placeholder => value pairs.
+	 * @return string HTML with placeholders replaced.
+	 */
+	private function substitute_placeholders( string $html, array $data ): string {
+		foreach ( $data as $key => $value ) {
+			if ( is_string( $value ) || is_numeric( $value ) ) {
+				$html = str_replace( '{{' . $key . '}}', (string) $value, $html );
+			}
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Process conditional blocks in templates.
+	 *
+	 * Supports simple conditionals like:
+	 *   {{#if_attending}}...content...{{/if_attending}}
+	 *   {{#if_waitlisted}}...content...{{/if_waitlisted}}
+	 *
+	 * A conditional block is shown if the corresponding data key (without the "if_" prefix)
+	 * evaluates to a matching value. For example, {{#if_attending}} is shown when
+	 * $data['rsvp_status'] equals 'attending' (case-insensitive).
+	 *
+	 * @param string $html The HTML containing conditional blocks.
+	 * @param array  $data The data array for evaluating conditions.
+	 * @return string HTML with conditionals resolved.
+	 */
+	private function process_conditionals( string $html, array $data ): string {
+		return preg_replace_callback(
+			'/\{\{#if_(\w+)\}\}(.*?)\{\{\/if_\1\}\}/s',
+			function ( $matches ) use ( $data ) {
+				$condition = $matches[1]; // e.g., "attending" or "waitlisted"
+
+				// Check against rsvp_status for RSVP templates.
+				if ( isset( $data['rsvp_status'] ) && strtolower( $data['rsvp_status'] ) === strtolower( $condition ) ) {
+					return $matches[2];
+				}
+
+				// Check against status for other templates.
+				if ( isset( $data['status'] ) && strtolower( $data['status'] ) === strtolower( $condition ) ) {
+					return $matches[2];
+				}
+
+				// Check for a direct boolean-like data key.
+				if ( ! empty( $data[ 'is_' . $condition ] ) || ! empty( $data[ $condition ] ) ) {
+					return $matches[2];
+				}
+
+				return '';
+			},
+			$html
+		) ?? $html;
+	}
+
+	/**
+	 * Get all available template names.
+	 *
+	 * @return array List of template names (without .html extension).
+	 */
+	public function get_available_templates(): array {
+		$files     = glob( $this->template_dir . '/*.html' );
+		$templates = [];
+
+		if ( $files ) {
+			foreach ( $files as $file ) {
+				$name = basename( $file, '.html' );
+				if ( 'base' !== $name ) {
+					$templates[] = $name;
+				}
+			}
+		}
+
+		return $templates;
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/test-email-templates.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/test-email-templates.php
@@ -1,0 +1,338 @@
+<?php
+/**
+ * Tests for the Email_Templates class.
+ *
+ * @package Groups\Tests\Notifications
+ */
+
+namespace Groups\Tests\Notifications;
+
+use Groups\Notifications\Email_Templates;
+use WP_UnitTestCase;
+
+/**
+ * Test email template rendering, placeholder substitution, and base wrapping.
+ */
+class Test_Email_Templates extends WP_UnitTestCase {
+
+	/**
+	 * Template renderer instance.
+	 *
+	 * @var Email_Templates
+	 */
+	private Email_Templates $templates;
+
+	/**
+	 * Path to the email templates directory.
+	 *
+	 * @var string
+	 */
+	private string $template_dir;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->template_dir = dirname( __DIR__, 3 ) . '/email-templates';
+		$this->templates    = new Email_Templates( $this->template_dir );
+	}
+
+	/**
+	 * Test that the base template exists and contains required structure.
+	 */
+	public function test_base_template_exists(): void {
+		$this->assertFileExists( $this->template_dir . '/base.html' );
+	}
+
+	/**
+	 * Test that the base template contains the content placeholder.
+	 */
+	public function test_base_template_has_content_placeholder(): void {
+		$base = file_get_contents( $this->template_dir . '/base.html' );
+		$this->assertStringContainsString( '{{content}}', $base );
+	}
+
+	/**
+	 * Test that the base template contains the unsubscribe placeholder.
+	 */
+	public function test_base_template_has_unsubscribe_placeholder(): void {
+		$base = file_get_contents( $this->template_dir . '/base.html' );
+		$this->assertStringContainsString( '{{unsubscribe_url}}', $base );
+	}
+
+	/**
+	 * Test rendering RSVP confirmation for attending status.
+	 */
+	public function test_render_rsvp_confirmation_attending(): void {
+		$data = [
+			'user_name'       => 'Alice',
+			'event_title'     => 'WordPress Meetup',
+			'event_date'      => 'March 20, 2026',
+			'event_time'      => '6:00 PM',
+			'event_url'       => 'https://events.wordpress.org/melbourne/event/meetup/',
+			'venue_name'      => 'Community Hall',
+			'group_name'      => 'Melbourne WordPress',
+			'rsvp_status'     => 'attending',
+			'unsubscribe_url' => 'https://example.com/unsubscribe',
+			'email_subject'   => 'RSVP Confirmed',
+			'preview_text'    => 'Your RSVP is confirmed.',
+		];
+
+		$html = $this->templates->render( 'rsvp-confirmation', $data );
+
+		$this->assertStringContainsString( 'Alice', $html );
+		$this->assertStringContainsString( 'WordPress Meetup', $html );
+		$this->assertStringContainsString( 'March 20, 2026', $html );
+		$this->assertStringContainsString( '6:00 PM', $html );
+		$this->assertStringContainsString( 'Community Hall', $html );
+		$this->assertStringContainsString( 'Melbourne WordPress', $html );
+		$this->assertStringContainsString( 'Your RSVP is Confirmed', $html );
+		$this->assertStringNotContainsString( "You're on the Waitlist", $html );
+	}
+
+	/**
+	 * Test rendering RSVP confirmation for waitlisted status.
+	 */
+	public function test_render_rsvp_confirmation_waitlisted(): void {
+		$data = [
+			'user_name'       => 'Bob',
+			'event_title'     => 'WordPress Meetup',
+			'event_date'      => 'March 20, 2026',
+			'event_time'      => '6:00 PM',
+			'event_url'       => 'https://events.wordpress.org/melbourne/event/meetup/',
+			'venue_name'      => 'Community Hall',
+			'group_name'      => 'Melbourne WordPress',
+			'rsvp_status'     => 'waitlisted',
+			'unsubscribe_url' => 'https://example.com/unsubscribe',
+			'email_subject'   => 'RSVP Waitlisted',
+			'preview_text'    => 'You are on the waitlist.',
+		];
+
+		$html = $this->templates->render( 'rsvp-confirmation', $data );
+
+		$this->assertStringContainsString( 'Bob', $html );
+		$this->assertStringContainsString( "You're on the Waitlist", $html );
+		$this->assertStringNotContainsString( 'Your RSVP is Confirmed', $html );
+		$this->assertStringContainsString( 'waitlist', $html );
+	}
+
+	/**
+	 * Test rendering event reminder template.
+	 */
+	public function test_render_event_reminder(): void {
+		$data = [
+			'user_name'       => 'Charlie',
+			'event_title'     => 'Contributor Day',
+			'event_date'      => 'April 1, 2026',
+			'event_time'      => '10:00 AM',
+			'event_url'       => 'https://events.wordpress.org/sydney/event/contributor-day/',
+			'venue_name'      => 'Tech Hub',
+			'venue_address'   => '123 Main St, Sydney',
+			'group_name'      => 'Sydney WordPress',
+			'unsubscribe_url' => 'https://example.com/unsubscribe',
+			'email_subject'   => 'Event Reminder',
+			'preview_text'    => 'Your event is coming up!',
+		];
+
+		$html = $this->templates->render( 'event-reminder', $data );
+
+		$this->assertStringContainsString( 'Charlie', $html );
+		$this->assertStringContainsString( 'Contributor Day', $html );
+		$this->assertStringContainsString( 'April 1, 2026', $html );
+		$this->assertStringContainsString( '123 Main St, Sydney', $html );
+		$this->assertStringContainsString( 'Your Event is Coming Up', $html );
+	}
+
+	/**
+	 * Test rendering application status template.
+	 */
+	public function test_render_application_status(): void {
+		$data = [
+			'user_name'       => 'Dana',
+			'group_name'      => 'Berlin WordPress',
+			'status'          => 'Orientation',
+			'status_message'  => 'Your application has been approved! Please complete orientation.',
+			'dashboard_url'   => 'https://events.wordpress.org/dashboard/',
+			'unsubscribe_url' => 'https://example.com/unsubscribe',
+			'email_subject'   => 'Application Update',
+			'preview_text'    => 'Your application status has changed.',
+		];
+
+		$html = $this->templates->render( 'application-status', $data );
+
+		$this->assertStringContainsString( 'Dana', $html );
+		$this->assertStringContainsString( 'Berlin WordPress', $html );
+		$this->assertStringContainsString( 'Orientation', $html );
+		$this->assertStringContainsString( 'approved', $html );
+		$this->assertStringContainsString( 'dashboard/', $html );
+	}
+
+	/**
+	 * Test rendering welcome organizer template.
+	 */
+	public function test_render_welcome_organizer(): void {
+		$data = [
+			'user_name'       => 'Eve',
+			'group_name'      => 'Tokyo WordPress',
+			'site_url'        => 'https://events.wordpress.org/tokyo-user-group/',
+			'dashboard_url'   => 'https://events.wordpress.org/tokyo-user-group/dashboard/',
+			'unsubscribe_url' => 'https://example.com/unsubscribe',
+			'email_subject'   => 'Welcome, Organizer!',
+			'preview_text'    => 'Your group is ready.',
+		];
+
+		$html = $this->templates->render( 'welcome-organizer', $data );
+
+		$this->assertStringContainsString( 'Eve', $html );
+		$this->assertStringContainsString( 'Tokyo WordPress', $html );
+		$this->assertStringContainsString( 'events.wordpress.org/tokyo-user-group/', $html );
+		$this->assertStringContainsString( 'Create your first event', $html );
+		$this->assertStringContainsString( 'Getting Started', $html );
+	}
+
+	/**
+	 * Test rendering dormancy alert template.
+	 */
+	public function test_render_dormancy_alert(): void {
+		$data = [
+			'deputy_name'     => 'Frank',
+			'group_name'      => 'Inactive City WP',
+			'days_inactive'   => '75',
+			'group_url'       => 'https://events.wordpress.org/inactive-city/',
+			'dashboard_url'   => 'https://events.wordpress.org/deputy-dashboard/',
+			'unsubscribe_url' => 'https://example.com/unsubscribe',
+			'email_subject'   => 'Dormancy Alert',
+			'preview_text'    => 'A group needs attention.',
+		];
+
+		$html = $this->templates->render( 'dormancy-alert', $data );
+
+		$this->assertStringContainsString( 'Frank', $html );
+		$this->assertStringContainsString( 'Inactive City WP', $html );
+		$this->assertStringContainsString( '75 days', $html );
+		$this->assertStringContainsString( 'Dormancy Alert', $html );
+		$this->assertStringContainsString( 'deputy-dashboard/', $html );
+	}
+
+	/**
+	 * Test rendering group announcement template.
+	 */
+	public function test_render_group_announcement(): void {
+		$data = [
+			'user_name'          => 'Grace',
+			'group_name'         => 'London WordPress',
+			'announcement_title' => 'New Venue for Next Month',
+			'announcement_body'  => 'We are moving our meetup to a new location starting next month.',
+			'group_url'          => 'https://events.wordpress.org/london/',
+			'unsubscribe_url'    => 'https://example.com/unsubscribe',
+			'email_subject'      => 'Group Announcement',
+			'preview_text'       => 'New announcement from London WordPress.',
+		];
+
+		$html = $this->templates->render( 'group-announcement', $data );
+
+		$this->assertStringContainsString( 'Grace', $html );
+		$this->assertStringContainsString( 'London WordPress', $html );
+		$this->assertStringContainsString( 'New Venue for Next Month', $html );
+		$this->assertStringContainsString( 'moving our meetup', $html );
+	}
+
+	/**
+	 * Test that all templates are wrapped in the base template.
+	 */
+	public function test_all_templates_wrapped_in_base(): void {
+		$templates = $this->templates->get_available_templates();
+
+		$this->assertNotEmpty( $templates, 'No content templates found.' );
+
+		foreach ( $templates as $template_name ) {
+			$html = $this->templates->render( $template_name, [
+				'user_name'          => 'Test',
+				'deputy_name'        => 'Test',
+				'event_title'        => 'Test Event',
+				'event_date'         => 'Jan 1, 2026',
+				'event_time'         => '12:00 PM',
+				'event_url'          => 'https://example.com',
+				'venue_name'         => 'Test Venue',
+				'venue_address'      => '123 Test St',
+				'group_name'         => 'Test Group',
+				'rsvp_status'        => 'attending',
+				'status'             => 'Active',
+				'status_message'     => 'All good.',
+				'dashboard_url'      => 'https://example.com/dashboard',
+				'site_url'           => 'https://example.com/site',
+				'group_url'          => 'https://example.com/group',
+				'days_inactive'      => '90',
+				'announcement_title' => 'Test Announcement',
+				'announcement_body'  => 'Test body content.',
+				'unsubscribe_url'    => 'https://example.com/unsubscribe',
+				'email_subject'      => 'Test Subject',
+				'preview_text'       => 'Test preview.',
+			] );
+
+			// All rendered emails should have the base template structure.
+			$this->assertStringContainsString( '<!DOCTYPE html>', $html, "Template {$template_name} missing DOCTYPE." );
+			$this->assertStringContainsString( 'WordPress.org', $html, "Template {$template_name} missing WordPress.org branding." );
+			$this->assertStringContainsString( 'Community Groups', $html, "Template {$template_name} missing Community Groups text." );
+			$this->assertStringContainsString( 'email-preferences', $html, "Template {$template_name} missing unsubscribe link." );
+			$this->assertStringContainsString( 'prefers-color-scheme: dark', $html, "Template {$template_name} missing dark mode support." );
+		}
+	}
+
+	/**
+	 * Test that rendering a nonexistent template throws an exception.
+	 */
+	public function test_render_nonexistent_template_throws(): void {
+		$this->expectException( \InvalidArgumentException::class );
+		$this->templates->render( 'nonexistent-template' );
+	}
+
+	/**
+	 * Test that unrecognized placeholders are left in the output.
+	 */
+	public function test_unrecognized_placeholders_left_intact(): void {
+		$html = $this->templates->render( 'event-reminder', [
+			'user_name'       => 'Test',
+			'event_title'     => 'Test Event',
+			'email_subject'   => 'Test',
+			'preview_text'    => 'Test',
+			'unsubscribe_url' => 'https://example.com/unsubscribe',
+			// event_date, event_time, venue_name, etc. intentionally omitted.
+		] );
+
+		// Omitted placeholders should remain as {{placeholder}}.
+		$this->assertStringContainsString( '{{event_date}}', $html );
+		$this->assertStringContainsString( '{{event_time}}', $html );
+	}
+
+	/**
+	 * Test get_available_templates returns expected templates.
+	 */
+	public function test_get_available_templates(): void {
+		$templates = $this->templates->get_available_templates();
+
+		$expected = [
+			'application-status',
+			'dormancy-alert',
+			'event-reminder',
+			'group-announcement',
+			'rsvp-confirmation',
+			'welcome-organizer',
+		];
+
+		sort( $templates );
+		sort( $expected );
+
+		$this->assertSame( $expected, $templates );
+	}
+
+	/**
+	 * Test that base template is NOT in the available templates list.
+	 */
+	public function test_base_not_in_available_templates(): void {
+		$templates = $this->templates->get_available_templates();
+		$this->assertNotContains( 'base', $templates );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/test-email-templates.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/test-email-templates.php
@@ -8,6 +8,7 @@
 namespace Groups\Tests\Notifications;
 
 use Groups\Notifications\Email_Templates;
+use Groups\Notifications\Email_Notifier;
 use WP_UnitTestCase;
 
 /**
@@ -334,5 +335,163 @@ class Test_Email_Templates extends WP_UnitTestCase {
 	public function test_base_not_in_available_templates(): void {
 		$templates = $this->templates->get_available_templates();
 		$this->assertNotContains( 'base', $templates );
+	}
+
+	/**
+	 * Test that placeholder values containing HTML are escaped in output.
+	 *
+	 * Non-HTML-allowed placeholders like group_name, user_name, event_title
+	 * should have their HTML entities escaped to prevent XSS.
+	 */
+	public function test_placeholder_values_are_html_escaped(): void {
+		$xss_payload = '<script>alert("xss")</script>';
+
+		$data = [
+			'user_name'       => $xss_payload,
+			'event_title'     => 'Event with <b>bold</b> & "quotes"',
+			'event_date'      => 'Jan 1, 2026',
+			'event_time'      => '12:00 PM',
+			'event_url'       => 'https://example.com',
+			'venue_name'      => 'Test Venue',
+			'venue_address'   => '123 Test St',
+			'group_name'      => $xss_payload,
+			'unsubscribe_url' => 'https://example.com/unsubscribe',
+			'email_subject'   => 'Test Subject',
+			'preview_text'    => 'Test preview.',
+		];
+
+		$html = $this->templates->render( 'event-reminder', $data );
+
+		// Raw script tags must NOT appear in the output.
+		$this->assertStringNotContainsString( '<script>', $html );
+		$this->assertStringNotContainsString( '</script>', $html );
+
+		// The escaped version should be present.
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+
+		// Ampersands and quotes should be escaped in non-HTML placeholders.
+		$this->assertStringContainsString( '&amp;', $html );
+	}
+
+	/**
+	 * Test that HTML-allowed placeholders preserve safe HTML but strip scripts.
+	 *
+	 * announcement_body is allowed to contain HTML (via wp_kses_post),
+	 * so safe tags like <p> and <strong> should be preserved, but
+	 * dangerous tags like <script> should be stripped.
+	 */
+	public function test_html_allowed_placeholders_strip_scripts_but_keep_safe_html(): void {
+		$data = [
+			'user_name'          => 'Grace',
+			'group_name'         => 'London WordPress',
+			'announcement_title' => 'Test',
+			'announcement_body'  => '<p>Safe <strong>HTML</strong> content.</p><script>alert("xss")</script>',
+			'group_url'          => 'https://events.wordpress.org/london/',
+			'unsubscribe_url'    => 'https://example.com/unsubscribe',
+			'email_subject'      => 'Group Announcement',
+			'preview_text'       => 'Test.',
+		];
+
+		$html = $this->templates->render( 'group-announcement', $data );
+
+		// Safe HTML tags should be preserved.
+		$this->assertStringContainsString( '<p>Safe <strong>HTML</strong> content.</p>', $html );
+
+		// Script tags should be stripped entirely.
+		$this->assertStringNotContainsString( '<script>', $html );
+		$this->assertStringNotContainsString( 'alert("xss")', $html );
+	}
+
+	/**
+	 * Test that email_subject is properly escaped in attribute contexts.
+	 *
+	 * The email_subject appears in <title> and aria-label attributes in base.html,
+	 * which need esc_attr() escaping rather than just esc_html().
+	 */
+	public function test_email_subject_escaped_in_attribute_contexts(): void {
+		$data = [
+			'user_name'       => 'Test',
+			'event_title'     => 'Test Event',
+			'event_date'      => 'Jan 1, 2026',
+			'event_time'      => '12:00 PM',
+			'event_url'       => 'https://example.com',
+			'venue_name'      => 'Test Venue',
+			'venue_address'   => '123 Test St',
+			'group_name'      => 'Test Group',
+			'unsubscribe_url' => 'https://example.com/unsubscribe',
+			'email_subject'   => 'Subject with "quotes" & <tags>',
+			'preview_text'    => 'Test preview.',
+		];
+
+		$html = $this->templates->render( 'event-reminder', $data );
+
+		// In the title tag, the subject should be attribute-safe.
+		$this->assertStringNotContainsString( '<title>Subject with "quotes" & <tags></title>', $html );
+
+		// The aria-label should use esc_attr-safe content.
+		$this->assertStringNotContainsString( 'aria-label="Subject with "quotes"', $html );
+	}
+
+	/**
+	 * Test that the unsubscribe URL uses an HMAC token, not the raw email.
+	 */
+	public function test_unsubscribe_url_uses_token_not_raw_email(): void {
+		$email = 'user@example.com';
+
+		$notifier = new Email_Notifier();
+
+		// Use reflection to access the private get_default_unsubscribe_url method.
+		$reflection = new \ReflectionMethod( $notifier, 'get_default_unsubscribe_url' );
+		$reflection->setAccessible( true );
+
+		$url = $reflection->invoke( $notifier, $email );
+
+		// The raw email should NOT appear in the URL.
+		$this->assertStringNotContainsString( 'user@example.com', $url );
+		$this->assertStringNotContainsString( 'user%40example.com', $url );
+
+		// The URL should use a token parameter instead of email.
+		$this->assertStringContainsString( 'token=', $url );
+		$this->assertStringNotContainsString( 'email=', $url );
+	}
+
+	/**
+	 * Test that generate_unsubscribe_token creates verifiable tokens.
+	 */
+	public function test_unsubscribe_token_roundtrip(): void {
+		$email = 'test@wordpress.org';
+
+		$token = Email_Notifier::generate_unsubscribe_token( $email );
+
+		// Token should be a non-empty string.
+		$this->assertNotEmpty( $token );
+
+		// Token should be URL-safe (no +, /, or = characters).
+		$this->assertDoesNotMatchRegularExpression( '/[+\/=]/', $token );
+
+		// Verify the token resolves back to the original email.
+		$result = Email_Notifier::verify_unsubscribe_token( $token );
+		$this->assertSame( $email, $result );
+	}
+
+	/**
+	 * Test that tampered unsubscribe tokens are rejected.
+	 */
+	public function test_tampered_unsubscribe_token_is_rejected(): void {
+		$token = Email_Notifier::generate_unsubscribe_token( 'legit@example.com' );
+
+		// Tamper with the token.
+		$tampered = $token . 'tampered';
+
+		$result = Email_Notifier::verify_unsubscribe_token( $tampered );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that an invalid unsubscribe token returns false.
+	 */
+	public function test_invalid_unsubscribe_token_returns_false(): void {
+		$this->assertFalse( Email_Notifier::verify_unsubscribe_token( '' ) );
+		$this->assertFalse( Email_Notifier::verify_unsubscribe_token( 'not-a-real-token' ) );
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a complete HTML email framework for WordPress.org Community Groups with 7 branded templates (base layout + 6 content templates), a PHP template renderer with placeholder substitution and conditional blocks, and an email notifier that sends via `wp_mail()`
- Base template features table-based layout for email client compatibility, WordPress.org branded gradient header, responsive design (600px max width, fluid on mobile), dark mode support via `@media (prefers-color-scheme: dark)`, and MSO/Outlook compatibility
- Content templates: RSVP confirmation (attending/waitlisted), event reminder, application status, welcome organizer with getting-started tips, dormancy alert for deputies, group announcement broadcast
- PHPUnit test suite covering all templates with placeholder substitution, conditional rendering, base wrapping, and error handling

Closes #36

## Test plan

- [ ] Verify `Email_Templates::render()` substitutes all `{{placeholder}}` tokens correctly
- [ ] Verify conditional blocks (`{{#if_attending}}...{{/if_attending}}`) show/hide based on `rsvp_status`
- [ ] Verify all content templates are wrapped in the base template with header, footer, and unsubscribe link
- [ ] Verify `Email_Notifier::send()` sets HTML content type and sends via `wp_mail()`
- [ ] Open `base.html` in a browser and confirm responsive layout at 600px and mobile widths
- [ ] Test dark mode rendering by toggling system color scheme preference
- [ ] Run PHPUnit: `wp-env run phpunit -- --filter Test_Email_Templates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)