### PR TITLE
Add Membership model using WordPress site roles

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -48,6 +48,7 @@ class Plugin {
 		new Post_Types\Event();
 		new Post_Types\Venue();
 
+		add_action( 'init', [ Models\Membership::class, 'register_roles' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
 	}
 

--- a/wp-content/plugins/wordpress-groups/includes/models/class-membership.php
+++ b/wp-content/plugins/wordpress-groups/includes/models/class-membership.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * Membership model — site role management, join/leave groups.
+ *
+ * Uses native WordPress multisite user roles. Each group is a site,
+ * and membership is managed by adding/removing users from that site.
+ *
+ * @package Groups\Models
+ */
+
+namespace Groups\Models;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles group membership via WordPress multisite site roles.
+ */
+class Membership {
+
+	/**
+	 * Custom roles and their capabilities.
+	 *
+	 * @var array<string, array{display_name: string, capabilities: array<string, bool>}>
+	 */
+	const ROLES = [
+		'organizer' => [
+			'display_name' => 'Organizer',
+			'capabilities' => [
+				// Editor capabilities.
+				'moderate_comments'          => true,
+				'manage_categories'          => true,
+				'manage_links'               => true,
+				'upload_files'               => true,
+				'unfiltered_html'            => true,
+				'edit_posts'                 => true,
+				'edit_others_posts'          => true,
+				'edit_published_posts'       => true,
+				'publish_posts'              => true,
+				'edit_pages'                 => true,
+				'read'                       => true,
+				'edit_others_pages'          => true,
+				'edit_published_pages'       => true,
+				'publish_pages'              => true,
+				'delete_pages'               => true,
+				'delete_others_pages'        => true,
+				'delete_published_pages'     => true,
+				'delete_posts'               => true,
+				'delete_others_posts'        => true,
+				'delete_published_posts'     => true,
+				'delete_private_posts'       => true,
+				'edit_private_posts'         => true,
+				'read_private_posts'         => true,
+				'delete_private_pages'       => true,
+				'edit_private_pages'         => true,
+				'read_private_pages'         => true,
+				// Additional organizer capability.
+				'manage_options'             => true,
+			],
+		],
+		'co_organizer' => [
+			'display_name' => 'Co-Organizer',
+			'capabilities' => [
+				// Editor capabilities.
+				'moderate_comments'          => true,
+				'manage_categories'          => true,
+				'manage_links'               => true,
+				'upload_files'               => true,
+				'unfiltered_html'            => true,
+				'edit_posts'                 => true,
+				'edit_others_posts'          => true,
+				'edit_published_posts'       => true,
+				'publish_posts'              => true,
+				'edit_pages'                 => true,
+				'read'                       => true,
+				'edit_others_pages'          => true,
+				'edit_published_pages'       => true,
+				'publish_pages'              => true,
+				'delete_pages'               => true,
+				'delete_others_pages'        => true,
+				'delete_published_pages'     => true,
+				'delete_posts'               => true,
+				'delete_others_posts'        => true,
+				'delete_published_posts'     => true,
+				'delete_private_posts'       => true,
+				'edit_private_posts'         => true,
+				'read_private_posts'         => true,
+				'delete_private_pages'       => true,
+				'edit_private_pages'         => true,
+				'read_private_pages'         => true,
+			],
+		],
+		'member' => [
+			'display_name' => 'Member',
+			'capabilities' => [
+				// Subscriber capabilities.
+				'read' => true,
+			],
+		],
+	];
+
+	/**
+	 * Register custom roles on the current site.
+	 *
+	 * Hooked to `init` so roles are available on every site in the network.
+	 */
+	public static function register_roles(): void {
+		foreach ( self::ROLES as $role_slug => $role_data ) {
+			// Only add if the role doesn't already exist.
+			if ( null === get_role( $role_slug ) ) {
+				add_role( $role_slug, $role_data['display_name'], $role_data['capabilities'] );
+			}
+		}
+	}
+
+	/**
+	 * Add a user to a group site with the member role.
+	 *
+	 * @param int $user_id The user ID to add.
+	 * @param int $blog_id The blog ID. Defaults to current blog.
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function join( int $user_id, int $blog_id = 0 ): true|\WP_Error {
+		$blog_id = $blog_id ?: get_current_blog_id();
+
+		if ( self::is_banned( $user_id, $blog_id ) ) {
+			return new \WP_Error(
+				'user_banned',
+				__( 'This user is banned from this group.', 'wordpress-groups' )
+			);
+		}
+
+		$result = add_user_to_blog( $blog_id, $user_id, 'member' );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		/**
+		 * Fires after a user joins a group.
+		 *
+		 * @param int $user_id The user ID.
+		 * @param int $blog_id The blog ID.
+		 */
+		do_action( 'groups_member_joined', $user_id, $blog_id );
+
+		return true;
+	}
+
+	/**
+	 * Remove a user from a group site.
+	 *
+	 * @param int $user_id The user ID to remove.
+	 * @param int $blog_id The blog ID. Defaults to current blog.
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function leave( int $user_id, int $blog_id = 0 ): true|\WP_Error {
+		$blog_id = $blog_id ?: get_current_blog_id();
+
+		$result = remove_user_from_blog( $user_id, $blog_id );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		/**
+		 * Fires after a user leaves a group.
+		 *
+		 * @param int $user_id The user ID.
+		 * @param int $blog_id The blog ID.
+		 */
+		do_action( 'groups_member_left', $user_id, $blog_id );
+
+		return true;
+	}
+
+	/**
+	 * Change a user's role on a group site.
+	 *
+	 * @param int    $user_id The user ID.
+	 * @param string $role    The new role (organizer, co_organizer, or member).
+	 * @param int    $blog_id The blog ID. Defaults to current blog.
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function change_role( int $user_id, string $role, int $blog_id = 0 ): true|\WP_Error {
+		$blog_id = $blog_id ?: get_current_blog_id();
+
+		if ( ! array_key_exists( $role, self::ROLES ) ) {
+			return new \WP_Error(
+				'invalid_role',
+				sprintf(
+					/* translators: %s: role slug */
+					__( 'Invalid role: %s. Must be one of: organizer, co_organizer, member.', 'wordpress-groups' ),
+					$role
+				)
+			);
+		}
+
+		// Verify the user is a member of the site.
+		if ( ! is_user_member_of_blog( $user_id, $blog_id ) ) {
+			return new \WP_Error(
+				'not_a_member',
+				__( 'User is not a member of this group.', 'wordpress-groups' )
+			);
+		}
+
+		// Switch to the target blog to modify the user's role.
+		switch_to_blog( $blog_id );
+
+		$user = new \WP_User( $user_id );
+		$user->set_role( $role );
+
+		restore_current_blog();
+
+		return true;
+	}
+
+	/**
+	 * Ban a user from a group site.
+	 *
+	 * Removes the user from the site and sets a user meta flag to prevent rejoin.
+	 *
+	 * @param int $user_id The user ID to ban.
+	 * @param int $blog_id The blog ID. Defaults to current blog.
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function ban( int $user_id, int $blog_id = 0 ): true|\WP_Error {
+		$blog_id = $blog_id ?: get_current_blog_id();
+
+		// Remove user from the site if they're a member.
+		if ( is_user_member_of_blog( $user_id, $blog_id ) ) {
+			$result = remove_user_from_blog( $user_id, $blog_id );
+
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+
+		// Set the ban flag.
+		update_user_meta( $user_id, "_groups_banned_{$blog_id}", 1 );
+
+		return true;
+	}
+
+	/**
+	 * Check if a user is banned from a group site.
+	 *
+	 * @param int $user_id The user ID to check.
+	 * @param int $blog_id The blog ID. Defaults to current blog.
+	 * @return bool True if the user is banned, false otherwise.
+	 */
+	public static function is_banned( int $user_id, int $blog_id = 0 ): bool {
+		$blog_id = $blog_id ?: get_current_blog_id();
+
+		return (bool) get_user_meta( $user_id, "_groups_banned_{$blog_id}", true );
+	}
+
+	/**
+	 * Get members of a group site, optionally filtered by role.
+	 *
+	 * @param int    $blog_id The blog ID. Defaults to current blog.
+	 * @param string $role    Optional role to filter by.
+	 * @return \WP_User[] Array of WP_User objects.
+	 */
+	public static function get_members( int $blog_id = 0, string $role = '' ): array {
+		$blog_id = $blog_id ?: get_current_blog_id();
+
+		$args = [
+			'blog_id' => $blog_id,
+		];
+
+		if ( $role ) {
+			$args['role'] = $role;
+		}
+
+		return get_users( $args );
+	}
+
+	/**
+	 * Count members of a group site.
+	 *
+	 * @param int $blog_id The blog ID. Defaults to current blog.
+	 * @return int The number of members.
+	 */
+	public static function get_member_count( int $blog_id = 0 ): int {
+		$blog_id = $blog_id ?: get_current_blog_id();
+
+		return count(
+			get_users(
+				[
+					'blog_id' => $blog_id,
+					'fields'  => 'ID',
+				]
+			)
+		);
+	}
+
+	/**
+	 * Get a user's role on a group site.
+	 *
+	 * @param int $user_id The user ID.
+	 * @param int $blog_id The blog ID. Defaults to current blog.
+	 * @return string|false The user's role slug, or false if not a member.
+	 */
+	public static function get_user_role( int $user_id, int $blog_id = 0 ): string|false {
+		$blog_id = $blog_id ?: get_current_blog_id();
+
+		if ( ! is_user_member_of_blog( $user_id, $blog_id ) ) {
+			return false;
+		}
+
+		switch_to_blog( $blog_id );
+
+		$user  = new \WP_User( $user_id );
+		$roles = $user->roles;
+
+		restore_current_blog();
+
+		if ( empty( $roles ) ) {
+			return false;
+		}
+
+		return reset( $roles );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/models/class-membership.php
+++ b/wp-content/plugins/wordpress-groups/includes/models/class-membership.php
@@ -31,7 +31,6 @@ class Membership {
 				'manage_categories'          => true,
 				'manage_links'               => true,
 				'upload_files'               => true,
-				'unfiltered_html'            => true,
 				'edit_posts'                 => true,
 				'edit_others_posts'          => true,
 				'edit_published_posts'       => true,
@@ -65,7 +64,6 @@ class Membership {
 				'manage_categories'          => true,
 				'manage_links'               => true,
 				'upload_files'               => true,
-				'unfiltered_html'            => true,
 				'edit_posts'                 => true,
 				'edit_others_posts'          => true,
 				'edit_published_posts'       => true,
@@ -101,15 +99,36 @@ class Membership {
 	/**
 	 * Register custom roles on the current site.
 	 *
-	 * Hooked to `init` so roles are available on every site in the network.
+	 * Uses wp_roles()->is_role() as a guard so that add_role() (which writes
+	 * to wp_options) is only called once per site, not on every page load.
 	 */
 	public static function register_roles(): void {
+		$wp_roles = wp_roles();
+
 		foreach ( self::ROLES as $role_slug => $role_data ) {
-			// Only add if the role doesn't already exist.
-			if ( null === get_role( $role_slug ) ) {
+			if ( ! $wp_roles->is_role( $role_slug ) ) {
 				add_role( $role_slug, $role_data['display_name'], $role_data['capabilities'] );
 			}
 		}
+	}
+
+	/**
+	 * Check whether a user can manage members on a group site.
+	 *
+	 * Returns true if the user is an organizer on the site or a network admin.
+	 *
+	 * @param int $user_id The user ID to check.
+	 * @param int $blog_id The blog ID. Defaults to current blog.
+	 * @return bool True if the user can manage members.
+	 */
+	public static function can_manage_members( int $user_id, int $blog_id = 0 ): bool {
+		$blog_id = $blog_id ?: get_current_blog_id();
+
+		if ( is_super_admin( $user_id ) ) {
+			return true;
+		}
+
+		return 'organizer' === self::get_user_role( $user_id, $blog_id );
 	}
 
 	/**
@@ -176,13 +195,24 @@ class Membership {
 	/**
 	 * Change a user's role on a group site.
 	 *
-	 * @param int    $user_id The user ID.
-	 * @param string $role    The new role (organizer, co_organizer, or member).
-	 * @param int    $blog_id The blog ID. Defaults to current blog.
+	 * Requires the current user (or the caller) to be an organizer or network admin.
+	 *
+	 * @param int    $user_id    The user ID.
+	 * @param string $role       The new role (organizer, co_organizer, or member).
+	 * @param int    $blog_id    The blog ID. Defaults to current blog.
+	 * @param int    $actor_id   The user performing the action. Defaults to current user.
 	 * @return true|\WP_Error True on success, WP_Error on failure.
 	 */
-	public static function change_role( int $user_id, string $role, int $blog_id = 0 ): true|\WP_Error {
-		$blog_id = $blog_id ?: get_current_blog_id();
+	public static function change_role( int $user_id, string $role, int $blog_id = 0, int $actor_id = 0 ): true|\WP_Error {
+		$blog_id  = $blog_id ?: get_current_blog_id();
+		$actor_id = $actor_id ?: get_current_user_id();
+
+		if ( ! self::can_manage_members( $actor_id, $blog_id ) ) {
+			return new \WP_Error(
+				'unauthorized',
+				__( 'You do not have permission to manage members in this group.', 'wordpress-groups' )
+			);
+		}
 
 		if ( ! array_key_exists( $role, self::ROLES ) ) {
 			return new \WP_Error(
@@ -203,6 +233,8 @@ class Membership {
 			);
 		}
 
+		$old_role = self::get_user_role( $user_id, $blog_id );
+
 		// Switch to the target blog to modify the user's role.
 		switch_to_blog( $blog_id );
 
@@ -211,6 +243,16 @@ class Membership {
 
 		restore_current_blog();
 
+		/**
+		 * Fires after a member's role is changed on a group site.
+		 *
+		 * @param int    $user_id  The user ID.
+		 * @param string $role     The new role.
+		 * @param string $old_role The previous role.
+		 * @param int    $blog_id  The blog ID.
+		 */
+		do_action( 'groups_member_role_changed', $user_id, $role, $old_role, $blog_id );
+
 		return true;
 	}
 
@@ -218,13 +260,23 @@ class Membership {
 	 * Ban a user from a group site.
 	 *
 	 * Removes the user from the site and sets a user meta flag to prevent rejoin.
+	 * Requires the caller to be an organizer or network admin.
 	 *
-	 * @param int $user_id The user ID to ban.
-	 * @param int $blog_id The blog ID. Defaults to current blog.
+	 * @param int $user_id  The user ID to ban.
+	 * @param int $blog_id  The blog ID. Defaults to current blog.
+	 * @param int $actor_id The user performing the action. Defaults to current user.
 	 * @return true|\WP_Error True on success, WP_Error on failure.
 	 */
-	public static function ban( int $user_id, int $blog_id = 0 ): true|\WP_Error {
-		$blog_id = $blog_id ?: get_current_blog_id();
+	public static function ban( int $user_id, int $blog_id = 0, int $actor_id = 0 ): true|\WP_Error {
+		$blog_id  = $blog_id ?: get_current_blog_id();
+		$actor_id = $actor_id ?: get_current_user_id();
+
+		if ( ! self::can_manage_members( $actor_id, $blog_id ) ) {
+			return new \WP_Error(
+				'unauthorized',
+				__( 'You do not have permission to manage members in this group.', 'wordpress-groups' )
+			);
+		}
 
 		// Remove user from the site if they're a member.
 		if ( is_user_member_of_blog( $user_id, $blog_id ) ) {
@@ -237,6 +289,49 @@ class Membership {
 
 		// Set the ban flag.
 		update_user_meta( $user_id, "_groups_banned_{$blog_id}", 1 );
+
+		/**
+		 * Fires after a user is banned from a group.
+		 *
+		 * @param int $user_id The user ID.
+		 * @param int $blog_id The blog ID.
+		 */
+		do_action( 'groups_member_banned', $user_id, $blog_id );
+
+		return true;
+	}
+
+	/**
+	 * Unban a user from a group site.
+	 *
+	 * Removes the ban meta flag, allowing the user to rejoin.
+	 * Requires the caller to be an organizer or network admin.
+	 *
+	 * @param int $user_id  The user ID to unban.
+	 * @param int $blog_id  The blog ID. Defaults to current blog.
+	 * @param int $actor_id The user performing the action. Defaults to current user.
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function unban( int $user_id, int $blog_id = 0, int $actor_id = 0 ): true|\WP_Error {
+		$blog_id  = $blog_id ?: get_current_blog_id();
+		$actor_id = $actor_id ?: get_current_user_id();
+
+		if ( ! self::can_manage_members( $actor_id, $blog_id ) ) {
+			return new \WP_Error(
+				'unauthorized',
+				__( 'You do not have permission to manage members in this group.', 'wordpress-groups' )
+			);
+		}
+
+		delete_user_meta( $user_id, "_groups_banned_{$blog_id}" );
+
+		/**
+		 * Fires after a user is unbanned from a group.
+		 *
+		 * @param int $user_id The user ID.
+		 * @param int $blog_id The blog ID.
+		 */
+		do_action( 'groups_member_unbanned', $user_id, $blog_id );
 
 		return true;
 	}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/models/test-membership.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/models/test-membership.php
@@ -24,6 +24,13 @@ class Test_Membership extends WP_UnitTestCase {
 	private int $blog_id;
 
 	/**
+	 * An organizer user ID for authorization in mutating methods.
+	 *
+	 * @var int
+	 */
+	private int $organizer_id;
+
+	/**
 	 * Set up a test site and register roles before each test.
 	 */
 	public function set_up(): void {
@@ -38,6 +45,16 @@ class Test_Membership extends WP_UnitTestCase {
 		// Register custom roles on the test site.
 		switch_to_blog( $this->blog_id );
 		Membership::register_roles();
+		restore_current_blog();
+
+		// Create an organizer to act as the authorized actor for mutating methods.
+		$this->organizer_id = self::factory()->user->create();
+		Membership::join( $this->organizer_id, $this->blog_id );
+
+		// Promote to organizer directly (bypassing change_role auth check for setup).
+		switch_to_blog( $this->blog_id );
+		$user = new \WP_User( $this->organizer_id );
+		$user->set_role( 'organizer' );
 		restore_current_blog();
 	}
 
@@ -159,7 +176,7 @@ class Test_Membership extends WP_UnitTestCase {
 		$user_id = self::factory()->user->create();
 
 		Membership::join( $user_id, $this->blog_id );
-		$result = Membership::change_role( $user_id, 'organizer', $this->blog_id );
+		$result = Membership::change_role( $user_id, 'organizer', $this->blog_id, $this->organizer_id );
 
 		$this->assertTrue( $result );
 		$this->assertSame( 'organizer', Membership::get_user_role( $user_id, $this->blog_id ) );
@@ -172,7 +189,7 @@ class Test_Membership extends WP_UnitTestCase {
 		$user_id = self::factory()->user->create();
 
 		Membership::join( $user_id, $this->blog_id );
-		Membership::change_role( $user_id, 'co_organizer', $this->blog_id );
+		Membership::change_role( $user_id, 'co_organizer', $this->blog_id, $this->organizer_id );
 
 		$this->assertSame( 'co_organizer', Membership::get_user_role( $user_id, $this->blog_id ) );
 	}
@@ -184,7 +201,7 @@ class Test_Membership extends WP_UnitTestCase {
 		$user_id = self::factory()->user->create();
 
 		Membership::join( $user_id, $this->blog_id );
-		$result = Membership::change_role( $user_id, 'superadmin', $this->blog_id );
+		$result = Membership::change_role( $user_id, 'superadmin', $this->blog_id, $this->organizer_id );
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'invalid_role', $result->get_error_code() );
@@ -196,10 +213,54 @@ class Test_Membership extends WP_UnitTestCase {
 	public function test_change_role_non_member_returns_error(): void {
 		$user_id = self::factory()->user->create();
 
-		$result = Membership::change_role( $user_id, 'organizer', $this->blog_id );
+		$result = Membership::change_role( $user_id, 'organizer', $this->blog_id, $this->organizer_id );
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'not_a_member', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::change_role
+	 */
+	public function test_change_role_fires_action_hook(): void {
+		$user_id = self::factory()->user->create();
+		$fired   = false;
+
+		Membership::join( $user_id, $this->blog_id );
+
+		add_action(
+			'groups_member_role_changed',
+			function ( $uid, $new_role, $old_role, $bid ) use ( $user_id, &$fired ) {
+				$fired = true;
+				$this->assertSame( $user_id, $uid );
+				$this->assertSame( 'organizer', $new_role );
+				$this->assertSame( 'member', $old_role );
+				$this->assertSame( $this->blog_id, $bid );
+			},
+			10,
+			4
+		);
+
+		Membership::change_role( $user_id, 'organizer', $this->blog_id, $this->organizer_id );
+
+		$this->assertTrue( $fired, 'The groups_member_role_changed action should have fired.' );
+	}
+
+	/**
+	 * @covers ::change_role
+	 */
+	public function test_unauthorized_role_change_returns_wp_error(): void {
+		$user_id    = self::factory()->user->create();
+		$non_org_id = self::factory()->user->create();
+
+		Membership::join( $user_id, $this->blog_id );
+		Membership::join( $non_org_id, $this->blog_id );
+
+		// non_org_id is a regular member, not an organizer.
+		$result = Membership::change_role( $user_id, 'organizer', $this->blog_id, $non_org_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'unauthorized', $result->get_error_code() );
 	}
 
 	/**
@@ -210,7 +271,7 @@ class Test_Membership extends WP_UnitTestCase {
 		$user_id = self::factory()->user->create();
 
 		Membership::join( $user_id, $this->blog_id );
-		$result = Membership::ban( $user_id, $this->blog_id );
+		$result = Membership::ban( $user_id, $this->blog_id, $this->organizer_id );
 
 		$this->assertTrue( $result );
 		$this->assertFalse( is_user_member_of_blog( $user_id, $this->blog_id ) );
@@ -234,13 +295,85 @@ class Test_Membership extends WP_UnitTestCase {
 		$user_id = self::factory()->user->create();
 
 		Membership::join( $user_id, $this->blog_id );
-		Membership::ban( $user_id, $this->blog_id );
+		Membership::ban( $user_id, $this->blog_id, $this->organizer_id );
 
 		$result = Membership::join( $user_id, $this->blog_id );
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'user_banned', $result->get_error_code() );
 		$this->assertFalse( is_user_member_of_blog( $user_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::ban
+	 */
+	public function test_ban_fires_action_hook(): void {
+		$user_id = self::factory()->user->create();
+		$fired   = false;
+
+		Membership::join( $user_id, $this->blog_id );
+
+		add_action(
+			'groups_member_banned',
+			function ( $uid, $bid ) use ( $user_id, &$fired ) {
+				$fired = true;
+				$this->assertSame( $user_id, $uid );
+				$this->assertSame( $this->blog_id, $bid );
+			},
+			10,
+			2
+		);
+
+		Membership::ban( $user_id, $this->blog_id, $this->organizer_id );
+
+		$this->assertTrue( $fired, 'The groups_member_banned action should have fired.' );
+	}
+
+	/**
+	 * @covers ::unban
+	 */
+	public function test_unban_allows_rejoin(): void {
+		$user_id = self::factory()->user->create();
+
+		Membership::join( $user_id, $this->blog_id );
+		Membership::ban( $user_id, $this->blog_id, $this->organizer_id );
+
+		$this->assertTrue( Membership::is_banned( $user_id, $this->blog_id ) );
+
+		$result = Membership::unban( $user_id, $this->blog_id, $this->organizer_id );
+		$this->assertTrue( $result );
+		$this->assertFalse( Membership::is_banned( $user_id, $this->blog_id ) );
+
+		// User can now rejoin.
+		$join_result = Membership::join( $user_id, $this->blog_id );
+		$this->assertTrue( $join_result );
+		$this->assertTrue( is_user_member_of_blog( $user_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::unban
+	 */
+	public function test_unban_fires_action_hook(): void {
+		$user_id = self::factory()->user->create();
+		$fired   = false;
+
+		Membership::join( $user_id, $this->blog_id );
+		Membership::ban( $user_id, $this->blog_id, $this->organizer_id );
+
+		add_action(
+			'groups_member_unbanned',
+			function ( $uid, $bid ) use ( $user_id, &$fired ) {
+				$fired = true;
+				$this->assertSame( $user_id, $uid );
+				$this->assertSame( $this->blog_id, $bid );
+			},
+			10,
+			2
+		);
+
+		Membership::unban( $user_id, $this->blog_id, $this->organizer_id );
+
+		$this->assertTrue( $fired, 'The groups_member_unbanned action should have fired.' );
 	}
 
 	/**
@@ -271,7 +404,7 @@ class Test_Membership extends WP_UnitTestCase {
 
 		Membership::join( $user1, $this->blog_id );
 		Membership::join( $user2, $this->blog_id );
-		Membership::change_role( $user1, 'organizer', $this->blog_id );
+		Membership::change_role( $user1, 'organizer', $this->blog_id, $this->organizer_id );
 
 		$organizers    = Membership::get_members( $this->blog_id, 'organizer' );
 		$organizer_ids = wp_list_pluck( $organizers, 'ID' );
@@ -320,5 +453,22 @@ class Test_Membership extends WP_UnitTestCase {
 		$user_id = self::factory()->user->create();
 
 		$this->assertFalse( Membership::get_user_role( $user_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::can_manage_members
+	 */
+	public function test_can_manage_members_for_organizer(): void {
+		$this->assertTrue( Membership::can_manage_members( $this->organizer_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::can_manage_members
+	 */
+	public function test_can_manage_members_false_for_regular_member(): void {
+		$user_id = self::factory()->user->create();
+		Membership::join( $user_id, $this->blog_id );
+
+		$this->assertFalse( Membership::can_manage_members( $user_id, $this->blog_id ) );
 	}
 }

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/models/test-membership.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/models/test-membership.php
@@ -1,0 +1,324 @@
+<?php
+/**
+ * Tests for the Membership model.
+ *
+ * @package Groups\Tests
+ */
+
+namespace Groups\Tests\Models;
+
+use Groups\Models\Membership;
+use WP_UnitTestCase;
+
+/**
+ * @coversDefaultClass \Groups\Models\Membership
+ * @group multisite
+ */
+class Test_Membership extends WP_UnitTestCase {
+
+	/**
+	 * Test blog ID (a secondary site in the multisite network).
+	 *
+	 * @var int
+	 */
+	private int $blog_id;
+
+	/**
+	 * Set up a test site and register roles before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests require a multisite installation.' );
+		}
+
+		$this->blog_id = self::factory()->blog->create();
+
+		// Register custom roles on the test site.
+		switch_to_blog( $this->blog_id );
+		Membership::register_roles();
+		restore_current_blog();
+	}
+
+	/**
+	 * @covers ::register_roles
+	 */
+	public function test_register_roles_creates_custom_roles(): void {
+		switch_to_blog( $this->blog_id );
+
+		$organizer    = get_role( 'organizer' );
+		$co_organizer = get_role( 'co_organizer' );
+		$member       = get_role( 'member' );
+
+		restore_current_blog();
+
+		$this->assertNotNull( $organizer );
+		$this->assertNotNull( $co_organizer );
+		$this->assertNotNull( $member );
+
+		$this->assertTrue( $organizer->has_cap( 'manage_options' ) );
+		$this->assertTrue( $organizer->has_cap( 'edit_others_posts' ) );
+
+		$this->assertTrue( $co_organizer->has_cap( 'edit_others_posts' ) );
+		$this->assertFalse( $co_organizer->has_cap( 'manage_options' ) );
+
+		$this->assertTrue( $member->has_cap( 'read' ) );
+		$this->assertFalse( $member->has_cap( 'edit_posts' ) );
+	}
+
+	/**
+	 * @covers ::join
+	 */
+	public function test_join_adds_user_to_site(): void {
+		$user_id = self::factory()->user->create();
+
+		$result = Membership::join( $user_id, $this->blog_id );
+
+		$this->assertTrue( $result );
+		$this->assertTrue( is_user_member_of_blog( $user_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::join
+	 */
+	public function test_join_assigns_member_role(): void {
+		$user_id = self::factory()->user->create();
+
+		Membership::join( $user_id, $this->blog_id );
+
+		$role = Membership::get_user_role( $user_id, $this->blog_id );
+		$this->assertSame( 'member', $role );
+	}
+
+	/**
+	 * @covers ::join
+	 */
+	public function test_join_fires_action_hook(): void {
+		$user_id = self::factory()->user->create();
+		$fired   = false;
+
+		add_action(
+			'groups_member_joined',
+			function ( $uid, $bid ) use ( $user_id, &$fired ) {
+				$fired = true;
+				$this->assertSame( $user_id, $uid );
+				$this->assertSame( $this->blog_id, $bid );
+			},
+			10,
+			2
+		);
+
+		Membership::join( $user_id, $this->blog_id );
+
+		$this->assertTrue( $fired, 'The groups_member_joined action should have fired.' );
+	}
+
+	/**
+	 * @covers ::leave
+	 */
+	public function test_leave_removes_user_from_site(): void {
+		$user_id = self::factory()->user->create();
+
+		Membership::join( $user_id, $this->blog_id );
+		$result = Membership::leave( $user_id, $this->blog_id );
+
+		$this->assertTrue( $result );
+		$this->assertFalse( is_user_member_of_blog( $user_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::leave
+	 */
+	public function test_leave_fires_action_hook(): void {
+		$user_id = self::factory()->user->create();
+		$fired   = false;
+
+		Membership::join( $user_id, $this->blog_id );
+
+		add_action(
+			'groups_member_left',
+			function ( $uid, $bid ) use ( $user_id, &$fired ) {
+				$fired = true;
+				$this->assertSame( $user_id, $uid );
+				$this->assertSame( $this->blog_id, $bid );
+			},
+			10,
+			2
+		);
+
+		Membership::leave( $user_id, $this->blog_id );
+
+		$this->assertTrue( $fired, 'The groups_member_left action should have fired.' );
+	}
+
+	/**
+	 * @covers ::change_role
+	 */
+	public function test_change_role_works(): void {
+		$user_id = self::factory()->user->create();
+
+		Membership::join( $user_id, $this->blog_id );
+		$result = Membership::change_role( $user_id, 'organizer', $this->blog_id );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'organizer', Membership::get_user_role( $user_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::change_role
+	 */
+	public function test_change_role_to_co_organizer(): void {
+		$user_id = self::factory()->user->create();
+
+		Membership::join( $user_id, $this->blog_id );
+		Membership::change_role( $user_id, 'co_organizer', $this->blog_id );
+
+		$this->assertSame( 'co_organizer', Membership::get_user_role( $user_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::change_role
+	 */
+	public function test_change_role_invalid_role_returns_error(): void {
+		$user_id = self::factory()->user->create();
+
+		Membership::join( $user_id, $this->blog_id );
+		$result = Membership::change_role( $user_id, 'superadmin', $this->blog_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_role', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::change_role
+	 */
+	public function test_change_role_non_member_returns_error(): void {
+		$user_id = self::factory()->user->create();
+
+		$result = Membership::change_role( $user_id, 'organizer', $this->blog_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'not_a_member', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::ban
+	 * @covers ::is_banned
+	 */
+	public function test_ban_removes_user_and_sets_flag(): void {
+		$user_id = self::factory()->user->create();
+
+		Membership::join( $user_id, $this->blog_id );
+		$result = Membership::ban( $user_id, $this->blog_id );
+
+		$this->assertTrue( $result );
+		$this->assertFalse( is_user_member_of_blog( $user_id, $this->blog_id ) );
+		$this->assertTrue( Membership::is_banned( $user_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::is_banned
+	 */
+	public function test_is_banned_returns_false_for_non_banned_user(): void {
+		$user_id = self::factory()->user->create();
+
+		$this->assertFalse( Membership::is_banned( $user_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::join
+	 * @covers ::is_banned
+	 */
+	public function test_banned_user_cannot_rejoin(): void {
+		$user_id = self::factory()->user->create();
+
+		Membership::join( $user_id, $this->blog_id );
+		Membership::ban( $user_id, $this->blog_id );
+
+		$result = Membership::join( $user_id, $this->blog_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'user_banned', $result->get_error_code() );
+		$this->assertFalse( is_user_member_of_blog( $user_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::get_members
+	 */
+	public function test_get_members_returns_correct_users(): void {
+		$user1 = self::factory()->user->create();
+		$user2 = self::factory()->user->create();
+		$user3 = self::factory()->user->create();
+
+		Membership::join( $user1, $this->blog_id );
+		Membership::join( $user2, $this->blog_id );
+
+		$members    = Membership::get_members( $this->blog_id );
+		$member_ids = wp_list_pluck( $members, 'ID' );
+
+		$this->assertContains( $user1, $member_ids );
+		$this->assertContains( $user2, $member_ids );
+		$this->assertNotContains( $user3, $member_ids );
+	}
+
+	/**
+	 * @covers ::get_members
+	 */
+	public function test_get_members_filtered_by_role(): void {
+		$user1 = self::factory()->user->create();
+		$user2 = self::factory()->user->create();
+
+		Membership::join( $user1, $this->blog_id );
+		Membership::join( $user2, $this->blog_id );
+		Membership::change_role( $user1, 'organizer', $this->blog_id );
+
+		$organizers    = Membership::get_members( $this->blog_id, 'organizer' );
+		$organizer_ids = wp_list_pluck( $organizers, 'ID' );
+
+		$this->assertContains( $user1, $organizer_ids );
+		$this->assertNotContains( $user2, $organizer_ids );
+
+		$members    = Membership::get_members( $this->blog_id, 'member' );
+		$member_ids = wp_list_pluck( $members, 'ID' );
+
+		$this->assertContains( $user2, $member_ids );
+		$this->assertNotContains( $user1, $member_ids );
+	}
+
+	/**
+	 * @covers ::get_member_count
+	 */
+	public function test_get_member_count(): void {
+		$user1 = self::factory()->user->create();
+		$user2 = self::factory()->user->create();
+
+		// Count before adding members (site may have default admin).
+		$initial_count = Membership::get_member_count( $this->blog_id );
+
+		Membership::join( $user1, $this->blog_id );
+		Membership::join( $user2, $this->blog_id );
+
+		$this->assertSame( $initial_count + 2, Membership::get_member_count( $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::get_user_role
+	 */
+	public function test_get_user_role_returns_role(): void {
+		$user_id = self::factory()->user->create();
+
+		Membership::join( $user_id, $this->blog_id );
+
+		$this->assertSame( 'member', Membership::get_user_role( $user_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::get_user_role
+	 */
+	public function test_get_user_role_returns_false_for_non_member(): void {
+		$user_id = self::factory()->user->create();
+
+		$this->assertFalse( Membership::get_user_role( $user_id, $this->blog_id ) );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Groups\Models\Membership` class that manages group membership via native WordPress multisite site roles
- Registers three custom roles on `init`: `organizer` (editor caps + manage_options), `co_organizer` (editor caps), `member` (subscriber caps)
- Provides methods: `join()`, `leave()`, `change_role()`, `ban()`, `is_banned()`, `get_members()`, `get_member_count()`, `get_user_role()`
- Ban system uses user meta (`_groups_banned_{blog_id}`) to prevent rejoining
- Fires `groups_member_joined` and `groups_member_left` action hooks
- Wires up role registration in `Plugin::init_components()` via `init` hook

## Test plan
- [ ] `test_register_roles_creates_custom_roles` — verifies all 3 roles exist with correct caps
- [ ] `test_join_adds_user_to_site` — user becomes member of blog
- [ ] `test_join_assigns_member_role` — joined user gets `member` role
- [ ] `test_join_fires_action_hook` — `groups_member_joined` fires with correct args
- [ ] `test_leave_removes_user_from_site` — user removed from blog
- [ ] `test_leave_fires_action_hook` — `groups_member_left` fires
- [ ] `test_change_role_works` — role changes to organizer
- [ ] `test_change_role_invalid_role_returns_error` — rejects unknown roles
- [ ] `test_ban_removes_user_and_sets_flag` — user removed + banned meta set
- [ ] `test_is_banned_returns_false_for_non_banned_user` — default is not banned
- [ ] `test_banned_user_cannot_rejoin` — `join()` returns WP_Error for banned users
- [ ] `test_get_members_returns_correct_users` — only site members returned
- [ ] `test_get_members_filtered_by_role` — role filter works correctly
- [ ] `test_get_member_count` — accurate count after joins
- [ ] `test_get_user_role` — returns correct role or false

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)