### PR TITLE
Add RSVP model with waitlist promotion

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/models/class-rsvp.php
+++ b/wp-content/plugins/wordpress-groups/includes/models/class-rsvp.php
@@ -1,0 +1,345 @@
+<?php
+/**
+ * RSVP model — comment-based RSVPs with waitlist promotion.
+ *
+ * @package Groups\Models
+ */
+
+namespace Groups\Models;
+
+use Groups\Post_Types\Event as Event_Post_Type;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles RSVP creation, updates, cancellation, waitlist promotion,
+ * and attendance tracking using WordPress comments on event posts.
+ */
+class Rsvp {
+
+	/**
+	 * Comment type used for RSVPs.
+	 *
+	 * @var string
+	 */
+	const COMMENT_TYPE = 'rsvp';
+
+	/**
+	 * Valid RSVP statuses.
+	 *
+	 * @var string[]
+	 */
+	const STATUSES = [ 'attending', 'waitlisted', 'not_attending', 'no_show' ];
+
+	/**
+	 * Comment meta keys for RSVP data.
+	 *
+	 * @var string[]
+	 */
+	const META_KEYS = [
+		'status'                => '_rsvp_status',
+		'guest_count'           => '_rsvp_guest_count',
+		'answers'               => '_rsvp_answers',
+		'attendance_confirmed'  => '_rsvp_attendance_confirmed',
+		'is_first_event'        => '_rsvp_is_first_event',
+	];
+
+	/**
+	 * Create an RSVP for an event.
+	 *
+	 * Inserts a comment of type 'rsvp' on the event post. If the event
+	 * has an attendee limit and is full, the status is set to 'waitlisted'.
+	 *
+	 * @param int   $event_id The event post ID.
+	 * @param int   $user_id  The user ID.
+	 * @param array $args {
+	 *     Optional RSVP arguments.
+	 *
+	 *     @type string $status      RSVP status. Default 'attending'.
+	 *     @type int    $guest_count Number of additional guests. Default 0.
+	 *     @type array  $answers     Custom question answers. Default empty.
+	 *     @type string $message     Optional comment content/message.
+	 * }
+	 * @return int|\WP_Error Comment ID on success, WP_Error on failure.
+	 */
+	public static function create( int $event_id, int $user_id, array $args = [] ): int|\WP_Error {
+		$post = get_post( $event_id );
+
+		if ( ! $post || Event_Post_Type::POST_TYPE !== $post->post_type ) {
+			return new \WP_Error( 'invalid_event', __( 'Invalid event post ID.', 'wordpress-groups' ) );
+		}
+
+		// Check for duplicate RSVP.
+		$existing = self::get_user_rsvp( $event_id, $user_id );
+
+		if ( $existing ) {
+			return new \WP_Error( 'duplicate_rsvp', __( 'User has already RSVPed to this event.', 'wordpress-groups' ) );
+		}
+
+		$user = get_userdata( $user_id );
+
+		if ( ! $user ) {
+			return new \WP_Error( 'invalid_user', __( 'Invalid user ID.', 'wordpress-groups' ) );
+		}
+
+		$status      = $args['status'] ?? 'attending';
+		$guest_count = absint( $args['guest_count'] ?? 0 );
+
+		// Auto-waitlist if event is full.
+		if ( 'attending' === $status && self::is_event_full( $event_id, 1 + $guest_count ) ) {
+			$status = 'waitlisted';
+		}
+
+		$comment_data = [
+			'comment_post_ID'  => $event_id,
+			'user_id'          => $user_id,
+			'comment_author'   => $user->display_name,
+			'comment_author_email' => $user->user_email,
+			'comment_content'  => sanitize_textarea_field( $args['message'] ?? '' ),
+			'comment_type'     => self::COMMENT_TYPE,
+			'comment_approved' => 1,
+		];
+
+		$comment_id = wp_insert_comment( $comment_data );
+
+		if ( ! $comment_id ) {
+			return new \WP_Error( 'rsvp_insert_failed', __( 'Failed to create RSVP.', 'wordpress-groups' ) );
+		}
+
+		// Store meta.
+		update_comment_meta( $comment_id, self::META_KEYS['status'], $status );
+		update_comment_meta( $comment_id, self::META_KEYS['guest_count'], $guest_count );
+
+		if ( ! empty( $args['answers'] ) ) {
+			update_comment_meta( $comment_id, self::META_KEYS['answers'], wp_json_encode( $args['answers'] ) );
+		}
+
+		/**
+		 * Fires after an RSVP is created.
+		 *
+		 * @param int    $comment_id The RSVP comment ID.
+		 * @param int    $event_id   The event post ID.
+		 * @param int    $user_id    The user ID.
+		 * @param string $status     The RSVP status.
+		 */
+		do_action( 'groups_rsvp_created', $comment_id, $event_id, $user_id, $status );
+
+		return $comment_id;
+	}
+
+	/**
+	 * Update an existing RSVP.
+	 *
+	 * @param int   $comment_id The RSVP comment ID.
+	 * @param array $args {
+	 *     RSVP fields to update.
+	 *
+	 *     @type string $status      RSVP status.
+	 *     @type int    $guest_count Number of additional guests.
+	 *     @type array  $answers     Custom question answers.
+	 * }
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function update( int $comment_id, array $args ): true|\WP_Error {
+		$comment = get_comment( $comment_id );
+
+		if ( ! $comment || self::COMMENT_TYPE !== $comment->comment_type ) {
+			return new \WP_Error( 'invalid_rsvp', __( 'Invalid RSVP comment ID.', 'wordpress-groups' ) );
+		}
+
+		if ( isset( $args['status'] ) ) {
+			if ( ! in_array( $args['status'], self::STATUSES, true ) ) {
+				return new \WP_Error( 'invalid_status', __( 'Invalid RSVP status.', 'wordpress-groups' ) );
+			}
+			update_comment_meta( $comment_id, self::META_KEYS['status'], $args['status'] );
+		}
+
+		if ( isset( $args['guest_count'] ) ) {
+			update_comment_meta( $comment_id, self::META_KEYS['guest_count'], absint( $args['guest_count'] ) );
+		}
+
+		if ( isset( $args['answers'] ) ) {
+			update_comment_meta( $comment_id, self::META_KEYS['answers'], wp_json_encode( $args['answers'] ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Cancel an RSVP and promote the next waitlisted person.
+	 *
+	 * @param int $comment_id The RSVP comment ID.
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function cancel( int $comment_id ): true|\WP_Error {
+		$comment = get_comment( $comment_id );
+
+		if ( ! $comment || self::COMMENT_TYPE !== $comment->comment_type ) {
+			return new \WP_Error( 'invalid_rsvp', __( 'Invalid RSVP comment ID.', 'wordpress-groups' ) );
+		}
+
+		$previous_status = get_comment_meta( $comment_id, self::META_KEYS['status'], true );
+
+		update_comment_meta( $comment_id, self::META_KEYS['status'], 'not_attending' );
+
+		// Promote next waitlisted person if the cancelled RSVP was attending.
+		if ( 'attending' === $previous_status ) {
+			self::promote_next( (int) $comment->comment_post_ID );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Promote the next waitlisted RSVP to attending.
+	 *
+	 * Finds the oldest waitlisted RSVP for the event and sets its
+	 * status to 'attending'.
+	 *
+	 * @param int $event_id The event post ID.
+	 * @return int|false The promoted comment ID, or false if none to promote.
+	 */
+	public static function promote_next( int $event_id ): int|false {
+		$waitlisted = get_comments( [
+			'post_id' => $event_id,
+			'type'    => self::COMMENT_TYPE,
+			'status'  => 'approve',
+			'orderby' => 'comment_date',
+			'order'   => 'ASC',
+			'number'  => 1,
+			'meta_query' => [
+				[
+					'key'   => self::META_KEYS['status'],
+					'value' => 'waitlisted',
+				],
+			],
+		] );
+
+		if ( empty( $waitlisted ) ) {
+			return false;
+		}
+
+		$comment = $waitlisted[0];
+		$comment_id = (int) $comment->comment_ID;
+
+		update_comment_meta( $comment_id, self::META_KEYS['status'], 'attending' );
+
+		/**
+		 * Fires after a waitlisted RSVP is promoted to attending.
+		 *
+		 * @param int $comment_id The RSVP comment ID.
+		 * @param int $event_id   The event post ID.
+		 * @param int $user_id    The user ID.
+		 */
+		do_action( 'groups_rsvp_promoted', $comment_id, $event_id, (int) $comment->user_id );
+
+		return $comment_id;
+	}
+
+	/**
+	 * Mark attendance for an RSVP (organizer action).
+	 *
+	 * @param int  $comment_id The RSVP comment ID.
+	 * @param bool $attended   Whether the person attended.
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function mark_attendance( int $comment_id, bool $attended ): true|\WP_Error {
+		$comment = get_comment( $comment_id );
+
+		if ( ! $comment || self::COMMENT_TYPE !== $comment->comment_type ) {
+			return new \WP_Error( 'invalid_rsvp', __( 'Invalid RSVP comment ID.', 'wordpress-groups' ) );
+		}
+
+		$status = $attended ? 'attending' : 'no_show';
+
+		update_comment_meta( $comment_id, self::META_KEYS['status'], $status );
+		update_comment_meta( $comment_id, self::META_KEYS['attendance_confirmed'], true );
+
+		return true;
+	}
+
+	/**
+	 * Get all RSVPs for an event, optionally filtered by status.
+	 *
+	 * @param int    $event_id The event post ID.
+	 * @param string $status   Optional. Filter by RSVP status.
+	 * @return \WP_Comment[] Array of RSVP comments.
+	 */
+	public static function get_for_event( int $event_id, string $status = '' ): array {
+		$query_args = [
+			'post_id' => $event_id,
+			'type'    => self::COMMENT_TYPE,
+			'status'  => 'approve',
+			'orderby' => 'comment_date',
+			'order'   => 'ASC',
+		];
+
+		if ( '' !== $status ) {
+			$query_args['meta_query'] = [
+				[
+					'key'   => self::META_KEYS['status'],
+					'value' => $status,
+				],
+			];
+		}
+
+		return get_comments( $query_args );
+	}
+
+	/**
+	 * Count RSVPs by status, including guest counts in the total.
+	 *
+	 * @param int    $event_id The event post ID.
+	 * @param string $status   RSVP status to count. Default 'attending'.
+	 * @return int Total count of attendees (RSVPs + their guests).
+	 */
+	public static function get_count( int $event_id, string $status = 'attending' ): int {
+		$rsvps = self::get_for_event( $event_id, $status );
+		$count = 0;
+
+		foreach ( $rsvps as $rsvp ) {
+			$guest_count = (int) get_comment_meta( $rsvp->comment_ID, self::META_KEYS['guest_count'], true );
+			$count += 1 + $guest_count; // The person + their guests.
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Get a specific user's RSVP for an event.
+	 *
+	 * @param int $event_id The event post ID.
+	 * @param int $user_id  The user ID.
+	 * @return \WP_Comment|null The RSVP comment, or null if not found.
+	 */
+	public static function get_user_rsvp( int $event_id, int $user_id ): ?\WP_Comment {
+		$comments = get_comments( [
+			'post_id' => $event_id,
+			'user_id' => $user_id,
+			'type'    => self::COMMENT_TYPE,
+			'status'  => 'approve',
+			'number'  => 1,
+		] );
+
+		return $comments[0] ?? null;
+	}
+
+	/**
+	 * Check whether the event is at capacity for attending RSVPs.
+	 *
+	 * @param int $event_id        The event post ID.
+	 * @param int $additional_spots Number of additional spots needed. Default 1.
+	 * @return bool True if the event is full (no room for additional_spots).
+	 */
+	private static function is_event_full( int $event_id, int $additional_spots = 1 ): bool {
+		$limit = (int) get_post_meta( $event_id, '_event_attendee_limit', true );
+
+		if ( $limit <= 0 ) {
+			return false;
+		}
+
+		$current_count = self::get_count( $event_id, 'attending' );
+
+		return ( $current_count + $additional_spots ) > $limit;
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/models/test-rsvp.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/models/test-rsvp.php
@@ -1,0 +1,463 @@
+<?php
+/**
+ * Tests for the RSVP model.
+ *
+ * @package Groups\Tests
+ */
+
+namespace Groups\Tests\Models;
+
+use Groups\Models\Event;
+use Groups\Models\Rsvp;
+use Groups\Post_Types\Event as Event_Post_Type;
+use WP_UnitTestCase;
+
+/**
+ * @coversDefaultClass \Groups\Models\Rsvp
+ */
+class Test_Rsvp extends WP_UnitTestCase {
+
+	/**
+	 * Ensure the event CPT and statuses are registered before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$event_cpt = new Event_Post_Type();
+		$event_cpt->register_post_type();
+		$event_cpt->register_post_statuses();
+	}
+
+	/**
+	 * Helper to create an event and return its post ID.
+	 *
+	 * @param array $overrides Optional event arg overrides.
+	 * @return int Event post ID.
+	 */
+	private function create_event( array $overrides = [] ): int {
+		$args = array_merge(
+			[
+				'title'     => 'Test Event',
+				'content'   => 'A test event.',
+				'start_utc' => '2026-04-15 18:00:00',
+				'end_utc'   => '2026-04-15 20:00:00',
+				'timezone'  => 'America/New_York',
+			],
+			$overrides
+		);
+
+		return Event::create( $args );
+	}
+
+	/**
+	 * Helper to create a test user and return their ID.
+	 *
+	 * @param string $login Optional username.
+	 * @return int User ID.
+	 */
+	private function create_user( string $login = '' ): int {
+		if ( '' === $login ) {
+			$login = 'testuser_' . wp_generate_password( 6, false );
+		}
+
+		return self::factory()->user->create( [
+			'user_login' => $login,
+			'user_email' => $login . '@example.com',
+			'role'       => 'subscriber',
+		] );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_rsvp_returns_comment_id(): void {
+		$event_id = $this->create_event();
+		$user_id  = $this->create_user();
+
+		$comment_id = Rsvp::create( $event_id, $user_id );
+
+		$this->assertIsInt( $comment_id );
+		$this->assertGreaterThan( 0, $comment_id );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_rsvp_sets_attending_status_when_under_limit(): void {
+		$event_id = $this->create_event( [ 'attendee_limit' => 10 ] );
+		$user_id  = $this->create_user();
+
+		$comment_id = Rsvp::create( $event_id, $user_id );
+
+		$this->assertSame( 'attending', get_comment_meta( $comment_id, '_rsvp_status', true ) );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_rsvp_auto_waitlists_when_event_full(): void {
+		$event_id = $this->create_event( [ 'attendee_limit' => 2 ] );
+
+		// Fill the event with 2 attendees.
+		$user1 = $this->create_user( 'user_one' );
+		$user2 = $this->create_user( 'user_two' );
+		Rsvp::create( $event_id, $user1 );
+		Rsvp::create( $event_id, $user2 );
+
+		// Third person should be waitlisted.
+		$user3      = $this->create_user( 'user_three' );
+		$comment_id = Rsvp::create( $event_id, $user3 );
+
+		$this->assertSame( 'waitlisted', get_comment_meta( $comment_id, '_rsvp_status', true ) );
+	}
+
+	/**
+	 * @covers ::create
+	 * @covers ::cancel
+	 * @covers ::promote_next
+	 */
+	public function test_cancel_promotes_waitlisted_person(): void {
+		$event_id = $this->create_event( [ 'attendee_limit' => 1 ] );
+
+		$user1 = $this->create_user( 'user_one' );
+		$user2 = $this->create_user( 'user_two' );
+
+		$rsvp1 = Rsvp::create( $event_id, $user1 );
+		$rsvp2 = Rsvp::create( $event_id, $user2 );
+
+		// User 2 should be waitlisted.
+		$this->assertSame( 'waitlisted', get_comment_meta( $rsvp2, '_rsvp_status', true ) );
+
+		// Cancel user 1's RSVP.
+		Rsvp::cancel( $rsvp1 );
+
+		// User 2 should now be attending.
+		$this->assertSame( 'attending', get_comment_meta( $rsvp2, '_rsvp_status', true ) );
+	}
+
+	/**
+	 * @covers ::create
+	 * @covers ::get_count
+	 */
+	public function test_guest_count_affects_capacity(): void {
+		$event_id = $this->create_event( [ 'attendee_limit' => 3 ] );
+
+		// User with 1 guest takes 2 spots.
+		$user1 = $this->create_user( 'user_one' );
+		Rsvp::create( $event_id, $user1, [ 'guest_count' => 1 ] );
+
+		$this->assertSame( 2, Rsvp::get_count( $event_id, 'attending' ) );
+
+		// Next user with 0 guests takes 1 spot — fills the event to 3.
+		$user2 = $this->create_user( 'user_two' );
+		Rsvp::create( $event_id, $user2 );
+
+		$this->assertSame( 3, Rsvp::get_count( $event_id, 'attending' ) );
+
+		// Third user should be waitlisted.
+		$user3      = $this->create_user( 'user_three' );
+		$comment_id = Rsvp::create( $event_id, $user3 );
+
+		$this->assertSame( 'waitlisted', get_comment_meta( $comment_id, '_rsvp_status', true ) );
+	}
+
+	/**
+	 * @covers ::mark_attendance
+	 */
+	public function test_mark_attendance_attended(): void {
+		$event_id   = $this->create_event();
+		$user_id    = $this->create_user();
+		$comment_id = Rsvp::create( $event_id, $user_id );
+
+		$result = Rsvp::mark_attendance( $comment_id, true );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'attending', get_comment_meta( $comment_id, '_rsvp_status', true ) );
+		$this->assertEquals( true, get_comment_meta( $comment_id, '_rsvp_attendance_confirmed', true ) );
+	}
+
+	/**
+	 * @covers ::mark_attendance
+	 */
+	public function test_mark_attendance_no_show(): void {
+		$event_id   = $this->create_event();
+		$user_id    = $this->create_user();
+		$comment_id = Rsvp::create( $event_id, $user_id );
+
+		Rsvp::mark_attendance( $comment_id, false );
+
+		$this->assertSame( 'no_show', get_comment_meta( $comment_id, '_rsvp_status', true ) );
+		$this->assertEquals( true, get_comment_meta( $comment_id, '_rsvp_attendance_confirmed', true ) );
+	}
+
+	/**
+	 * @covers ::get_for_event
+	 */
+	public function test_get_for_event_returns_all_rsvps(): void {
+		$event_id = $this->create_event();
+
+		$user1 = $this->create_user( 'user_one' );
+		$user2 = $this->create_user( 'user_two' );
+		Rsvp::create( $event_id, $user1 );
+		Rsvp::create( $event_id, $user2 );
+
+		$rsvps = Rsvp::get_for_event( $event_id );
+
+		$this->assertCount( 2, $rsvps );
+	}
+
+	/**
+	 * @covers ::get_for_event
+	 */
+	public function test_get_for_event_filters_by_status(): void {
+		$event_id = $this->create_event( [ 'attendee_limit' => 1 ] );
+
+		$user1 = $this->create_user( 'user_one' );
+		$user2 = $this->create_user( 'user_two' );
+		Rsvp::create( $event_id, $user1 );
+		Rsvp::create( $event_id, $user2 );
+
+		$attending  = Rsvp::get_for_event( $event_id, 'attending' );
+		$waitlisted = Rsvp::get_for_event( $event_id, 'waitlisted' );
+
+		$this->assertCount( 1, $attending );
+		$this->assertCount( 1, $waitlisted );
+	}
+
+	/**
+	 * @covers ::get_user_rsvp
+	 */
+	public function test_get_user_rsvp_returns_comment(): void {
+		$event_id = $this->create_event();
+		$user_id  = $this->create_user();
+
+		$comment_id = Rsvp::create( $event_id, $user_id );
+
+		$rsvp = Rsvp::get_user_rsvp( $event_id, $user_id );
+
+		$this->assertInstanceOf( \WP_Comment::class, $rsvp );
+		$this->assertEquals( $comment_id, $rsvp->comment_ID );
+	}
+
+	/**
+	 * @covers ::get_user_rsvp
+	 */
+	public function test_get_user_rsvp_returns_null_when_not_found(): void {
+		$event_id = $this->create_event();
+
+		$rsvp = Rsvp::get_user_rsvp( $event_id, 999999 );
+
+		$this->assertNull( $rsvp );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_cannot_rsvp_twice_same_user_same_event(): void {
+		$event_id = $this->create_event();
+		$user_id  = $this->create_user();
+
+		Rsvp::create( $event_id, $user_id );
+		$result = Rsvp::create( $event_id, $user_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'duplicate_rsvp', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::promote_next
+	 */
+	public function test_promote_next_fires_action_hook(): void {
+		$event_id = $this->create_event( [ 'attendee_limit' => 1 ] );
+
+		$user1 = $this->create_user( 'user_one' );
+		$user2 = $this->create_user( 'user_two' );
+
+		$rsvp1 = Rsvp::create( $event_id, $user1 );
+		$rsvp2 = Rsvp::create( $event_id, $user2 );
+
+		$fired = false;
+
+		add_action(
+			'groups_rsvp_promoted',
+			function ( $comment_id, $fired_event_id, $fired_user_id ) use ( $rsvp2, $event_id, $user2, &$fired ) {
+				$fired = true;
+				$this->assertEquals( $rsvp2, $comment_id );
+				$this->assertSame( $event_id, $fired_event_id );
+				$this->assertSame( $user2, $fired_user_id );
+			},
+			10,
+			3
+		);
+
+		// Cancel user 1 to trigger promotion.
+		Rsvp::cancel( $rsvp1 );
+
+		$this->assertTrue( $fired, 'The groups_rsvp_promoted action should have fired.' );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_rsvp_fires_action_hook(): void {
+		$event_id = $this->create_event();
+		$user_id  = $this->create_user();
+
+		$fired = false;
+
+		add_action(
+			'groups_rsvp_created',
+			function ( $comment_id, $fired_event_id, $fired_user_id, $status ) use ( $event_id, $user_id, &$fired ) {
+				$fired = true;
+				$this->assertIsInt( $comment_id );
+				$this->assertSame( $event_id, $fired_event_id );
+				$this->assertSame( $user_id, $fired_user_id );
+				$this->assertSame( 'attending', $status );
+			},
+			10,
+			4
+		);
+
+		Rsvp::create( $event_id, $user_id );
+
+		$this->assertTrue( $fired, 'The groups_rsvp_created action should have fired.' );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_rsvp_with_invalid_event_returns_error(): void {
+		$user_id = $this->create_user();
+
+		$result = Rsvp::create( 999999, $user_id );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_event', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_rsvp_with_invalid_user_returns_error(): void {
+		$event_id = $this->create_event();
+
+		$result = Rsvp::create( $event_id, 999999 );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_user', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function test_update_rsvp_status(): void {
+		$event_id   = $this->create_event();
+		$user_id    = $this->create_user();
+		$comment_id = Rsvp::create( $event_id, $user_id );
+
+		$result = Rsvp::update( $comment_id, [ 'status' => 'not_attending' ] );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'not_attending', get_comment_meta( $comment_id, '_rsvp_status', true ) );
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function test_update_rsvp_guest_count(): void {
+		$event_id   = $this->create_event();
+		$user_id    = $this->create_user();
+		$comment_id = Rsvp::create( $event_id, $user_id );
+
+		Rsvp::update( $comment_id, [ 'guest_count' => 3 ] );
+
+		$this->assertEquals( 3, get_comment_meta( $comment_id, '_rsvp_guest_count', true ) );
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function test_update_invalid_rsvp_returns_error(): void {
+		$result = Rsvp::update( 999999, [ 'status' => 'attending' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_rsvp', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::update
+	 */
+	public function test_update_with_invalid_status_returns_error(): void {
+		$event_id   = $this->create_event();
+		$user_id    = $this->create_user();
+		$comment_id = Rsvp::create( $event_id, $user_id );
+
+		$result = Rsvp::update( $comment_id, [ 'status' => 'invalid_status' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_status', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::cancel
+	 */
+	public function test_cancel_sets_not_attending(): void {
+		$event_id   = $this->create_event();
+		$user_id    = $this->create_user();
+		$comment_id = Rsvp::create( $event_id, $user_id );
+
+		Rsvp::cancel( $comment_id );
+
+		$this->assertSame( 'not_attending', get_comment_meta( $comment_id, '_rsvp_status', true ) );
+	}
+
+	/**
+	 * @covers ::cancel
+	 */
+	public function test_cancel_invalid_rsvp_returns_error(): void {
+		$result = Rsvp::cancel( 999999 );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_rsvp', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_rsvp_uses_comment_type_rsvp(): void {
+		$event_id   = $this->create_event();
+		$user_id    = $this->create_user();
+		$comment_id = Rsvp::create( $event_id, $user_id );
+
+		$comment = get_comment( $comment_id );
+
+		$this->assertSame( 'rsvp', $comment->comment_type );
+		$this->assertEquals( 1, $comment->comment_approved );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_rsvp_with_no_limit_always_attends(): void {
+		$event_id = $this->create_event(); // No attendee_limit set.
+
+		// Create many RSVPs — all should be attending.
+		for ( $i = 0; $i < 5; $i++ ) {
+			$user_id    = $this->create_user();
+			$comment_id = Rsvp::create( $event_id, $user_id );
+
+			$this->assertSame( 'attending', get_comment_meta( $comment_id, '_rsvp_status', true ) );
+		}
+	}
+
+	/**
+	 * @covers ::promote_next
+	 */
+	public function test_promote_next_returns_false_when_no_waitlisted(): void {
+		$event_id = $this->create_event();
+
+		$result = Rsvp::promote_next( $event_id );
+
+		$this->assertFalse( $result );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Groups\Models\Rsvp` class that stores RSVPs as WordPress comments (type `rsvp`) on event posts
- Implements automatic waitlist promotion: when an attending RSVP is cancelled, the oldest waitlisted RSVP is promoted to attending
- Guest counts are included in capacity calculations against `_event_attendee_limit`
- Fires `groups_rsvp_created` and `groups_rsvp_promoted` action hooks for extensibility
- Prevents duplicate RSVPs (same user + same event)
- Adds comprehensive PHPUnit test suite with 25 tests covering all public methods

## Methods
| Method | Description |
|--------|-------------|
| `create()` | Create RSVP comment with auto-waitlist when full |
| `update()` | Update status/guest count/answers |
| `cancel()` | Set not_attending, promote next waitlisted |
| `promote_next()` | Promote oldest waitlisted RSVP |
| `mark_attendance()` | Organizer marks attended/no_show |
| `get_for_event()` | Get RSVPs optionally filtered by status |
| `get_count()` | Count RSVPs + guests by status |
| `get_user_rsvp()` | Get a user's RSVP for an event |

## Test plan
- [ ] All PHPUnit tests pass (`phpunit --filter Test_Rsvp`)
- [ ] RSVP under capacity gets `attending` status
- [ ] RSVP at capacity gets `waitlisted` status
- [ ] Cancelling an attending RSVP promotes the next waitlisted person
- [ ] Guest counts correctly affect capacity calculations
- [ ] Duplicate RSVPs are rejected with `duplicate_rsvp` error
- [ ] Action hooks fire with correct parameters

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)