### PR TITLE
REST API: Membership endpoints (list, join, leave)

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -58,5 +58,8 @@ class Plugin {
 	public function register_rest_routes(): void {
 		$event_controller = new REST\Event_Controller();
 		$event_controller->register_routes();
+
+		$membership_controller = new REST\Membership_Controller();
+		$membership_controller->register_routes();
 	}
 }

--- a/wp-content/plugins/wordpress-groups/includes/models/class-membership.php
+++ b/wp-content/plugins/wordpress-groups/includes/models/class-membership.php
@@ -154,6 +154,9 @@ class Membership {
 			return $result;
 		}
 
+		// Record when the user joined this group.
+		update_user_meta( $user_id, "_groups_joined_{$blog_id}", current_time( 'mysql', true ) );
+
 		/**
 		 * Fires after a user joins a group.
 		 *
@@ -180,6 +183,9 @@ class Membership {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
+
+		// Clean up the joined timestamp.
+		delete_user_meta( $user_id, "_groups_joined_{$blog_id}" );
 
 		/**
 		 * Fires after a user leaves a group.

--- a/wp-content/plugins/wordpress-groups/includes/rest/class-membership-controller.php
+++ b/wp-content/plugins/wordpress-groups/includes/rest/class-membership-controller.php
@@ -1,0 +1,358 @@
+<?php
+/**
+ * REST API controller for group membership.
+ *
+ * @package Groups\REST
+ */
+
+namespace Groups\REST;
+
+use Groups\Models\Membership;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles listing members and join/leave operations via the REST API.
+ */
+class Membership_Controller extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST routes.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'groups/v1';
+
+	/**
+	 * Base path for membership routes.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'members';
+
+	/**
+	 * Register REST routes.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_items' ],
+					'permission_callback' => [ $this, 'get_items_permissions_check' ],
+					'args'                => $this->get_collection_params(),
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/join',
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'join_item' ],
+					'permission_callback' => [ $this, 'join_item_permissions_check' ],
+				],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/leave',
+			[
+				[
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'leave_item' ],
+					'permission_callback' => [ $this, 'leave_item_permissions_check' ],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permission check for listing members.
+	 *
+	 * Member lists are public.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true
+	 */
+	public function get_items_permissions_check( $request ): true {
+		return true;
+	}
+
+	/**
+	 * Permission check for joining a group.
+	 *
+	 * The user must be logged in and must not be banned.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function join_item_permissions_check( $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to join a group.', 'wordpress-groups' ),
+				[ 'status' => 401 ]
+			);
+		}
+
+		$user_id = get_current_user_id();
+		$blog_id = get_current_blog_id();
+
+		if ( Membership::is_banned( $user_id, $blog_id ) ) {
+			return new WP_Error(
+				'rest_user_banned',
+				__( 'You are banned from this group.', 'wordpress-groups' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		if ( is_user_member_of_blog( $user_id, $blog_id ) ) {
+			return new WP_Error(
+				'rest_already_member',
+				__( 'You are already a member of this group.', 'wordpress-groups' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Permission check for leaving a group.
+	 *
+	 * The user must be logged in and must be a member.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function leave_item_permissions_check( $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to leave a group.', 'wordpress-groups' ),
+				[ 'status' => 401 ]
+			);
+		}
+
+		$user_id = get_current_user_id();
+		$blog_id = get_current_blog_id();
+
+		if ( ! is_user_member_of_blog( $user_id, $blog_id ) ) {
+			return new WP_Error(
+				'rest_not_a_member',
+				__( 'You are not a member of this group.', 'wordpress-groups' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieve a collection of group members.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ): WP_REST_Response {
+		$role    = sanitize_text_field( $request->get_param( 'role' ) ?? '' );
+		$blog_id = get_current_blog_id();
+		$members = Membership::get_members( $blog_id, $role );
+
+		$data = [];
+		foreach ( $members as $user ) {
+			$data[] = $this->prepare_item_for_response( $user, $request )->get_data();
+		}
+
+		$response = new WP_REST_Response( $data, 200 );
+		$response->header( 'X-WP-Total', count( $data ) );
+
+		return $response;
+	}
+
+	/**
+	 * Join the current user to the group.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function join_item( $request ) {
+		$user_id = get_current_user_id();
+		$blog_id = get_current_blog_id();
+
+		$result = Membership::join( $user_id, $blog_id );
+
+		if ( is_wp_error( $result ) ) {
+			$result->add_data( [ 'status' => 400 ] );
+			return $result;
+		}
+
+		$user     = get_userdata( $user_id );
+		$response = $this->prepare_item_for_response( $user, $request );
+		$response->set_status( 201 );
+
+		return $response;
+	}
+
+	/**
+	 * Remove the current user from the group.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function leave_item( $request ) {
+		$user_id = get_current_user_id();
+		$blog_id = get_current_blog_id();
+
+		// Capture user data before removing (role will be gone after leave).
+		$user = get_userdata( $user_id );
+		$role = Membership::get_user_role( $user_id, $blog_id );
+
+		$result = Membership::leave( $user_id, $blog_id );
+
+		if ( is_wp_error( $result ) ) {
+			$result->add_data( [ 'status' => 400 ] );
+			return $result;
+		}
+
+		$data = [
+			'user_id'      => (int) $user->ID,
+			'display_name' => esc_html( $user->display_name ),
+			'avatar_url'   => esc_url( get_avatar_url( $user->ID ) ),
+			'role'         => $role ?: 'member',
+			'joined_date'  => null,
+		];
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Prepare a single member for the response.
+	 *
+	 * @param \WP_User        $user    User object.
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $user, $request ): WP_REST_Response {
+		$blog_id     = get_current_blog_id();
+		$role        = Membership::get_user_role( (int) $user->ID, $blog_id );
+		$joined_date = $this->get_joined_date( (int) $user->ID, $blog_id );
+
+		$data = [
+			'user_id'      => (int) $user->ID,
+			'display_name' => esc_html( $user->display_name ),
+			'avatar_url'   => esc_url( get_avatar_url( $user->ID ) ),
+			'role'         => $role ?: 'member',
+			'joined_date'  => $joined_date,
+		];
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Get the date a user was added to a blog.
+	 *
+	 * Reads from the user's capabilities meta on the target blog to determine
+	 * when the user was added (not directly available, so we use user_registered
+	 * as a fallback and check if the blog-specific meta exists).
+	 *
+	 * @param int $user_id The user ID.
+	 * @param int $blog_id The blog ID.
+	 * @return string|null ISO 8601 date string, or null if unavailable.
+	 */
+	private function get_joined_date( int $user_id, int $blog_id ): ?string {
+		global $wpdb;
+
+		$prefix = $wpdb->get_blog_prefix( $blog_id );
+		$key    = $prefix . 'capabilities';
+
+		// WordPress does not store a "joined date" per blog. Fall back to user_registered.
+		$user = get_userdata( $user_id );
+
+		if ( ! $user || ! get_user_meta( $user_id, $key, true ) ) {
+			return null;
+		}
+
+		return mysql_to_rfc3339( $user->user_registered );
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_collection_params(): array {
+		return [
+			'role' => [
+				'description' => __( 'Limit results to members with a specific role.', 'wordpress-groups' ),
+				'type'        => 'string',
+				'enum'        => [ 'organizer', 'co_organizer', 'member' ],
+			],
+		];
+	}
+
+	/**
+	 * Get the member schema for responses.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_item_schema(): array {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$this->schema = [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'member',
+			'type'       => 'object',
+			'properties' => [
+				'user_id'      => [
+					'description' => __( 'Unique identifier for the user.', 'wordpress-groups' ),
+					'type'        => 'integer',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'display_name' => [
+					'description' => __( 'Display name of the user.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'avatar_url'   => [
+					'description' => __( 'URL to the user avatar.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'role'         => [
+					'description' => __( 'The user role on this group site.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'joined_date'  => [
+					'description' => __( 'The date the user joined this group, in RFC3339 format.', 'wordpress-groups' ),
+					'type'        => [ 'string', 'null' ],
+					'format'      => 'date-time',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+			],
+		];
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/rest/class-membership-controller.php
+++ b/wp-content/plugins/wordpress-groups/includes/rest/class-membership-controller.php
@@ -262,29 +262,30 @@ class Membership_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Get the date a user was added to a blog.
+	 * Get the date a user joined a group site.
 	 *
-	 * Reads from the user's capabilities meta on the target blog to determine
-	 * when the user was added (not directly available, so we use user_registered
-	 * as a fallback and check if the blog-specific meta exists).
+	 * Reads from the `_groups_joined_{blog_id}` user meta, which is set when a
+	 * user joins via the Membership model. Falls back to `user_registered` for
+	 * legacy members who joined before this meta was introduced.
 	 *
 	 * @param int $user_id The user ID.
 	 * @param int $blog_id The blog ID.
 	 * @return string|null ISO 8601 date string, or null if unavailable.
 	 */
 	private function get_joined_date( int $user_id, int $blog_id ): ?string {
-		global $wpdb;
-
-		$prefix = $wpdb->get_blog_prefix( $blog_id );
-		$key    = $prefix . 'capabilities';
-
-		// WordPress does not store a "joined date" per blog. Fall back to user_registered.
 		$user = get_userdata( $user_id );
 
-		if ( ! $user || ! get_user_meta( $user_id, $key, true ) ) {
+		if ( ! $user ) {
 			return null;
 		}
 
+		$joined = get_user_meta( $user_id, "_groups_joined_{$blog_id}", true );
+
+		if ( $joined ) {
+			return mysql_to_rfc3339( $joined );
+		}
+
+		// Legacy fallback: use account registration date.
 		return mysql_to_rfc3339( $user->user_registered );
 	}
 

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/models/test-membership.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/models/test-membership.php
@@ -436,6 +436,34 @@ class Test_Membership extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::join
+	 */
+	public function test_join_stores_joined_timestamp(): void {
+		$user_id = self::factory()->user->create();
+
+		Membership::join( $user_id, $this->blog_id );
+
+		$joined = get_user_meta( $user_id, "_groups_joined_{$this->blog_id}", true );
+		$this->assertNotEmpty( $joined, 'Join should store a _groups_joined_{blog_id} user meta.' );
+
+		// Verify it looks like a MySQL datetime.
+		$this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $joined );
+	}
+
+	/**
+	 * @covers ::leave
+	 */
+	public function test_leave_deletes_joined_timestamp(): void {
+		$user_id = self::factory()->user->create();
+
+		Membership::join( $user_id, $this->blog_id );
+		$this->assertNotEmpty( get_user_meta( $user_id, "_groups_joined_{$this->blog_id}", true ) );
+
+		Membership::leave( $user_id, $this->blog_id );
+		$this->assertEmpty( get_user_meta( $user_id, "_groups_joined_{$this->blog_id}", true ) );
+	}
+
+	/**
 	 * @covers ::get_user_role
 	 */
 	public function test_get_user_role_returns_role(): void {

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/rest/test-membership-controller.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/rest/test-membership-controller.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * Tests for the Membership REST API controller.
+ *
+ * @package Groups\Tests\REST
+ */
+
+namespace Groups\Tests\REST;
+
+use Groups\Models\Membership;
+use Groups\REST\Membership_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+use WP_UnitTestCase;
+
+/**
+ * @coversDefaultClass \Groups\REST\Membership_Controller
+ * @group rest-api
+ * @group multisite
+ */
+class Test_Membership_Controller extends WP_UnitTestCase {
+
+	/**
+	 * REST server instance.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private WP_REST_Server $server;
+
+	/**
+	 * Test blog ID (a secondary site in the multisite network).
+	 *
+	 * @var int
+	 */
+	private int $blog_id;
+
+	/**
+	 * A regular user ID for join/leave operations.
+	 *
+	 * @var int
+	 */
+	private int $user_id;
+
+	/**
+	 * An organizer user ID.
+	 *
+	 * @var int
+	 */
+	private int $organizer_id;
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite tests require a multisite installation.' );
+		}
+
+		global $wp_rest_server;
+		$this->server = $wp_rest_server = new WP_REST_Server();
+
+		$this->blog_id = self::factory()->blog->create();
+
+		// Register custom roles on the test site.
+		switch_to_blog( $this->blog_id );
+		Membership::register_roles();
+
+		$controller = new Membership_Controller();
+		$controller->register_routes();
+
+		restore_current_blog();
+
+		// Create users.
+		$this->user_id      = self::factory()->user->create( [ 'display_name' => 'Test User' ] );
+		$this->organizer_id = self::factory()->user->create( [ 'display_name' => 'Organizer' ] );
+
+		// Set up organizer on the test site.
+		Membership::join( $this->organizer_id, $this->blog_id );
+		switch_to_blog( $this->blog_id );
+		$user = new \WP_User( $this->organizer_id );
+		$user->set_role( 'organizer' );
+		restore_current_blog();
+	}
+
+	/**
+	 * Tear down each test.
+	 */
+	public function tear_down(): void {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper to dispatch a request on the test blog.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @return \WP_REST_Response
+	 */
+	private function dispatch_on_blog( WP_REST_Request $request ) {
+		switch_to_blog( $this->blog_id );
+		$response = $this->server->dispatch( $request );
+		restore_current_blog();
+
+		return $response;
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_list_returns_members_with_roles(): void {
+		// Add a regular member.
+		Membership::join( $this->user_id, $this->blog_id );
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/members' );
+		$response = $this->dispatch_on_blog( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data     = $response->get_data();
+		$user_ids = array_column( $data, 'user_id' );
+
+		$this->assertContains( $this->user_id, $user_ids );
+		$this->assertContains( $this->organizer_id, $user_ids );
+
+		// Check that role information is present.
+		$member_entry = null;
+		$org_entry    = null;
+
+		foreach ( $data as $entry ) {
+			if ( $entry['user_id'] === $this->user_id ) {
+				$member_entry = $entry;
+			}
+			if ( $entry['user_id'] === $this->organizer_id ) {
+				$org_entry = $entry;
+			}
+		}
+
+		$this->assertNotNull( $member_entry );
+		$this->assertSame( 'member', $member_entry['role'] );
+		$this->assertArrayHasKey( 'display_name', $member_entry );
+		$this->assertArrayHasKey( 'avatar_url', $member_entry );
+		$this->assertArrayHasKey( 'joined_date', $member_entry );
+
+		$this->assertNotNull( $org_entry );
+		$this->assertSame( 'organizer', $org_entry['role'] );
+	}
+
+	/**
+	 * @covers ::join_item
+	 */
+	public function test_join_adds_user_to_site(): void {
+		wp_set_current_user( $this->user_id );
+
+		$request  = new WP_REST_Request( 'POST', '/groups/v1/members/join' );
+		$response = $this->dispatch_on_blog( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( $this->user_id, $data['user_id'] );
+		$this->assertSame( 'member', $data['role'] );
+
+		// Verify user is actually a member now.
+		$this->assertTrue( is_user_member_of_blog( $this->user_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::leave_item
+	 */
+	public function test_leave_removes_user(): void {
+		// First join.
+		Membership::join( $this->user_id, $this->blog_id );
+		$this->assertTrue( is_user_member_of_blog( $this->user_id, $this->blog_id ) );
+
+		wp_set_current_user( $this->user_id );
+
+		$request  = new WP_REST_Request( 'DELETE', '/groups/v1/members/leave' );
+		$response = $this->dispatch_on_blog( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( $this->user_id, $data['user_id'] );
+
+		// Verify user is no longer a member.
+		$this->assertFalse( is_user_member_of_blog( $this->user_id, $this->blog_id ) );
+	}
+
+	/**
+	 * @covers ::join_item_permissions_check
+	 */
+	public function test_anonymous_cannot_join(): void {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'POST', '/groups/v1/members/join' );
+		$response = $this->dispatch_on_blog( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::join_item_permissions_check
+	 */
+	public function test_banned_user_cannot_join(): void {
+		// Ban the user.
+		Membership::ban( $this->user_id, $this->blog_id, $this->organizer_id );
+
+		wp_set_current_user( $this->user_id );
+
+		$request  = new WP_REST_Request( 'POST', '/groups/v1/members/join' );
+		$response = $this->dispatch_on_blog( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'rest_user_banned', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @covers ::join_item_permissions_check
+	 */
+	public function test_already_a_member_cannot_join_again(): void {
+		Membership::join( $this->user_id, $this->blog_id );
+
+		wp_set_current_user( $this->user_id );
+
+		$request  = new WP_REST_Request( 'POST', '/groups/v1/members/join' );
+		$response = $this->dispatch_on_blog( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_already_member', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @covers ::leave_item_permissions_check
+	 */
+	public function test_anonymous_cannot_leave(): void {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'DELETE', '/groups/v1/members/leave' );
+		$response = $this->dispatch_on_blog( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::leave_item_permissions_check
+	 */
+	public function test_non_member_cannot_leave(): void {
+		wp_set_current_user( $this->user_id );
+
+		$request  = new WP_REST_Request( 'DELETE', '/groups/v1/members/leave' );
+		$response = $this->dispatch_on_blog( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_not_a_member', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_list_members_is_public(): void {
+		// Anonymous user.
+		wp_set_current_user( 0 );
+
+		Membership::join( $this->user_id, $this->blog_id );
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/members' );
+		$response = $this->dispatch_on_blog( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNotEmpty( $response->get_data() );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_list_members_filtered_by_role(): void {
+		Membership::join( $this->user_id, $this->blog_id );
+
+		$request = new WP_REST_Request( 'GET', '/groups/v1/members' );
+		$request->set_param( 'role', 'organizer' );
+
+		$response = $this->dispatch_on_blog( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data     = $response->get_data();
+		$user_ids = array_column( $data, 'user_id' );
+
+		$this->assertContains( $this->organizer_id, $user_ids );
+		$this->assertNotContains( $this->user_id, $user_ids );
+	}
+
+	/**
+	 * @covers ::get_item_schema
+	 */
+	public function test_schema_includes_expected_properties(): void {
+		$controller = new Membership_Controller();
+		$schema     = $controller->get_item_schema();
+
+		$this->assertArrayHasKey( 'user_id', $schema['properties'] );
+		$this->assertArrayHasKey( 'display_name', $schema['properties'] );
+		$this->assertArrayHasKey( 'avatar_url', $schema['properties'] );
+		$this->assertArrayHasKey( 'role', $schema['properties'] );
+		$this->assertArrayHasKey( 'joined_date', $schema['properties'] );
+	}
+
+	/**
+	 * @covers ::join_item
+	 */
+	public function test_join_response_includes_expected_fields(): void {
+		wp_set_current_user( $this->user_id );
+
+		$request  = new WP_REST_Request( 'POST', '/groups/v1/members/join' );
+		$response = $this->dispatch_on_blog( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'user_id', $data );
+		$this->assertArrayHasKey( 'display_name', $data );
+		$this->assertArrayHasKey( 'avatar_url', $data );
+		$this->assertArrayHasKey( 'role', $data );
+		$this->assertArrayHasKey( 'joined_date', $data );
+		$this->assertSame( 'Test User', $data['display_name'] );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/rest/test-membership-controller.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/rest/test-membership-controller.php
@@ -309,6 +309,57 @@ class Test_Membership_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::get_items
+	 */
+	public function test_joined_date_uses_group_meta_not_user_registered(): void {
+		wp_set_current_user( $this->user_id );
+
+		$request  = new WP_REST_Request( 'POST', '/groups/v1/members/join' );
+		$response = $this->dispatch_on_blog( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertNotNull( $data['joined_date'], 'joined_date should not be null after joining.' );
+
+		// The joined_date should NOT equal user_registered (account creation date).
+		$user            = get_userdata( $this->user_id );
+		$registered_date = mysql_to_rfc3339( $user->user_registered );
+		$meta_value      = get_user_meta( $this->user_id, "_groups_joined_{$this->blog_id}", true );
+
+		$this->assertNotEmpty( $meta_value, 'Join should have stored a _groups_joined meta.' );
+		$this->assertSame( mysql_to_rfc3339( $meta_value ), $data['joined_date'] );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_joined_date_falls_back_to_user_registered_for_legacy_members(): void {
+		// Simulate a legacy member by adding them to the blog directly (no meta).
+		add_user_to_blog( $this->blog_id, $this->user_id, 'member' );
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/members' );
+		$response = $this->dispatch_on_blog( $request );
+
+		$data         = $response->get_data();
+		$member_entry = null;
+
+		foreach ( $data as $entry ) {
+			if ( $entry['user_id'] === $this->user_id ) {
+				$member_entry = $entry;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $member_entry );
+
+		$user            = get_userdata( $this->user_id );
+		$registered_date = mysql_to_rfc3339( $user->user_registered );
+
+		$this->assertSame( $registered_date, $member_entry['joined_date'] );
+	}
+
+	/**
 	 * @covers ::join_item
 	 */
 	public function test_join_response_includes_expected_fields(): void {


### PR DESCRIPTION
## Summary
- Adds `Membership_Controller` (`Groups\REST`) with three routes under `groups/v1`:
  - `GET /members` — public listing of site members with roles, display names, avatars, and joined dates
  - `POST /members/join` — authenticated join (rejects banned users and duplicate membership)
  - `DELETE /members/leave` — authenticated leave (rejects non-members)
- Wires the controller into `class-plugin.php` via `register_rest_routes`
- Delegates all business logic to the existing `Groups\Models\Membership` model

## Test plan
- [ ] `test_list_returns_members_with_roles` — verifies members list includes role data
- [ ] `test_join_adds_user_to_site` — join creates membership with 201 response
- [ ] `test_leave_removes_user` — leave removes membership with 200 response
- [ ] `test_anonymous_cannot_join` — returns 401 for unauthenticated users
- [ ] `test_banned_user_cannot_join` — returns 403 with `rest_user_banned` code
- [ ] `test_already_a_member_cannot_join_again` — returns 400 with `rest_already_member` code
- [ ] `test_list_members_is_public` — anonymous users can list members
- [ ] `test_list_members_filtered_by_role` — role filter param works
- [ ] Additional edge cases: non-member cannot leave, schema validation, response field checks

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)