### PR TITLE
Add REST API RSVP endpoints

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -61,5 +61,8 @@ class Plugin {
 
 		$membership_controller = new REST\Membership_Controller();
 		$membership_controller->register_routes();
+
+		$rsvp_controller = new REST\Rsvp_Controller();
+		$rsvp_controller->register_routes();
 	}
 }

--- a/wp-content/plugins/wordpress-groups/includes/models/class-rsvp.php
+++ b/wp-content/plugins/wordpress-groups/includes/models/class-rsvp.php
@@ -1,0 +1,378 @@
+<?php
+/**
+ * RSVP model — comment-based RSVPs with waitlist promotion and attendance.
+ *
+ * RSVPs are stored as comments on event posts. Comment meta tracks status,
+ * guest count, and attendance. Waitlist promotion happens automatically
+ * when an attending RSVP is cancelled and there is capacity available.
+ *
+ * @package Groups\Models
+ */
+
+namespace Groups\Models;
+
+use Groups\Post_Types\Event as Event_Post_Type;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles RSVP creation, updates, cancellation, waitlist promotion, and attendance.
+ */
+class Rsvp {
+
+	/**
+	 * Comment type used for RSVPs.
+	 *
+	 * @var string
+	 */
+	const COMMENT_TYPE = 'groups_rsvp';
+
+	/**
+	 * Valid RSVP statuses.
+	 *
+	 * @var string[]
+	 */
+	const STATUSES = [
+		'attending',
+		'waitlisted',
+		'not_attending',
+		'no_show',
+	];
+
+	/**
+	 * Comment meta keys.
+	 *
+	 * @var string[]
+	 */
+	const META_KEYS = [
+		'_rsvp_status',
+		'_rsvp_guests',
+		'_rsvp_answers',
+		'_rsvp_attendance_confirmed',
+		'_rsvp_is_first_event',
+	];
+
+	/**
+	 * Create an RSVP for a user on an event.
+	 *
+	 * If the event has an attendee limit and it has been reached, the user
+	 * is placed on the waitlist (if enabled).
+	 *
+	 * @param int    $event_id The event post ID.
+	 * @param int    $user_id  The user ID.
+	 * @param int    $guests   Number of additional guests. Default 0.
+	 * @param string $answers  JSON-encoded custom question answers. Default empty.
+	 * @return int|\WP_Error Comment ID on success, WP_Error on failure.
+	 */
+	public static function create( int $event_id, int $user_id, int $guests = 0, string $answers = '' ): int|\WP_Error {
+		$post = get_post( $event_id );
+
+		if ( ! $post || Event_Post_Type::POST_TYPE !== $post->post_type ) {
+			return new \WP_Error( 'invalid_event', __( 'Invalid event.', 'wordpress-groups' ) );
+		}
+
+		// Check for duplicate RSVP.
+		$existing = self::get_user_rsvp( $event_id, $user_id );
+
+		if ( $existing ) {
+			return new \WP_Error(
+				'duplicate_rsvp',
+				__( 'You have already RSVPed to this event.', 'wordpress-groups' )
+			);
+		}
+
+		// Determine status based on capacity.
+		$status = self::determine_status( $event_id );
+
+		$user = get_userdata( $user_id );
+
+		if ( ! $user ) {
+			return new \WP_Error( 'invalid_user', __( 'Invalid user.', 'wordpress-groups' ) );
+		}
+
+		$comment_data = [
+			'comment_post_ID'  => $event_id,
+			'user_id'          => $user_id,
+			'comment_author'   => $user->display_name,
+			'comment_author_email' => $user->user_email,
+			'comment_content'  => '',
+			'comment_type'     => self::COMMENT_TYPE,
+			'comment_approved' => 1,
+		];
+
+		$comment_id = wp_insert_comment( $comment_data );
+
+		if ( ! $comment_id ) {
+			return new \WP_Error( 'rsvp_failed', __( 'Failed to create RSVP.', 'wordpress-groups' ) );
+		}
+
+		update_comment_meta( $comment_id, '_rsvp_status', $status );
+		update_comment_meta( $comment_id, '_rsvp_guests', absint( $guests ) );
+		update_comment_meta( $comment_id, '_rsvp_attendance_confirmed', false );
+
+		if ( $answers ) {
+			update_comment_meta( $comment_id, '_rsvp_answers', $answers );
+		}
+
+		/**
+		 * Fires after an RSVP is created.
+		 *
+		 * @param int    $comment_id The comment ID.
+		 * @param int    $event_id   The event post ID.
+		 * @param int    $user_id    The user ID.
+		 * @param string $status     The RSVP status (attending or waitlisted).
+		 */
+		do_action( 'groups_rsvp_created', $comment_id, $event_id, $user_id, $status );
+
+		return $comment_id;
+	}
+
+	/**
+	 * Update an existing RSVP.
+	 *
+	 * @param int    $comment_id The RSVP comment ID.
+	 * @param array  $args {
+	 *     Optional. Arguments to update.
+	 *
+	 *     @type int    $guests  Number of additional guests.
+	 *     @type string $answers JSON-encoded custom question answers.
+	 * }
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function update( int $comment_id, array $args ): true|\WP_Error {
+		$comment = get_comment( $comment_id );
+
+		if ( ! $comment || self::COMMENT_TYPE !== $comment->comment_type ) {
+			return new \WP_Error( 'invalid_rsvp', __( 'Invalid RSVP.', 'wordpress-groups' ) );
+		}
+
+		if ( isset( $args['guests'] ) ) {
+			update_comment_meta( $comment_id, '_rsvp_guests', absint( $args['guests'] ) );
+		}
+
+		if ( isset( $args['answers'] ) ) {
+			update_comment_meta( $comment_id, '_rsvp_answers', $args['answers'] );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Cancel an RSVP and promote the next waitlisted user if applicable.
+	 *
+	 * @param int $comment_id The RSVP comment ID.
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function cancel( int $comment_id ): true|\WP_Error {
+		$comment = get_comment( $comment_id );
+
+		if ( ! $comment || self::COMMENT_TYPE !== $comment->comment_type ) {
+			return new \WP_Error( 'invalid_rsvp', __( 'Invalid RSVP.', 'wordpress-groups' ) );
+		}
+
+		$old_status = get_comment_meta( $comment_id, '_rsvp_status', true );
+		$event_id   = (int) $comment->comment_post_ID;
+
+		update_comment_meta( $comment_id, '_rsvp_status', 'not_attending' );
+
+		/**
+		 * Fires after an RSVP is cancelled.
+		 *
+		 * @param int    $comment_id The comment ID.
+		 * @param int    $event_id   The event post ID.
+		 * @param int    $user_id    The user ID.
+		 * @param string $old_status The previous RSVP status.
+		 */
+		do_action( 'groups_rsvp_cancelled', $comment_id, $event_id, (int) $comment->user_id, $old_status );
+
+		// Promote from waitlist if an attending spot opened up.
+		if ( 'attending' === $old_status ) {
+			self::maybe_promote_waitlist( $event_id );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Mark attendance for a user's RSVP on an event.
+	 *
+	 * @param int  $event_id The event post ID.
+	 * @param int  $user_id  The user ID.
+	 * @param bool $attended Whether the user attended. Default true.
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function mark_attendance( int $event_id, int $user_id, bool $attended = true ): true|\WP_Error {
+		$rsvp = self::get_user_rsvp( $event_id, $user_id );
+
+		if ( ! $rsvp ) {
+			return new \WP_Error( 'no_rsvp', __( 'No RSVP found for this user.', 'wordpress-groups' ) );
+		}
+
+		$comment_id = (int) $rsvp->comment_ID;
+
+		update_comment_meta( $comment_id, '_rsvp_attendance_confirmed', $attended );
+
+		if ( ! $attended ) {
+			update_comment_meta( $comment_id, '_rsvp_status', 'no_show' );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get all RSVPs for an event, optionally filtered by status.
+	 *
+	 * @param int    $event_id The event post ID.
+	 * @param string $status   Optional status to filter by.
+	 * @return \WP_Comment[] Array of comment objects.
+	 */
+	public static function get_rsvps( int $event_id, string $status = '' ): array {
+		$args = [
+			'post_id' => $event_id,
+			'type'    => self::COMMENT_TYPE,
+			'status'  => 'approve',
+			'orderby' => 'comment_date',
+			'order'   => 'ASC',
+		];
+
+		if ( $status ) {
+			$args['meta_key']   = '_rsvp_status'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			$args['meta_value'] = $status;         // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		}
+
+		return get_comments( $args );
+	}
+
+	/**
+	 * Get the RSVP comment for a specific user on an event.
+	 *
+	 * Only returns RSVPs that are not cancelled (not_attending).
+	 *
+	 * @param int $event_id The event post ID.
+	 * @param int $user_id  The user ID.
+	 * @return \WP_Comment|null The RSVP comment or null if not found.
+	 */
+	public static function get_user_rsvp( int $event_id, int $user_id ): ?\WP_Comment {
+		$comments = get_comments( [
+			'post_id'    => $event_id,
+			'user_id'    => $user_id,
+			'type'       => self::COMMENT_TYPE,
+			'status'     => 'approve',
+			'number'     => 1,
+			'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				[
+					'key'     => '_rsvp_status',
+					'value'   => 'not_attending',
+					'compare' => '!=',
+				],
+			],
+		] );
+
+		return $comments[0] ?? null;
+	}
+
+	/**
+	 * Get the count of attending RSVPs for an event.
+	 *
+	 * @param int $event_id The event post ID.
+	 * @return int The number of attending RSVPs.
+	 */
+	public static function get_attending_count( int $event_id ): int {
+		return count( self::get_rsvps( $event_id, 'attending' ) );
+	}
+
+	/**
+	 * Determine the RSVP status based on event capacity.
+	 *
+	 * @param int $event_id The event post ID.
+	 * @return string 'attending' or 'waitlisted'.
+	 */
+	private static function determine_status( int $event_id ): string {
+		$limit = (int) get_post_meta( $event_id, '_event_attendee_limit', true );
+
+		// No limit set — everyone attends.
+		if ( 0 === $limit ) {
+			return 'attending';
+		}
+
+		$attending_count = self::get_attending_count( $event_id );
+
+		if ( $attending_count < $limit ) {
+			return 'attending';
+		}
+
+		// Check if waitlist is enabled.
+		$waitlist_enabled = (bool) get_post_meta( $event_id, '_event_waitlist_enabled', true );
+
+		if ( $waitlist_enabled ) {
+			return 'waitlisted';
+		}
+
+		// No waitlist — still mark as attending (over-capacity allowed if no waitlist).
+		return 'attending';
+	}
+
+	/**
+	 * Promote the next waitlisted RSVP to attending status.
+	 *
+	 * Called when an attending RSVP is cancelled to fill the opened spot.
+	 *
+	 * @param int $event_id The event post ID.
+	 */
+	public static function maybe_promote_waitlist( int $event_id ): void {
+		$limit = (int) get_post_meta( $event_id, '_event_attendee_limit', true );
+
+		// No limit — nothing to promote.
+		if ( 0 === $limit ) {
+			return;
+		}
+
+		$attending_count = self::get_attending_count( $event_id );
+
+		if ( $attending_count >= $limit ) {
+			return;
+		}
+
+		// Get the oldest waitlisted RSVP.
+		$waitlisted = self::get_rsvps( $event_id, 'waitlisted' );
+
+		if ( empty( $waitlisted ) ) {
+			return;
+		}
+
+		$promoted = $waitlisted[0];
+		update_comment_meta( $promoted->comment_ID, '_rsvp_status', 'attending' );
+
+		/**
+		 * Fires after a waitlisted RSVP is promoted to attending.
+		 *
+		 * @param int $comment_id The comment ID.
+		 * @param int $event_id   The event post ID.
+		 * @param int $user_id    The user ID.
+		 */
+		do_action( 'groups_rsvp_promoted', (int) $promoted->comment_ID, $event_id, (int) $promoted->user_id );
+	}
+
+	/**
+	 * Prepare RSVP data for REST API response.
+	 *
+	 * @param \WP_Comment $comment The RSVP comment.
+	 * @return array RSVP data array.
+	 */
+	public static function prepare_for_response( \WP_Comment $comment ): array {
+		$user_id = (int) $comment->user_id;
+		$user    = get_userdata( $user_id );
+
+		return [
+			'id'                    => (int) $comment->comment_ID,
+			'event_id'              => (int) $comment->comment_post_ID,
+			'user_id'               => $user_id,
+			'display_name'          => $user ? esc_html( $user->display_name ) : '',
+			'avatar_url'            => get_avatar_url( $user_id, [ 'size' => 96 ] ),
+			'status'                => get_comment_meta( $comment->comment_ID, '_rsvp_status', true ),
+			'guests'                => (int) get_comment_meta( $comment->comment_ID, '_rsvp_guests', true ),
+			'attendance_confirmed'  => (bool) get_comment_meta( $comment->comment_ID, '_rsvp_attendance_confirmed', true ),
+			'timestamp'             => $comment->comment_date_gmt,
+		];
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/rest/class-rsvp-controller.php
+++ b/wp-content/plugins/wordpress-groups/includes/rest/class-rsvp-controller.php
@@ -1,0 +1,605 @@
+<?php
+/**
+ * REST API controller for RSVPs.
+ *
+ * @package Groups\REST
+ */
+
+namespace Groups\REST;
+
+use Groups\Models\Rsvp;
+use Groups\Post_Types\Event;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles RSVP operations via the REST API.
+ *
+ * RSVPs are stored as comments on event posts. This controller provides
+ * endpoints for listing, creating, updating, cancelling RSVPs, and
+ * marking attendance.
+ */
+class Rsvp_Controller extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST routes.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'groups/v1';
+
+	/**
+	 * Base path for RSVP routes.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'events/(?P<event_id>[\d]+)';
+
+	/**
+	 * Register REST routes.
+	 */
+	public function register_routes(): void {
+		// GET /events/{event_id}/rsvps — list RSVPs for an event.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/rsvps',
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_items' ],
+					'permission_callback' => [ $this, 'get_items_permissions_check' ],
+					'args'                => [
+						'event_id' => [
+							'description' => __( 'The event ID.', 'wordpress-groups' ),
+							'type'        => 'integer',
+							'required'    => true,
+						],
+						'status'   => [
+							'description' => __( 'Filter RSVPs by status.', 'wordpress-groups' ),
+							'type'        => 'string',
+							'enum'        => Rsvp::STATUSES,
+						],
+					],
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+
+		// POST /events/{event_id}/rsvp — RSVP to an event.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/rsvp',
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'create_item' ],
+					'permission_callback' => [ $this, 'create_item_permissions_check' ],
+					'args'                => [
+						'event_id' => [
+							'description' => __( 'The event ID.', 'wordpress-groups' ),
+							'type'        => 'integer',
+							'required'    => true,
+						],
+						'guests'   => [
+							'description' => __( 'Number of additional guests.', 'wordpress-groups' ),
+							'type'        => 'integer',
+							'default'     => 0,
+						],
+						'answers'  => [
+							'description' => __( 'Custom question answers (JSON string).', 'wordpress-groups' ),
+							'type'        => 'string',
+							'default'     => '',
+						],
+					],
+				],
+			]
+		);
+
+		// PUT /events/{event_id}/rsvp — update own RSVP.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/rsvp',
+			[
+				[
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => [ $this, 'update_item' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => [
+						'event_id' => [
+							'description' => __( 'The event ID.', 'wordpress-groups' ),
+							'type'        => 'integer',
+							'required'    => true,
+						],
+						'guests'   => [
+							'description' => __( 'Number of additional guests.', 'wordpress-groups' ),
+							'type'        => 'integer',
+						],
+						'answers'  => [
+							'description' => __( 'Custom question answers (JSON string).', 'wordpress-groups' ),
+							'type'        => 'string',
+						],
+					],
+				],
+			]
+		);
+
+		// DELETE /events/{event_id}/rsvp — cancel own RSVP.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/rsvp',
+			[
+				[
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'delete_item' ],
+					'permission_callback' => [ $this, 'delete_item_permissions_check' ],
+					'args'                => [
+						'event_id' => [
+							'description' => __( 'The event ID.', 'wordpress-groups' ),
+							'type'        => 'integer',
+							'required'    => true,
+						],
+					],
+				],
+			]
+		);
+
+		// POST /events/{event_id}/attendance — mark attendance (organizer only).
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/attendance',
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'mark_attendance' ],
+					'permission_callback' => [ $this, 'mark_attendance_permissions_check' ],
+					'args'                => [
+						'event_id' => [
+							'description' => __( 'The event ID.', 'wordpress-groups' ),
+							'type'        => 'integer',
+							'required'    => true,
+						],
+						'user_id'  => [
+							'description' => __( 'The user ID to mark attendance for.', 'wordpress-groups' ),
+							'type'        => 'integer',
+							'required'    => true,
+						],
+						'attended' => [
+							'description' => __( 'Whether the user attended.', 'wordpress-groups' ),
+							'type'        => 'boolean',
+							'default'     => true,
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Validate that an event exists and is a valid event post.
+	 *
+	 * @param int $event_id The event post ID.
+	 * @return \WP_Post|WP_Error The event post or an error.
+	 */
+	private function validate_event( int $event_id ): \WP_Post|WP_Error {
+		$post = get_post( $event_id );
+
+		if ( ! $post || Event::POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'rest_event_not_found',
+				__( 'Event not found.', 'wordpress-groups' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		return $post;
+	}
+
+	/**
+	 * Check whether the current user is an organizer or co-organizer.
+	 *
+	 * @return bool
+	 */
+	private function is_organizer(): bool {
+		if ( is_super_admin() ) {
+			return true;
+		}
+
+		$user = wp_get_current_user();
+
+		return in_array( 'organizer', (array) $user->roles, true )
+			|| in_array( 'co_organizer', (array) $user->roles, true )
+			|| in_array( 'co-organizer', (array) $user->roles, true )
+			|| in_array( 'administrator', (array) $user->roles, true );
+	}
+
+	/**
+	 * Permission check for listing RSVPs — public.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function get_items_permissions_check( $request ) {
+		$event = $this->validate_event( absint( $request->get_param( 'event_id' ) ) );
+
+		if ( is_wp_error( $event ) ) {
+			return $event;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieve RSVPs for an event.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_items( $request ) {
+		$event_id = absint( $request->get_param( 'event_id' ) );
+		$status   = $request->get_param( 'status' ) ?? '';
+
+		$rsvps = Rsvp::get_rsvps( $event_id, sanitize_text_field( $status ) );
+		$data  = [];
+
+		foreach ( $rsvps as $rsvp ) {
+			$data[] = Rsvp::prepare_for_response( $rsvp );
+		}
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Permission check for creating an RSVP — must be logged in.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function create_item_permissions_check( $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to RSVP.', 'wordpress-groups' ),
+				[ 'status' => 401 ]
+			);
+		}
+
+		$event = $this->validate_event( absint( $request->get_param( 'event_id' ) ) );
+
+		if ( is_wp_error( $event ) ) {
+			return $event;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Create an RSVP.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ) {
+		$event_id = absint( $request->get_param( 'event_id' ) );
+		$user_id  = get_current_user_id();
+		$guests   = absint( $request->get_param( 'guests' ) );
+		$answers  = sanitize_text_field( $request->get_param( 'answers' ) ?? '' );
+
+		$result = Rsvp::create( $event_id, $user_id, $guests, $answers );
+
+		if ( is_wp_error( $result ) ) {
+			$error_data = $result->get_error_data();
+			$status     = 400;
+
+			if ( 'duplicate_rsvp' === $result->get_error_code() ) {
+				$status = 409;
+			}
+
+			return new WP_Error(
+				$result->get_error_code(),
+				$result->get_error_message(),
+				[ 'status' => $status ]
+			);
+		}
+
+		$comment  = get_comment( $result );
+		$data     = Rsvp::prepare_for_response( $comment );
+		$response = new WP_REST_Response( $data, 201 );
+
+		return $response;
+	}
+
+	/**
+	 * Permission check for updating own RSVP — must be logged in.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function update_item_permissions_check( $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to update your RSVP.', 'wordpress-groups' ),
+				[ 'status' => 401 ]
+			);
+		}
+
+		$event = $this->validate_event( absint( $request->get_param( 'event_id' ) ) );
+
+		if ( is_wp_error( $event ) ) {
+			return $event;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Update own RSVP.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		$event_id = absint( $request->get_param( 'event_id' ) );
+		$user_id  = get_current_user_id();
+		$rsvp     = Rsvp::get_user_rsvp( $event_id, $user_id );
+
+		if ( ! $rsvp ) {
+			return new WP_Error(
+				'rest_rsvp_not_found',
+				__( 'No RSVP found for this event.', 'wordpress-groups' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		$args = [];
+
+		$guests = $request->get_param( 'guests' );
+		if ( null !== $guests ) {
+			$args['guests'] = absint( $guests );
+		}
+
+		$answers = $request->get_param( 'answers' );
+		if ( null !== $answers ) {
+			$args['answers'] = sanitize_text_field( $answers );
+		}
+
+		$result = Rsvp::update( (int) $rsvp->comment_ID, $args );
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error(
+				$result->get_error_code(),
+				$result->get_error_message(),
+				[ 'status' => 400 ]
+			);
+		}
+
+		// Re-fetch to include updated data.
+		$comment = get_comment( $rsvp->comment_ID );
+		$data    = Rsvp::prepare_for_response( $comment );
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Permission check for cancelling own RSVP — must be logged in.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function delete_item_permissions_check( $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to cancel your RSVP.', 'wordpress-groups' ),
+				[ 'status' => 401 ]
+			);
+		}
+
+		$event = $this->validate_event( absint( $request->get_param( 'event_id' ) ) );
+
+		if ( is_wp_error( $event ) ) {
+			return $event;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Cancel own RSVP.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		$event_id = absint( $request->get_param( 'event_id' ) );
+		$user_id  = get_current_user_id();
+		$rsvp     = Rsvp::get_user_rsvp( $event_id, $user_id );
+
+		if ( ! $rsvp ) {
+			return new WP_Error(
+				'rest_rsvp_not_found',
+				__( 'No RSVP found for this event.', 'wordpress-groups' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		$result = Rsvp::cancel( (int) $rsvp->comment_ID );
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error(
+				$result->get_error_code(),
+				$result->get_error_message(),
+				[ 'status' => 400 ]
+			);
+		}
+
+		// Re-fetch to include updated status.
+		$comment = get_comment( $rsvp->comment_ID );
+		$data    = Rsvp::prepare_for_response( $comment );
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Permission check for marking attendance — organizer or co-organizer only.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function mark_attendance_permissions_check( $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to mark attendance.', 'wordpress-groups' ),
+				[ 'status' => 401 ]
+			);
+		}
+
+		if ( ! $this->is_organizer() ) {
+			return new WP_Error(
+				'rest_cannot_mark_attendance',
+				__( 'Only organizers and co-organizers can mark attendance.', 'wordpress-groups' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		$event = $this->validate_event( absint( $request->get_param( 'event_id' ) ) );
+
+		if ( is_wp_error( $event ) ) {
+			return $event;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Mark attendance for a user.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function mark_attendance( WP_REST_Request $request ) {
+		$event_id = absint( $request->get_param( 'event_id' ) );
+		$user_id  = absint( $request->get_param( 'user_id' ) );
+		$attended = (bool) $request->get_param( 'attended' );
+
+		$result = Rsvp::mark_attendance( $event_id, $user_id, $attended );
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error(
+				$result->get_error_code(),
+				$result->get_error_message(),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$rsvp = Rsvp::get_user_rsvp( $event_id, $user_id );
+
+		// If the RSVP was marked as no_show, get_user_rsvp won't find it
+		// (it excludes not_attending). Fetch by searching all RSVPs.
+		if ( ! $rsvp ) {
+			$all_rsvps = get_comments( [
+				'post_id' => $event_id,
+				'user_id' => $user_id,
+				'type'    => Rsvp::COMMENT_TYPE,
+				'status'  => 'approve',
+				'number'  => 1,
+				'orderby' => 'comment_date',
+				'order'   => 'DESC',
+			] );
+
+			$rsvp = $all_rsvps[0] ?? null;
+		}
+
+		if ( ! $rsvp ) {
+			return new WP_Error(
+				'rest_rsvp_not_found',
+				__( 'RSVP not found after marking attendance.', 'wordpress-groups' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		$data = Rsvp::prepare_for_response( $rsvp );
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Get the RSVP schema for responses.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_item_schema(): array {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$this->schema = [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'rsvp',
+			'type'       => 'object',
+			'properties' => [
+				'id'                   => [
+					'description' => __( 'Unique identifier for the RSVP.', 'wordpress-groups' ),
+					'type'        => 'integer',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'event_id'             => [
+					'description' => __( 'The event post ID.', 'wordpress-groups' ),
+					'type'        => 'integer',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'user_id'              => [
+					'description' => __( 'The user ID.', 'wordpress-groups' ),
+					'type'        => 'integer',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'display_name'         => [
+					'description' => __( 'The user display name.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'avatar_url'           => [
+					'description' => __( 'The user avatar URL.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'status'               => [
+					'description' => __( 'The RSVP status.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'enum'        => Rsvp::STATUSES,
+					'context'     => [ 'view' ],
+				],
+				'guests'               => [
+					'description' => __( 'Number of additional guests.', 'wordpress-groups' ),
+					'type'        => 'integer',
+					'context'     => [ 'view', 'edit' ],
+				],
+				'attendance_confirmed' => [
+					'description' => __( 'Whether attendance has been confirmed.', 'wordpress-groups' ),
+					'type'        => 'boolean',
+					'context'     => [ 'view' ],
+				],
+				'timestamp'            => [
+					'description' => __( 'The RSVP creation time (UTC).', 'wordpress-groups' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+			],
+		];
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/rest/class-rsvp-controller.php
+++ b/wp-content/plugins/wordpress-groups/includes/rest/class-rsvp-controller.php
@@ -7,6 +7,7 @@
 
 namespace Groups\REST;
 
+use Groups\Models\Membership;
 use Groups\Models\Rsvp;
 use Groups\Post_Types\Event;
 use WP_Error;
@@ -70,7 +71,7 @@ class Rsvp_Controller extends WP_REST_Controller {
 			]
 		);
 
-		// POST /events/{event_id}/rsvp — RSVP to an event.
+		// POST/PUT/DELETE /events/{event_id}/rsvp — create, update, or cancel RSVP.
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/rsvp',
@@ -97,14 +98,6 @@ class Rsvp_Controller extends WP_REST_Controller {
 						],
 					],
 				],
-			]
-		);
-
-		// PUT /events/{event_id}/rsvp — update own RSVP.
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/rsvp',
-			[
 				[
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => [ $this, 'update_item' ],
@@ -125,14 +118,6 @@ class Rsvp_Controller extends WP_REST_Controller {
 						],
 					],
 				],
-			]
-		);
-
-		// DELETE /events/{event_id}/rsvp — cancel own RSVP.
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/rsvp',
-			[
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => [ $this, 'delete_item' ],
@@ -268,6 +253,14 @@ class Rsvp_Controller extends WP_REST_Controller {
 			);
 		}
 
+		if ( Membership::is_banned( get_current_user_id() ) ) {
+			return new WP_Error(
+				'rest_user_banned',
+				__( 'You are banned from this group.', 'wordpress-groups' ),
+				[ 'status' => 403 ]
+			);
+		}
+
 		$event = $this->validate_event( absint( $request->get_param( 'event_id' ) ) );
 
 		if ( is_wp_error( $event ) ) {
@@ -284,10 +277,26 @@ class Rsvp_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function create_item( $request ) {
-		$event_id = absint( $request->get_param( 'event_id' ) );
-		$user_id  = get_current_user_id();
-		$guests   = absint( $request->get_param( 'guests' ) );
-		$answers  = sanitize_text_field( $request->get_param( 'answers' ) ?? '' );
+		$event_id    = absint( $request->get_param( 'event_id' ) );
+		$user_id     = get_current_user_id();
+		$guests      = absint( $request->get_param( 'guests' ) );
+		$raw_answers = $request->get_param( 'answers' ) ?? '';
+
+		if ( '' !== $raw_answers ) {
+			$decoded = json_decode( wp_unslash( $raw_answers ), true );
+
+			if ( null === $decoded && 'null' !== $raw_answers ) {
+				return new WP_Error(
+					'rest_invalid_answers',
+					__( 'The answers field must be valid JSON.', 'wordpress-groups' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			$answers = wp_json_encode( $decoded );
+		} else {
+			$answers = '';
+		}
 
 		$result = Rsvp::create( $event_id, $user_id, $guests, $answers );
 
@@ -365,7 +374,21 @@ class Rsvp_Controller extends WP_REST_Controller {
 
 		$answers = $request->get_param( 'answers' );
 		if ( null !== $answers ) {
-			$args['answers'] = sanitize_text_field( $answers );
+			if ( '' !== $answers ) {
+				$decoded = json_decode( wp_unslash( $answers ), true );
+
+				if ( null === $decoded && 'null' !== $answers ) {
+					return new WP_Error(
+						'rest_invalid_answers',
+						__( 'The answers field must be valid JSON.', 'wordpress-groups' ),
+						[ 'status' => 400 ]
+					);
+				}
+
+				$args['answers'] = wp_json_encode( $decoded );
+			} else {
+				$args['answers'] = '';
+			}
 		}
 
 		$result = Rsvp::update( (int) $rsvp->comment_ID, $args );

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/rest/test-rsvp-controller.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/rest/test-rsvp-controller.php
@@ -7,6 +7,7 @@
 
 namespace Groups\Tests\REST;
 
+use Groups\Models\Membership;
 use Groups\Models\Rsvp;
 use Groups\Post_Types\Event;
 use Groups\REST\Rsvp_Controller;
@@ -405,6 +406,71 @@ class Test_Rsvp_Controller extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::update_item_permissions_check
+	 */
+	public function test_anonymous_cannot_update_rsvp(): void {
+		wp_set_current_user( 0 );
+
+		$event_id = $this->create_event();
+
+		$request = new WP_REST_Request( 'PUT', '/groups/v1/events/' . $event_id . '/rsvp' );
+		$request->set_body_params( [
+			'guests' => 1,
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::delete_item_permissions_check
+	 */
+	public function test_anonymous_cannot_cancel_rsvp(): void {
+		wp_set_current_user( 0 );
+
+		$event_id = $this->create_event();
+
+		$request  = new WP_REST_Request( 'DELETE', '/groups/v1/events/' . $event_id . '/rsvp' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::create_item_permissions_check
+	 */
+	public function test_rsvp_to_nonexistent_event_returns_404(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$request  = new WP_REST_Request( 'POST', '/groups/v1/events/999999/rsvp' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::create_item_permissions_check
+	 */
+	public function test_banned_user_cannot_rsvp(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$event_id = $this->create_event();
+
+		// Ban the subscriber from the current site.
+		update_user_meta( $this->subscriber_id, '_groups_banned_' . get_current_blog_id(), 1 );
+
+		$request  = new WP_REST_Request( 'POST', '/groups/v1/events/' . $event_id . '/rsvp' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'rest_user_banned', $response->get_data()['code'] );
+
+		// Clean up.
+		delete_user_meta( $this->subscriber_id, '_groups_banned_' . get_current_blog_id() );
 	}
 
 	/**

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/rest/test-rsvp-controller.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/rest/test-rsvp-controller.php
@@ -1,0 +1,433 @@
+<?php
+/**
+ * Tests for the RSVP REST API controller.
+ *
+ * @package Groups\Tests\REST
+ */
+
+namespace Groups\Tests\REST;
+
+use Groups\Models\Rsvp;
+use Groups\Post_Types\Event;
+use Groups\REST\Rsvp_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+use WP_UnitTestCase;
+
+/**
+ * @coversDefaultClass \Groups\REST\Rsvp_Controller
+ * @group rest-api
+ */
+class Test_Rsvp_Controller extends WP_UnitTestCase {
+
+	/**
+	 * REST server instance.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private WP_REST_Server $server;
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	private int $admin_id;
+
+	/**
+	 * Subscriber user ID (member role).
+	 *
+	 * @var int
+	 */
+	private int $subscriber_id;
+
+	/**
+	 * Organizer user ID.
+	 *
+	 * @var int
+	 */
+	private int $organizer_id;
+
+	/**
+	 * Second subscriber for waitlist tests.
+	 *
+	 * @var int
+	 */
+	private int $subscriber2_id;
+
+	/**
+	 * Set up the test suite — register CPT, statuses, and roles once.
+	 */
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+
+		$event_cpt = new Event();
+		$event_cpt->register_post_type();
+		$event_cpt->register_post_statuses();
+
+		if ( ! get_role( 'organizer' ) ) {
+			add_role( 'organizer', 'Organizer', [ 'read' => true ] );
+		}
+
+		if ( ! get_role( 'co_organizer' ) ) {
+			add_role( 'co_organizer', 'Co-Organizer', [ 'read' => true ] );
+		}
+	}
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wp_rest_server;
+		$this->server = $wp_rest_server = new WP_REST_Server();
+
+		$controller = new Rsvp_Controller();
+		$controller->register_routes();
+
+		$this->admin_id       = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$this->subscriber_id  = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$this->organizer_id   = self::factory()->user->create( [ 'role' => 'organizer' ] );
+		$this->subscriber2_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+	}
+
+	/**
+	 * Tear down each test.
+	 */
+	public function tear_down(): void {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper to create an event post with meta.
+	 *
+	 * @param array $args Optional post args.
+	 * @param array $meta Optional meta values.
+	 * @return int Post ID.
+	 */
+	private function create_event( array $args = [], array $meta = [] ): int {
+		$defaults = [
+			'post_type'   => Event::POST_TYPE,
+			'post_title'  => 'Test Event',
+			'post_status' => 'event-scheduled',
+			'post_author' => $this->admin_id,
+		];
+
+		$post_id = self::factory()->post->create( array_merge( $defaults, $args ) );
+
+		$default_meta = [
+			'_event_start_date'      => '2026-06-15 18:00:00',
+			'_event_end_date'        => '2026-06-15 20:00:00',
+			'_event_timezone'        => 'Australia/Melbourne',
+			'_event_attendee_limit'  => 0,
+			'_event_waitlist_enabled' => false,
+		];
+
+		foreach ( array_merge( $default_meta, $meta ) as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_list_rsvps_returns_attendees(): void {
+		$event_id = $this->create_event();
+
+		// Create RSVPs directly via the model.
+		Rsvp::create( $event_id, $this->subscriber_id );
+		Rsvp::create( $event_id, $this->subscriber2_id );
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/events/' . $event_id . '/rsvps' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertCount( 2, $data );
+
+		// Verify response contains expected fields.
+		$first = $data[0];
+		$this->assertArrayHasKey( 'id', $first );
+		$this->assertArrayHasKey( 'user_id', $first );
+		$this->assertArrayHasKey( 'display_name', $first );
+		$this->assertArrayHasKey( 'avatar_url', $first );
+		$this->assertArrayHasKey( 'status', $first );
+		$this->assertSame( 'attending', $first['status'] );
+	}
+
+	/**
+	 * @covers ::create_item
+	 */
+	public function test_rsvp_creates_comment_with_correct_meta(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$event_id = $this->create_event();
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/events/' . $event_id . '/rsvp' );
+		$request->set_body_params( [
+			'guests' => 2,
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( $event_id, $data['event_id'] );
+		$this->assertSame( $this->subscriber_id, $data['user_id'] );
+		$this->assertSame( 'attending', $data['status'] );
+		$this->assertSame( 2, $data['guests'] );
+
+		// Verify comment was actually created with correct type.
+		$comment = get_comment( $data['id'] );
+		$this->assertSame( Rsvp::COMMENT_TYPE, $comment->comment_type );
+		$this->assertSame( 'attending', get_comment_meta( $data['id'], '_rsvp_status', true ) );
+	}
+
+	/**
+	 * @covers ::create_item_permissions_check
+	 */
+	public function test_anonymous_cannot_rsvp(): void {
+		wp_set_current_user( 0 );
+
+		$event_id = $this->create_event();
+
+		$request  = new WP_REST_Request( 'POST', '/groups/v1/events/' . $event_id . '/rsvp' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::delete_item
+	 */
+	public function test_cancel_rsvp_works(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$event_id = $this->create_event();
+		Rsvp::create( $event_id, $this->subscriber_id );
+
+		$request  = new WP_REST_Request( 'DELETE', '/groups/v1/events/' . $event_id . '/rsvp' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'not_attending', $data['status'] );
+	}
+
+	/**
+	 * @covers ::delete_item
+	 */
+	public function test_waitlist_promotion_on_cancel(): void {
+		$event_id = $this->create_event( [], [
+			'_event_attendee_limit'   => 1,
+			'_event_waitlist_enabled' => true,
+		] );
+
+		// First user gets attending, second gets waitlisted.
+		$rsvp1_id = Rsvp::create( $event_id, $this->subscriber_id );
+		$rsvp2_id = Rsvp::create( $event_id, $this->subscriber2_id );
+
+		// Verify second user is waitlisted.
+		$this->assertSame( 'waitlisted', get_comment_meta( $rsvp2_id, '_rsvp_status', true ) );
+
+		// Cancel first user's RSVP via REST.
+		wp_set_current_user( $this->subscriber_id );
+		$request  = new WP_REST_Request( 'DELETE', '/groups/v1/events/' . $event_id . '/rsvp' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		// Verify second user was promoted to attending.
+		$promoted_status = get_comment_meta( $rsvp2_id, '_rsvp_status', true );
+		$this->assertSame( 'attending', $promoted_status, 'Waitlisted user should be promoted to attending after cancellation.' );
+	}
+
+	/**
+	 * @covers ::mark_attendance_permissions_check
+	 */
+	public function test_mark_attendance_requires_organizer_role(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$event_id = $this->create_event();
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/events/' . $event_id . '/attendance' );
+		$request->set_body_params( [
+			'user_id'  => $this->subscriber2_id,
+			'attended' => true,
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status(), 'Subscribers should not be able to mark attendance.' );
+	}
+
+	/**
+	 * @covers ::create_item_permissions_check
+	 * @covers ::mark_attendance_permissions_check
+	 */
+	public function test_subscriber_can_rsvp_but_not_mark_attendance(): void {
+		$event_id = $this->create_event();
+
+		// Subscriber can RSVP.
+		wp_set_current_user( $this->subscriber_id );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/events/' . $event_id . '/rsvp' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status(), 'Subscriber should be able to RSVP.' );
+
+		// Subscriber cannot mark attendance.
+		$request = new WP_REST_Request( 'POST', '/groups/v1/events/' . $event_id . '/attendance' );
+		$request->set_body_params( [
+			'user_id'  => $this->subscriber_id,
+			'attended' => true,
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status(), 'Subscriber should not be able to mark attendance.' );
+	}
+
+	/**
+	 * @covers ::create_item
+	 */
+	public function test_duplicate_rsvp_returns_error(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$event_id = $this->create_event();
+
+		// First RSVP succeeds.
+		$request  = new WP_REST_Request( 'POST', '/groups/v1/events/' . $event_id . '/rsvp' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+
+		// Second RSVP should fail with 409 Conflict.
+		$request  = new WP_REST_Request( 'POST', '/groups/v1/events/' . $event_id . '/rsvp' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'duplicate_rsvp', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @covers ::mark_attendance
+	 */
+	public function test_organizer_can_mark_attendance(): void {
+		wp_set_current_user( $this->organizer_id );
+
+		$event_id = $this->create_event();
+		Rsvp::create( $event_id, $this->subscriber_id );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/events/' . $event_id . '/attendance' );
+		$request->set_body_params( [
+			'user_id'  => $this->subscriber_id,
+			'attended' => true,
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertTrue( $data['attendance_confirmed'] );
+	}
+
+	/**
+	 * @covers ::update_item
+	 */
+	public function test_update_rsvp_guests(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$event_id = $this->create_event();
+		Rsvp::create( $event_id, $this->subscriber_id, 0 );
+
+		$request = new WP_REST_Request( 'PUT', '/groups/v1/events/' . $event_id . '/rsvp' );
+		$request->set_body_params( [
+			'guests' => 3,
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 3, $response->get_data()['guests'] );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_list_rsvps_filtered_by_status(): void {
+		$event_id = $this->create_event( [], [
+			'_event_attendee_limit'   => 1,
+			'_event_waitlist_enabled' => true,
+		] );
+
+		Rsvp::create( $event_id, $this->subscriber_id );
+		Rsvp::create( $event_id, $this->subscriber2_id );
+
+		// Filter for attending only.
+		$request = new WP_REST_Request( 'GET', '/groups/v1/events/' . $event_id . '/rsvps' );
+		$request->set_param( 'status', 'attending' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 1, $response->get_data() );
+		$this->assertSame( 'attending', $response->get_data()[0]['status'] );
+
+		// Filter for waitlisted only.
+		$request = new WP_REST_Request( 'GET', '/groups/v1/events/' . $event_id . '/rsvps' );
+		$request->set_param( 'status', 'waitlisted' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 1, $response->get_data() );
+		$this->assertSame( 'waitlisted', $response->get_data()[0]['status'] );
+	}
+
+	/**
+	 * @covers ::delete_item
+	 */
+	public function test_cancel_nonexistent_rsvp_returns_404(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$event_id = $this->create_event();
+
+		$request  = new WP_REST_Request( 'DELETE', '/groups/v1/events/' . $event_id . '/rsvp' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::mark_attendance
+	 */
+	public function test_mark_no_show(): void {
+		wp_set_current_user( $this->organizer_id );
+
+		$event_id = $this->create_event();
+		Rsvp::create( $event_id, $this->subscriber_id );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/events/' . $event_id . '/attendance' );
+		$request->set_body_params( [
+			'user_id'  => $this->subscriber_id,
+			'attended' => false,
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'no_show', $data['status'] );
+		$this->assertFalse( $data['attendance_confirmed'] );
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Groups\Models\Rsvp` model: comment-based RSVPs with waitlist promotion, attendance tracking, and duplicate prevention
- Add `Groups\REST\Rsvp_Controller` with five endpoints: list RSVPs (public), create/update/cancel RSVP (authenticated), mark attendance (organizer only)
- Add PHPUnit test suite covering permissions, waitlist logic, duplicate RSVP handling, and attendance marking
- Wire up controller registration in `class-plugin.php`

## Test plan
- [ ] Verify `GET /groups/v1/events/{id}/rsvps` returns attendees with display name, avatar URL, and status
- [ ] Verify `POST /groups/v1/events/{id}/rsvp` creates comment with `groups_rsvp` type and correct meta
- [ ] Verify anonymous users get 401 on RSVP/update/cancel endpoints
- [ ] Verify duplicate RSVP returns 409 Conflict
- [ ] Verify cancelling an attending RSVP promotes the next waitlisted user
- [ ] Verify only organizers/co-organizers can mark attendance
- [ ] Verify subscribers can RSVP but cannot mark attendance
- [ ] Run PHPUnit: `wp-env run tests-cli --env-cwd=wp-content/plugins/wordpress-groups phpunit`

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)