### PR TITLE
Venue CPT with geo fields and REST API

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -65,5 +65,8 @@ class Plugin {
 
 		$rsvp_controller = new REST\Rsvp_Controller();
 		$rsvp_controller->register_routes();
+
+		$venue_controller = new REST\Venue_Controller();
+		$venue_controller->register_routes();
 	}
 }

--- a/wp-content/plugins/wordpress-groups/includes/post-types/class-venue.php
+++ b/wp-content/plugins/wordpress-groups/includes/post-types/class-venue.php
@@ -10,7 +10,7 @@ namespace Groups\Post_Types;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Registers the `venue` CPT.
+ * Registers the `venue` CPT and its geo meta fields.
  */
 class Venue {
 
@@ -22,10 +22,29 @@ class Venue {
 	const POST_TYPE = 'venue';
 
 	/**
+	 * Meta keys for venue geo and detail fields.
+	 *
+	 * @var string[]
+	 */
+	const META_KEYS = [
+		'_venue_address',
+		'_venue_city',
+		'_venue_state',
+		'_venue_country',
+		'_venue_zip',
+		'_venue_latitude',
+		'_venue_longitude',
+		'_venue_capacity',
+		'_venue_accessibility_notes',
+		'_venue_website',
+	];
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		add_action( 'init', [ $this, 'register_post_type' ] );
+		add_action( 'init', [ $this, 'register_meta_fields' ] );
 	}
 
 	/**
@@ -70,5 +89,122 @@ class Venue {
 		];
 
 		register_post_type( self::POST_TYPE, $args );
+	}
+
+	/**
+	 * Register meta fields for REST API exposure.
+	 */
+	public function register_meta_fields(): void {
+		$string_fields = [
+			'_venue_address'             => __( 'Street address.', 'wordpress-groups' ),
+			'_venue_city'                => __( 'City.', 'wordpress-groups' ),
+			'_venue_state'               => __( 'State or province.', 'wordpress-groups' ),
+			'_venue_country'             => __( 'Country.', 'wordpress-groups' ),
+			'_venue_zip'                 => __( 'Postal / ZIP code.', 'wordpress-groups' ),
+			'_venue_accessibility_notes' => __( 'Accessibility notes for the venue.', 'wordpress-groups' ),
+			'_venue_website'             => __( 'Venue website URL.', 'wordpress-groups' ),
+		];
+
+		foreach ( $string_fields as $key => $description ) {
+			register_post_meta(
+				self::POST_TYPE,
+				$key,
+				[
+					'type'              => 'string',
+					'description'       => $description,
+					'single'            => true,
+					'show_in_rest'      => true,
+					'sanitize_callback' => '_venue_website' === $key
+						? [ self::class, 'sanitize_url' ]
+						: 'sanitize_text_field',
+					'auth_callback'     => [ self::class, 'auth_callback' ],
+				]
+			);
+		}
+
+		// Float fields: latitude and longitude.
+		register_post_meta(
+			self::POST_TYPE,
+			'_venue_latitude',
+			[
+				'type'              => 'number',
+				'description'       => __( 'Latitude (-90 to 90).', 'wordpress-groups' ),
+				'single'            => true,
+				'show_in_rest'      => true,
+				'sanitize_callback' => [ self::class, 'sanitize_latitude' ],
+				'auth_callback'     => [ self::class, 'auth_callback' ],
+			]
+		);
+
+		register_post_meta(
+			self::POST_TYPE,
+			'_venue_longitude',
+			[
+				'type'              => 'number',
+				'description'       => __( 'Longitude (-180 to 180).', 'wordpress-groups' ),
+				'single'            => true,
+				'show_in_rest'      => true,
+				'sanitize_callback' => [ self::class, 'sanitize_longitude' ],
+				'auth_callback'     => [ self::class, 'auth_callback' ],
+			]
+		);
+
+		// Integer field: capacity.
+		register_post_meta(
+			self::POST_TYPE,
+			'_venue_capacity',
+			[
+				'type'              => 'integer',
+				'description'       => __( 'Maximum capacity.', 'wordpress-groups' ),
+				'single'            => true,
+				'show_in_rest'      => true,
+				'sanitize_callback' => 'absint',
+				'auth_callback'     => [ self::class, 'auth_callback' ],
+			]
+		);
+	}
+
+	/**
+	 * Auth callback for meta fields — only organizers+ can edit.
+	 *
+	 * @param bool   $allowed Whether the user can edit the meta.
+	 * @param string $meta_key Meta key.
+	 * @param int    $post_id Post ID.
+	 * @return bool
+	 */
+	public static function auth_callback( bool $allowed, string $meta_key, int $post_id ): bool {
+		return current_user_can( 'edit_post', $post_id );
+	}
+
+	/**
+	 * Sanitize a URL value, restricting to http/https.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string Sanitized URL.
+	 */
+	public static function sanitize_url( $value ): string {
+		return esc_url_raw( (string) $value, [ 'http', 'https' ] );
+	}
+
+	/**
+	 * Sanitize latitude, clamping to -90..90.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return float
+	 */
+	public static function sanitize_latitude( $value ): float {
+		$value = (float) $value;
+		return max( -90.0, min( 90.0, $value ) );
+	}
+
+	/**
+	 * Sanitize longitude, clamping to -180..180.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return float
+	 */
+	public static function sanitize_longitude( $value ): float {
+		$value = (float) $value;
+		return max( -180.0, min( 180.0, $value ) );
 	}
 }

--- a/wp-content/plugins/wordpress-groups/includes/rest/class-venue-controller.php
+++ b/wp-content/plugins/wordpress-groups/includes/rest/class-venue-controller.php
@@ -480,7 +480,7 @@ class Venue_Controller extends WP_REST_Controller {
 
 		$data = [
 			'id'       => (int) $post->ID,
-			'title'    => esc_html( $post->post_title ),
+			'title'    => $post->post_title,
 			'content'  => wp_kses_post( $post->post_content ),
 			'status'   => esc_html( $post->post_status ),
 			'author'   => (int) $post->post_author,

--- a/wp-content/plugins/wordpress-groups/includes/rest/class-venue-controller.php
+++ b/wp-content/plugins/wordpress-groups/includes/rest/class-venue-controller.php
@@ -1,0 +1,764 @@
+<?php
+/**
+ * REST API controller for venues.
+ *
+ * @package Groups\REST
+ */
+
+namespace Groups\REST;
+
+use Groups\Post_Types\Venue;
+use WP_Error;
+use WP_Post;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles CRUD operations for the venue post type via the REST API.
+ */
+class Venue_Controller extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST routes.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'groups/v1';
+
+	/**
+	 * Base path for venue routes.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'venues';
+
+	/**
+	 * Register REST routes.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_items' ],
+					'permission_callback' => [ $this, 'get_items_permissions_check' ],
+					'args'                => $this->get_collection_params(),
+				],
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'create_item' ],
+					'permission_callback' => [ $this, 'create_item_permissions_check' ],
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args'                => [
+						'id' => [
+							'description' => __( 'Unique identifier for the venue.', 'wordpress-groups' ),
+							'type'        => 'integer',
+							'required'    => true,
+						],
+					],
+				],
+				[
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => [ $this, 'update_item' ],
+					'permission_callback' => [ $this, 'update_item_permissions_check' ],
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				],
+				[
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'delete_item' ],
+					'permission_callback' => [ $this, 'delete_item_permissions_check' ],
+					'args'                => [
+						'id' => [
+							'description' => __( 'Unique identifier for the venue.', 'wordpress-groups' ),
+							'type'        => 'integer',
+							'required'    => true,
+						],
+					],
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Check whether the current user can manage venues.
+	 *
+	 * Only organizers, co-organizers, and administrators may manage venues.
+	 *
+	 * @return bool
+	 */
+	private function can_manage_venues(): bool {
+		if ( is_super_admin() ) {
+			return true;
+		}
+
+		$user = wp_get_current_user();
+
+		if ( in_array( 'administrator', (array) $user->roles, true ) ) {
+			return true;
+		}
+
+		return in_array( 'organizer', (array) $user->roles, true )
+			|| in_array( 'co-organizer', (array) $user->roles, true );
+	}
+
+	/**
+	 * Permission check for listing venues.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true
+	 */
+	public function get_items_permissions_check( $request ): true {
+		return true;
+	}
+
+	/**
+	 * Permission check for reading a single venue.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function get_item_permissions_check( $request ) {
+		$post = get_post( absint( $request->get_param( 'id' ) ) );
+
+		if ( ! $post || Venue::POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'rest_venue_not_found',
+				__( 'Venue not found.', 'wordpress-groups' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		// Non-published venues require authorization.
+		if ( 'publish' !== $post->post_status ) {
+			if ( ! is_user_logged_in() || ! $this->can_manage_venues() ) {
+				return new WP_Error(
+					'rest_venue_not_found',
+					__( 'Venue not found.', 'wordpress-groups' ),
+					[ 'status' => 404 ]
+				);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Permission check for creating a venue.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function create_item_permissions_check( $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to create venues.', 'wordpress-groups' ),
+				[ 'status' => 401 ]
+			);
+		}
+
+		if ( ! $this->can_manage_venues() ) {
+			return new WP_Error(
+				'rest_cannot_create_venues',
+				__( 'Sorry, you are not allowed to create venues.', 'wordpress-groups' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Permission check for updating a venue.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function update_item_permissions_check( $request ) {
+		$post = get_post( absint( $request->get_param( 'id' ) ) );
+
+		if ( ! $post || Venue::POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'rest_venue_not_found',
+				__( 'Venue not found.', 'wordpress-groups' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to update venues.', 'wordpress-groups' ),
+				[ 'status' => 401 ]
+			);
+		}
+
+		if ( ! $this->can_manage_venues() ) {
+			return new WP_Error(
+				'rest_cannot_update_venues',
+				__( 'Sorry, you are not allowed to update this venue.', 'wordpress-groups' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Permission check for deleting a venue.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function delete_item_permissions_check( $request ) {
+		$post = get_post( absint( $request->get_param( 'id' ) ) );
+
+		if ( ! $post || Venue::POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'rest_venue_not_found',
+				__( 'Venue not found.', 'wordpress-groups' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to delete venues.', 'wordpress-groups' ),
+				[ 'status' => 401 ]
+			);
+		}
+
+		if ( ! $this->can_manage_venues() ) {
+			return new WP_Error(
+				'rest_cannot_delete_venues',
+				__( 'Sorry, you are not allowed to delete this venue.', 'wordpress-groups' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieve a collection of venues.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ): WP_REST_Response {
+		$args = [
+			'post_type'      => Venue::POST_TYPE,
+			'posts_per_page' => absint( $request->get_param( 'per_page' ) ) ?: 10,
+			'paged'          => absint( $request->get_param( 'page' ) ) ?: 1,
+			'orderby'        => 'title',
+			'order'          => 'ASC',
+			'post_status'    => 'publish',
+		];
+
+		// Search by keyword.
+		$search = $request->get_param( 'search' );
+		if ( $search ) {
+			$args['s'] = sanitize_text_field( $search );
+		}
+
+		// If the user can manage venues, also show drafts.
+		if ( is_user_logged_in() && $this->can_manage_venues() ) {
+			$args['post_status'] = [ 'publish', 'draft' ];
+		}
+
+		$query  = new \WP_Query( $args );
+		$venues = [];
+
+		foreach ( $query->posts as $post ) {
+			$venues[] = $this->prepare_item_for_response( $post, $request )->get_data();
+		}
+
+		$response = new WP_REST_Response( $venues, 200 );
+		$response->header( 'X-WP-Total', (int) $query->found_posts );
+		$response->header( 'X-WP-TotalPages', (int) $query->max_num_pages );
+
+		return $response;
+	}
+
+	/**
+	 * Retrieve a single venue.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_item( $request ) {
+		$post = get_post( absint( $request->get_param( 'id' ) ) );
+
+		if ( ! $post || Venue::POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'rest_venue_not_found',
+				__( 'Venue not found.', 'wordpress-groups' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		return $this->prepare_item_for_response( $post, $request );
+	}
+
+	/**
+	 * Create a venue.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ) {
+		$meta = $request->get_param( 'meta' );
+
+		if ( is_array( $meta ) ) {
+			$validation_error = $this->validate_venue_meta( $meta );
+			if ( is_wp_error( $validation_error ) ) {
+				return $validation_error;
+			}
+		}
+
+		$post_data = [
+			'post_type'    => Venue::POST_TYPE,
+			'post_title'   => sanitize_text_field( $request->get_param( 'title' ) ),
+			'post_content' => wp_kses_post( $request->get_param( 'content' ) ?? '' ),
+			'post_status'  => $this->sanitize_post_status( $request->get_param( 'status' ) ),
+			'post_author'  => get_current_user_id(),
+		];
+
+		$post_id = wp_insert_post( $post_data, true );
+
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		$this->update_venue_meta( $post_id, $request );
+
+		$post = get_post( $post_id );
+
+		$response = $this->prepare_item_for_response( $post, $request );
+		$response->set_status( 201 );
+		$response->header(
+			'Location',
+			rest_url( sprintf( '%s/%s/%d', $this->namespace, $this->rest_base, $post_id ) )
+		);
+
+		return $response;
+	}
+
+	/**
+	 * Update a venue.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_item( $request ) {
+		$post_id = absint( $request->get_param( 'id' ) );
+		$post    = get_post( $post_id );
+
+		if ( ! $post || Venue::POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'rest_venue_not_found',
+				__( 'Venue not found.', 'wordpress-groups' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		$meta = $request->get_param( 'meta' );
+
+		if ( is_array( $meta ) ) {
+			$validation_error = $this->validate_venue_meta( $meta );
+			if ( is_wp_error( $validation_error ) ) {
+				return $validation_error;
+			}
+		}
+
+		$post_data = [ 'ID' => $post_id ];
+
+		$title = $request->get_param( 'title' );
+		if ( null !== $title ) {
+			$post_data['post_title'] = sanitize_text_field( $title );
+		}
+
+		$content = $request->get_param( 'content' );
+		if ( null !== $content ) {
+			$post_data['post_content'] = wp_kses_post( $content );
+		}
+
+		$status = $request->get_param( 'status' );
+		if ( null !== $status ) {
+			$post_data['post_status'] = $this->sanitize_post_status( $status );
+		}
+
+		$result = wp_update_post( $post_data, true );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$this->update_venue_meta( $post_id, $request );
+
+		$post = get_post( $post_id );
+
+		return $this->prepare_item_for_response( $post, $request );
+	}
+
+	/**
+	 * Delete a venue (move to trash).
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ) {
+		$post_id = absint( $request->get_param( 'id' ) );
+		$post    = get_post( $post_id );
+
+		if ( ! $post || Venue::POST_TYPE !== $post->post_type ) {
+			return new WP_Error(
+				'rest_venue_not_found',
+				__( 'Venue not found.', 'wordpress-groups' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		$previous = $this->prepare_item_for_response( $post, $request );
+
+		$result = wp_trash_post( $post_id );
+
+		if ( ! $result ) {
+			return new WP_Error(
+				'rest_cannot_delete_venue',
+				__( 'The venue could not be deleted.', 'wordpress-groups' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		$response = new WP_REST_Response();
+		$response->set_data( [
+			'deleted'  => true,
+			'previous' => $previous->get_data(),
+		] );
+
+		return $response;
+	}
+
+	/**
+	 * Prepare a single venue post for the response.
+	 *
+	 * @param WP_Post         $post    Post object.
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $post, $request ): WP_REST_Response {
+		$meta = [];
+
+		foreach ( Venue::META_KEYS as $key ) {
+			$value = get_post_meta( $post->ID, $key, true );
+			// Strip the leading underscore and prefix for the public key name.
+			$public_key          = preg_replace( '/^_venue_/', '', $key );
+			$meta[ $public_key ] = $this->escape_meta_value( $key, $value );
+		}
+
+		$data = [
+			'id'       => (int) $post->ID,
+			'title'    => esc_html( $post->post_title ),
+			'content'  => wp_kses_post( $post->post_content ),
+			'status'   => esc_html( $post->post_status ),
+			'author'   => (int) $post->post_author,
+			'date'     => mysql_to_rfc3339( $post->post_date ),
+			'modified' => mysql_to_rfc3339( $post->post_modified ),
+			'link'     => esc_url( get_permalink( $post ) ),
+			'meta'     => $meta,
+		];
+
+		$response = new WP_REST_Response( $data, 200 );
+		$response->add_links( $this->prepare_links( $post ) );
+
+		return $response;
+	}
+
+	/**
+	 * Escape a meta value based on its key.
+	 *
+	 * @param string $key   Meta key.
+	 * @param mixed  $value Raw value.
+	 * @return mixed Escaped value.
+	 */
+	private function escape_meta_value( string $key, $value ) {
+		return match ( $key ) {
+			'_venue_latitude',
+			'_venue_longitude'  => (float) $value,
+			'_venue_capacity'   => absint( $value ),
+			'_venue_website'    => esc_url( $value ),
+			default             => sanitize_text_field( (string) $value ),
+		};
+	}
+
+	/**
+	 * Prepare links for the response.
+	 *
+	 * @param WP_Post $post Post object.
+	 * @return array<string, array<string, mixed>>
+	 */
+	private function prepare_links( WP_Post $post ): array {
+		$base = sprintf( '%s/%s', $this->namespace, $this->rest_base );
+
+		return [
+			'self'       => [
+				'href' => rest_url( sprintf( '%s/%d', $base, $post->ID ) ),
+			],
+			'collection' => [
+				'href' => rest_url( $base ),
+			],
+		];
+	}
+
+	/**
+	 * Validate venue meta fields.
+	 *
+	 * @param array $meta Meta values from the request.
+	 * @return true|WP_Error True on success, WP_Error on validation failure.
+	 */
+	private function validate_venue_meta( array $meta ) {
+		if ( array_key_exists( 'latitude', $meta ) && '' !== $meta['latitude'] ) {
+			$lat = (float) $meta['latitude'];
+			if ( $lat < -90.0 || $lat > 90.0 ) {
+				return new WP_Error(
+					'rest_invalid_latitude',
+					__( 'Latitude must be between -90 and 90.', 'wordpress-groups' ),
+					[ 'status' => 400 ]
+				);
+			}
+		}
+
+		if ( array_key_exists( 'longitude', $meta ) && '' !== $meta['longitude'] ) {
+			$lon = (float) $meta['longitude'];
+			if ( $lon < -180.0 || $lon > 180.0 ) {
+				return new WP_Error(
+					'rest_invalid_longitude',
+					__( 'Longitude must be between -180 and 180.', 'wordpress-groups' ),
+					[ 'status' => 400 ]
+				);
+			}
+		}
+
+		if ( array_key_exists( 'website', $meta ) && '' !== $meta['website'] ) {
+			$url = esc_url_raw( $meta['website'], [ 'http', 'https' ] );
+			if ( empty( $url ) ) {
+				return new WP_Error(
+					'rest_invalid_website',
+					__( 'Website must be a valid HTTP or HTTPS URL.', 'wordpress-groups' ),
+					[ 'status' => 400 ]
+				);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Update venue meta fields from the request.
+	 *
+	 * @param int             $post_id Post ID.
+	 * @param WP_REST_Request $request Full details about the request.
+	 */
+	private function update_venue_meta( int $post_id, WP_REST_Request $request ): void {
+		$meta = $request->get_param( 'meta' );
+
+		if ( ! is_array( $meta ) ) {
+			return;
+		}
+
+		$sanitizers = [
+			'address'             => 'sanitize_text_field',
+			'city'                => 'sanitize_text_field',
+			'state'               => 'sanitize_text_field',
+			'country'             => 'sanitize_text_field',
+			'zip'                 => 'sanitize_text_field',
+			'latitude'            => [ Venue::class, 'sanitize_latitude' ],
+			'longitude'           => [ Venue::class, 'sanitize_longitude' ],
+			'capacity'            => 'absint',
+			'accessibility_notes' => 'sanitize_text_field',
+			'website'             => [ Venue::class, 'sanitize_url' ],
+		];
+
+		foreach ( $sanitizers as $field => $sanitizer ) {
+			if ( array_key_exists( $field, $meta ) ) {
+				$meta_key = '_venue_' . $field;
+				$value    = call_user_func( $sanitizer, $meta[ $field ] );
+				update_post_meta( $post_id, $meta_key, $value );
+			}
+		}
+	}
+
+	/**
+	 * Sanitize venue post status.
+	 *
+	 * @param string|null $status Raw status.
+	 * @return string Sanitized status, defaults to draft.
+	 */
+	private function sanitize_post_status( ?string $status ): string {
+		$allowed = [ 'publish', 'draft' ];
+		$status  = sanitize_text_field( (string) $status );
+
+		if ( in_array( $status, $allowed, true ) ) {
+			return $status;
+		}
+
+		return 'draft';
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_collection_params(): array {
+		$params = parent::get_collection_params();
+
+		$params['search'] = [
+			'description' => __( 'Search venues by keyword.', 'wordpress-groups' ),
+			'type'        => 'string',
+		];
+
+		return $params;
+	}
+
+	/**
+	 * Get the venue schema for responses.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_item_schema(): array {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$this->schema = [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'venue',
+			'type'       => 'object',
+			'properties' => [
+				'id'       => [
+					'description' => __( 'Unique identifier for the venue.', 'wordpress-groups' ),
+					'type'        => 'integer',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
+				'title'    => [
+					'description' => __( 'The title for the venue.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'context'     => [ 'view', 'edit' ],
+					'required'    => true,
+				],
+				'content'  => [
+					'description' => __( 'The content / description for the venue.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'context'     => [ 'view', 'edit' ],
+				],
+				'status'   => [
+					'description' => __( 'The status of the venue.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'enum'        => [ 'publish', 'draft' ],
+					'context'     => [ 'view', 'edit' ],
+				],
+				'author'   => [
+					'description' => __( 'The ID of the author of the venue.', 'wordpress-groups' ),
+					'type'        => 'integer',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
+				'date'     => [
+					'description' => __( 'The date the venue was created, in RFC3339 format.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'format'      => 'date-time',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
+				'modified' => [
+					'description' => __( 'The date the venue was last modified, in RFC3339 format.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'format'      => 'date-time',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
+				'link'     => [
+					'description' => __( 'URL to the venue on the site.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => [ 'view' ],
+					'readonly'    => true,
+				],
+				'meta'     => [
+					'description' => __( 'Venue metadata.', 'wordpress-groups' ),
+					'type'        => 'object',
+					'context'     => [ 'view', 'edit' ],
+					'properties'  => [
+						'address'             => [
+							'description' => __( 'Street address.', 'wordpress-groups' ),
+							'type'        => 'string',
+						],
+						'city'                => [
+							'description' => __( 'City.', 'wordpress-groups' ),
+							'type'        => 'string',
+						],
+						'state'               => [
+							'description' => __( 'State or province.', 'wordpress-groups' ),
+							'type'        => 'string',
+						],
+						'country'             => [
+							'description' => __( 'Country.', 'wordpress-groups' ),
+							'type'        => 'string',
+						],
+						'zip'                 => [
+							'description' => __( 'Postal / ZIP code.', 'wordpress-groups' ),
+							'type'        => 'string',
+						],
+						'latitude'            => [
+							'description' => __( 'Latitude (-90 to 90).', 'wordpress-groups' ),
+							'type'        => 'number',
+						],
+						'longitude'           => [
+							'description' => __( 'Longitude (-180 to 180).', 'wordpress-groups' ),
+							'type'        => 'number',
+						],
+						'capacity'            => [
+							'description' => __( 'Maximum capacity.', 'wordpress-groups' ),
+							'type'        => 'integer',
+						],
+						'accessibility_notes' => [
+							'description' => __( 'Accessibility notes for the venue.', 'wordpress-groups' ),
+							'type'        => 'string',
+						],
+						'website'             => [
+							'description' => __( 'Venue website URL.', 'wordpress-groups' ),
+							'type'        => 'string',
+							'format'      => 'uri',
+						],
+					],
+				],
+			],
+		];
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/rest/test-venue-controller.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/rest/test-venue-controller.php
@@ -1,0 +1,670 @@
+<?php
+/**
+ * Tests for the Venue REST API controller.
+ *
+ * @package Groups\Tests\REST
+ */
+
+namespace Groups\Tests\REST;
+
+use Groups\Post_Types\Venue;
+use Groups\REST\Venue_Controller;
+use WP_REST_Request;
+use WP_REST_Server;
+use WP_UnitTestCase;
+
+/**
+ * @coversDefaultClass \Groups\REST\Venue_Controller
+ * @group rest-api
+ */
+class Test_Venue_Controller extends WP_UnitTestCase {
+
+	/**
+	 * REST server instance.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private WP_REST_Server $server;
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	private int $admin_id;
+
+	/**
+	 * Subscriber user ID.
+	 *
+	 * @var int
+	 */
+	private int $subscriber_id;
+
+	/**
+	 * Organizer user ID.
+	 *
+	 * @var int
+	 */
+	private int $organizer_id;
+
+	/**
+	 * Co-organizer user ID.
+	 *
+	 * @var int
+	 */
+	private int $co_organizer_id;
+
+	/**
+	 * Set up the test suite — register CPT once.
+	 */
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+
+		$venue_cpt = new Venue();
+		$venue_cpt->register_post_type();
+		$venue_cpt->register_meta_fields();
+
+		if ( ! get_role( 'organizer' ) ) {
+			add_role( 'organizer', 'Organizer', [ 'read' => true ] );
+		}
+
+		if ( ! get_role( 'co-organizer' ) ) {
+			add_role( 'co-organizer', 'Co-Organizer', [ 'read' => true ] );
+		}
+	}
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wp_rest_server;
+		$this->server = $wp_rest_server = new WP_REST_Server();
+
+		$controller = new Venue_Controller();
+		$controller->register_routes();
+
+		$this->admin_id        = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$this->subscriber_id   = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$this->organizer_id    = self::factory()->user->create( [ 'role' => 'organizer' ] );
+		$this->co_organizer_id = self::factory()->user->create( [ 'role' => 'co-organizer' ] );
+	}
+
+	/**
+	 * Tear down each test.
+	 */
+	public function tear_down(): void {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper to create a venue post with meta.
+	 *
+	 * @param array $args Optional post args.
+	 * @param array $meta Optional meta values.
+	 * @return int Post ID.
+	 */
+	private function create_venue( array $args = [], array $meta = [] ): int {
+		$defaults = [
+			'post_type'   => Venue::POST_TYPE,
+			'post_title'  => 'Test Venue',
+			'post_status' => 'publish',
+			'post_author' => $this->admin_id,
+		];
+
+		$post_id = self::factory()->post->create( array_merge( $defaults, $args ) );
+
+		$default_meta = [
+			'_venue_address'   => '123 Main St',
+			'_venue_city'      => 'Melbourne',
+			'_venue_state'     => 'VIC',
+			'_venue_country'   => 'Australia',
+			'_venue_zip'       => '3000',
+			'_venue_latitude'  => -37.8136,
+			'_venue_longitude' => 144.9631,
+		];
+
+		foreach ( array_merge( $default_meta, $meta ) as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		return $post_id;
+	}
+
+	// =========================================================================
+	// CRUD tests
+	// =========================================================================
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_get_venues_returns_venues(): void {
+		$this->create_venue( [ 'post_title' => 'Venue One' ] );
+		$this->create_venue( [ 'post_title' => 'Venue Two' ] );
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/venues' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertCount( 2, $data );
+		$this->assertSame( 2, (int) $response->get_headers()['X-WP-Total'] );
+	}
+
+	/**
+	 * @covers ::get_item
+	 */
+	public function test_get_single_venue_returns_venue_with_meta(): void {
+		$post_id = $this->create_venue(
+			[ 'post_title' => 'Library Hall' ],
+			[
+				'_venue_address'             => '456 Oak Ave',
+				'_venue_city'                => 'Sydney',
+				'_venue_state'               => 'NSW',
+				'_venue_country'             => 'Australia',
+				'_venue_zip'                 => '2000',
+				'_venue_latitude'            => -33.8688,
+				'_venue_longitude'           => 151.2093,
+				'_venue_capacity'            => 200,
+				'_venue_accessibility_notes' => 'Wheelchair accessible',
+				'_venue_website'             => 'https://library.example.com',
+			]
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/venues/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( $post_id, $data['id'] );
+		$this->assertSame( 'Library Hall', $data['title'] );
+		$this->assertSame( '456 Oak Ave', $data['meta']['address'] );
+		$this->assertSame( 'Sydney', $data['meta']['city'] );
+		$this->assertSame( 'NSW', $data['meta']['state'] );
+		$this->assertSame( 'Australia', $data['meta']['country'] );
+		$this->assertSame( '2000', $data['meta']['zip'] );
+		$this->assertEqualsWithDelta( -33.8688, $data['meta']['latitude'], 0.0001 );
+		$this->assertEqualsWithDelta( 151.2093, $data['meta']['longitude'], 0.0001 );
+		$this->assertSame( 200, $data['meta']['capacity'] );
+		$this->assertSame( 'Wheelchair accessible', $data['meta']['accessibility_notes'] );
+		$this->assertSame( 'https://library.example.com', $data['meta']['website'] );
+	}
+
+	/**
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_get_nonexistent_venue_returns_404(): void {
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/venues/999999' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::create_item
+	 */
+	public function test_create_venue_as_organizer(): void {
+		wp_set_current_user( $this->organizer_id );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/venues' );
+		$request->set_body_params( [
+			'title'   => 'Community Center',
+			'content' => 'A great space for events.',
+			'status'  => 'publish',
+			'meta'    => [
+				'address'             => '789 Elm St',
+				'city'                => 'Brisbane',
+				'state'               => 'QLD',
+				'country'             => 'Australia',
+				'zip'                 => '4000',
+				'latitude'            => -27.4698,
+				'longitude'           => 153.0251,
+				'capacity'            => 100,
+				'accessibility_notes' => 'Ramp at rear entrance',
+				'website'             => 'https://community.example.com',
+			],
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'Community Center', $data['title'] );
+		$this->assertSame( '789 Elm St', $data['meta']['address'] );
+		$this->assertSame( 'Brisbane', $data['meta']['city'] );
+		$this->assertEqualsWithDelta( -27.4698, $data['meta']['latitude'], 0.0001 );
+		$this->assertEqualsWithDelta( 153.0251, $data['meta']['longitude'], 0.0001 );
+		$this->assertSame( 100, $data['meta']['capacity'] );
+		$this->assertSame( 'Ramp at rear entrance', $data['meta']['accessibility_notes'] );
+		$this->assertSame( 'https://community.example.com', $data['meta']['website'] );
+
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Location', $headers );
+	}
+
+	/**
+	 * @covers ::create_item
+	 */
+	public function test_create_venue_with_all_meta_fields(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/venues' );
+		$request->set_body_params( [
+			'title'  => 'Full Meta Venue',
+			'status' => 'publish',
+			'meta'   => [
+				'address'             => '1 Test Rd',
+				'city'                => 'Perth',
+				'state'               => 'WA',
+				'country'             => 'Australia',
+				'zip'                 => '6000',
+				'latitude'            => -31.9505,
+				'longitude'           => 115.8605,
+				'capacity'            => 50,
+				'accessibility_notes' => 'Lift available',
+				'website'             => 'https://test.example.com',
+			],
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( '1 Test Rd', $data['meta']['address'] );
+		$this->assertSame( 'Perth', $data['meta']['city'] );
+		$this->assertSame( 'WA', $data['meta']['state'] );
+		$this->assertSame( 'Australia', $data['meta']['country'] );
+		$this->assertSame( '6000', $data['meta']['zip'] );
+		$this->assertEqualsWithDelta( -31.9505, $data['meta']['latitude'], 0.0001 );
+		$this->assertEqualsWithDelta( 115.8605, $data['meta']['longitude'], 0.0001 );
+		$this->assertSame( 50, $data['meta']['capacity'] );
+		$this->assertSame( 'Lift available', $data['meta']['accessibility_notes'] );
+		$this->assertSame( 'https://test.example.com', $data['meta']['website'] );
+	}
+
+	/**
+	 * @covers ::update_item
+	 */
+	public function test_update_venue(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = $this->create_venue( [ 'post_title' => 'Original Venue' ] );
+
+		$request = new WP_REST_Request( 'PUT', '/groups/v1/venues/' . $post_id );
+		$request->set_body_params( [
+			'title' => 'Updated Venue',
+			'meta'  => [
+				'city'      => 'Adelaide',
+				'latitude'  => -34.9285,
+				'longitude' => 138.6007,
+			],
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'Updated Venue', $data['title'] );
+		$this->assertSame( 'Adelaide', $data['meta']['city'] );
+		$this->assertEqualsWithDelta( -34.9285, $data['meta']['latitude'], 0.0001 );
+	}
+
+	/**
+	 * @covers ::delete_item
+	 */
+	public function test_delete_venue_trashes_post(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = $this->create_venue( [ 'post_title' => 'Doomed Venue' ] );
+
+		$request  = new WP_REST_Request( 'DELETE', '/groups/v1/venues/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertTrue( $data['deleted'] );
+		$this->assertSame( 'Doomed Venue', $data['previous']['title'] );
+
+		$post = get_post( $post_id );
+		$this->assertSame( 'trash', $post->post_status );
+	}
+
+	// =========================================================================
+	// Geo field validation tests
+	// =========================================================================
+
+	/**
+	 * @covers ::create_item
+	 */
+	public function test_invalid_latitude_rejected(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/venues' );
+		$request->set_body_params( [
+			'title' => 'Bad Lat Venue',
+			'meta'  => [
+				'latitude' => 91.0,
+			],
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_latitude', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @covers ::create_item
+	 */
+	public function test_negative_invalid_latitude_rejected(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/venues' );
+		$request->set_body_params( [
+			'title' => 'Bad Lat Venue',
+			'meta'  => [
+				'latitude' => -91.0,
+			],
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_latitude', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @covers ::create_item
+	 */
+	public function test_invalid_longitude_rejected(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/venues' );
+		$request->set_body_params( [
+			'title' => 'Bad Lon Venue',
+			'meta'  => [
+				'longitude' => 181.0,
+			],
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_longitude', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @covers ::create_item
+	 */
+	public function test_negative_invalid_longitude_rejected(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/venues' );
+		$request->set_body_params( [
+			'title' => 'Bad Lon Venue',
+			'meta'  => [
+				'longitude' => -181.0,
+			],
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_longitude', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @covers ::update_item
+	 */
+	public function test_invalid_latitude_rejected_on_update(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = $this->create_venue();
+
+		$request = new WP_REST_Request( 'PUT', '/groups/v1/venues/' . $post_id );
+		$request->set_body_params( [
+			'meta' => [
+				'latitude' => 95.0,
+			],
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::create_item
+	 */
+	public function test_valid_boundary_latitude_accepted(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/venues' );
+		$request->set_body_params( [
+			'title' => 'North Pole Venue',
+			'meta'  => [
+				'latitude'  => 90.0,
+				'longitude' => 0.0,
+			],
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertEqualsWithDelta( 90.0, $response->get_data()['meta']['latitude'], 0.0001 );
+	}
+
+	/**
+	 * @covers ::create_item
+	 */
+	public function test_valid_boundary_longitude_accepted(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/venues' );
+		$request->set_body_params( [
+			'title' => 'Date Line Venue',
+			'meta'  => [
+				'latitude'  => 0.0,
+				'longitude' => -180.0,
+			],
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertEqualsWithDelta( -180.0, $response->get_data()['meta']['longitude'], 0.0001 );
+	}
+
+	// =========================================================================
+	// Permission tests
+	// =========================================================================
+
+	/**
+	 * @covers ::create_item_permissions_check
+	 */
+	public function test_create_venue_rejected_for_anonymous(): void {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/venues' );
+		$request->set_body_params( [
+			'title' => 'Anonymous Venue',
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::create_item_permissions_check
+	 */
+	public function test_create_venue_rejected_for_subscribers(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/venues' );
+		$request->set_body_params( [
+			'title' => 'Subscriber Venue',
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::create_item_permissions_check
+	 * @covers ::create_item
+	 */
+	public function test_co_organizer_can_create_venue(): void {
+		wp_set_current_user( $this->co_organizer_id );
+
+		$request = new WP_REST_Request( 'POST', '/groups/v1/venues' );
+		$request->set_body_params( [
+			'title'  => 'Co-Org Venue',
+			'status' => 'publish',
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( 'Co-Org Venue', $response->get_data()['title'] );
+	}
+
+	/**
+	 * @covers ::update_item_permissions_check
+	 */
+	public function test_subscriber_cannot_update_venue(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$post_id = $this->create_venue();
+
+		$request = new WP_REST_Request( 'PUT', '/groups/v1/venues/' . $post_id );
+		$request->set_body_params( [
+			'title' => 'Hacked Venue',
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::delete_item_permissions_check
+	 */
+	public function test_subscriber_cannot_delete_venue(): void {
+		wp_set_current_user( $this->subscriber_id );
+
+		$post_id = $this->create_venue();
+
+		$request  = new WP_REST_Request( 'DELETE', '/groups/v1/venues/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_anonymous_can_list_published_venues(): void {
+		wp_set_current_user( 0 );
+
+		$this->create_venue( [ 'post_title' => 'Public Venue', 'post_status' => 'publish' ] );
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/venues' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$titles = array_column( $response->get_data(), 'title' );
+		$this->assertContains( 'Public Venue', $titles );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_anonymous_cannot_see_draft_venues_in_list(): void {
+		wp_set_current_user( 0 );
+
+		$this->create_venue( [ 'post_title' => 'Draft Venue', 'post_status' => 'draft' ] );
+		$this->create_venue( [ 'post_title' => 'Published Venue', 'post_status' => 'publish' ] );
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/venues' );
+		$response = $this->server->dispatch( $request );
+
+		$titles = array_column( $response->get_data(), 'title' );
+		$this->assertNotContains( 'Draft Venue', $titles );
+		$this->assertContains( 'Published Venue', $titles );
+	}
+
+	/**
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_anonymous_cannot_see_draft_venue(): void {
+		wp_set_current_user( 0 );
+
+		$post_id = $this->create_venue( [ 'post_status' => 'draft' ] );
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/venues/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::get_item_schema
+	 */
+	public function test_schema_includes_meta_properties(): void {
+		$controller = new Venue_Controller();
+		$schema     = $controller->get_item_schema();
+
+		$this->assertArrayHasKey( 'meta', $schema['properties'] );
+		$this->assertArrayHasKey( 'address', $schema['properties']['meta']['properties'] );
+		$this->assertArrayHasKey( 'city', $schema['properties']['meta']['properties'] );
+		$this->assertArrayHasKey( 'state', $schema['properties']['meta']['properties'] );
+		$this->assertArrayHasKey( 'country', $schema['properties']['meta']['properties'] );
+		$this->assertArrayHasKey( 'zip', $schema['properties']['meta']['properties'] );
+		$this->assertArrayHasKey( 'latitude', $schema['properties']['meta']['properties'] );
+		$this->assertArrayHasKey( 'longitude', $schema['properties']['meta']['properties'] );
+		$this->assertArrayHasKey( 'capacity', $schema['properties']['meta']['properties'] );
+		$this->assertArrayHasKey( 'accessibility_notes', $schema['properties']['meta']['properties'] );
+		$this->assertArrayHasKey( 'website', $schema['properties']['meta']['properties'] );
+	}
+
+	/**
+	 * @covers ::update_item
+	 */
+	public function test_update_nonexistent_venue_returns_404(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'PUT', '/groups/v1/venues/999999' );
+		$request->set_body_params( [
+			'title' => 'Ghost Venue',
+		] );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * @covers ::delete_item
+	 */
+	public function test_delete_nonexistent_venue_returns_404(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$request  = new WP_REST_Request( 'DELETE', '/groups/v1/venues/999999' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+	}
+}


### PR DESCRIPTION
## Summary
- Extended the `venue` CPT with geo meta fields (`_venue_address`, `_venue_city`, `_venue_state`, `_venue_country`, `_venue_zip`, `_venue_latitude`, `_venue_longitude`, `_venue_capacity`, `_venue_accessibility_notes`, `_venue_website`) registered via `register_post_meta()` with `show_in_rest => true`
- Created `Venue_Controller` REST API controller (`groups/v1/venues`) with full CRUD, lat/lon validation (-90/90, -180/180), field sanitization, and role-based permissions (organizer+ can create/edit, public can read)
- Wired the controller into `class-plugin.php`
- Added comprehensive PHPUnit tests covering CRUD, geo field validation, boundary values, and permission checks

## Test plan
- [ ] Verify venue creation via REST API with all meta fields
- [ ] Verify invalid latitude (>90 or <-90) returns 400
- [ ] Verify invalid longitude (>180 or <-180) returns 400
- [ ] Verify boundary values (90, -90, 180, -180) are accepted
- [ ] Verify anonymous users can read published venues but not drafts
- [ ] Verify subscribers cannot create/update/delete venues
- [ ] Verify organizers and co-organizers can create/update venues
- [ ] Run `phpunit` test suite for `test-venue-controller.php`

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)