### PR TITLE
Add newcomer tracking: first-event detection on RSVP creation

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/analytics/class-newcomer-tracker.php
+++ b/wp-content/plugins/wordpress-groups/includes/analytics/class-newcomer-tracker.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Newcomer tracker — first-event detection on RSVP creation.
+ *
+ * When a user RSVPs for the first time, this component flags the RSVP
+ * with `_rsvp_is_first_event` and fires the `groups_newcomer_detected`
+ * action so other subsystems (emails, analytics) can react.
+ *
+ * @package Groups\Analytics
+ */
+
+namespace Groups\Analytics;
+
+use Groups\Models\Rsvp;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Detects first-time attendees by checking attendance history across
+ * all sites in the multisite network.
+ */
+class Newcomer_Tracker {
+
+	/**
+	 * User meta key that caches whether a user has attended any event.
+	 *
+	 * @var string
+	 */
+	const HAS_ATTENDED_META = '_groups_has_attended';
+
+	/**
+	 * Register hooks.
+	 */
+	public function __construct() {
+		add_action( 'groups_rsvp_created', [ $this, 'check_newcomer' ], 10, 4 );
+	}
+
+	/**
+	 * Check whether the user who just RSVPed is a newcomer.
+	 *
+	 * Runs on the `groups_rsvp_created` action fired by the RSVP model.
+	 *
+	 * @param int    $comment_id The RSVP comment ID.
+	 * @param int    $event_id   The event post ID.
+	 * @param int    $user_id    The user ID.
+	 * @param string $status     The RSVP status (attending or waitlisted).
+	 */
+	public function check_newcomer( int $comment_id, int $event_id, int $user_id, string $status ): void {
+		if ( self::has_attended_before( $user_id ) ) {
+			return;
+		}
+
+		update_comment_meta( $comment_id, '_rsvp_is_first_event', 1 );
+
+		/**
+		 * Fires when a newcomer (first-time attendee) is detected.
+		 *
+		 * @param int $user_id    The user ID.
+		 * @param int $event_id   The event post ID.
+		 * @param int $comment_id The RSVP comment ID.
+		 */
+		do_action( 'groups_newcomer_detected', $user_id, $event_id, $comment_id );
+	}
+
+	/**
+	 * Determine whether a user has ever had a confirmed attendance.
+	 *
+	 * Checks a cached user meta flag first. If not set, performs a
+	 * cross-site query across all network sites looking for any RSVP
+	 * with `_rsvp_attendance_confirmed` = true.
+	 *
+	 * @param int $user_id The user ID.
+	 * @return bool True if the user has attended at least one event before.
+	 */
+	public static function has_attended_before( int $user_id ): bool {
+		// Fast path: check cached user meta.
+		$cached = get_user_meta( $user_id, self::HAS_ATTENDED_META, true );
+
+		if ( '1' === $cached ) {
+			return true;
+		}
+
+		// Cross-site lookup for any confirmed attendance.
+		if ( is_multisite() ) {
+			$sites = get_sites( [
+				'fields' => 'ids',
+				'number' => 0,
+			] );
+
+			foreach ( $sites as $blog_id ) {
+				switch_to_blog( $blog_id );
+
+				$found = self::has_confirmed_rsvp_on_current_site( $user_id );
+
+				restore_current_blog();
+
+				if ( $found ) {
+					// Cache the result so we never scan again for this user.
+					update_user_meta( $user_id, self::HAS_ATTENDED_META, '1' );
+					return true;
+				}
+			}
+		} else {
+			// Single-site fallback.
+			if ( self::has_confirmed_rsvp_on_current_site( $user_id ) ) {
+				update_user_meta( $user_id, self::HAS_ATTENDED_META, '1' );
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check whether the user has any RSVP with confirmed attendance on
+	 * the current site (must be called within the correct blog context).
+	 *
+	 * @param int $user_id The user ID.
+	 * @return bool
+	 */
+	private static function has_confirmed_rsvp_on_current_site( int $user_id ): bool {
+		$comments = get_comments( [
+			'user_id' => $user_id,
+			'type'    => Rsvp::COMMENT_TYPE,
+			'status'  => 'approve',
+			'number'  => 1,
+			'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				[
+					'key'   => '_rsvp_attendance_confirmed',
+					'value' => '1',
+				],
+			],
+		] );
+
+		return ! empty( $comments );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -48,6 +48,7 @@ class Plugin {
 		new Post_Types\Event();
 		new Post_Types\Venue();
 		new Blocks\Block_Registrar();
+		new Analytics\Newcomer_Tracker();
 
 		add_action( 'init', [ Models\Membership::class, 'register_roles' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/analytics/Test_Newcomer_Tracker.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/analytics/Test_Newcomer_Tracker.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Tests for the Newcomer Tracker.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Analytics\Newcomer_Tracker;
+use Groups\Models\Event;
+use Groups\Models\Rsvp;
+use Groups\Post_Types\Event as Event_Post_Type;
+
+/**
+ * @coversDefaultClass \Groups\Analytics\Newcomer_Tracker
+ */
+class Test_Newcomer_Tracker extends WP_UnitTestCase {
+
+	/**
+	 * Ensure CPTs and the tracker hook are registered.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$event_cpt = new Event_Post_Type();
+		$event_cpt->register_post_type();
+		$event_cpt->register_post_statuses();
+
+		// Ensure the tracker is listening (idempotent — the plugin already
+		// wires this up, but tests may run in isolation).
+		new Newcomer_Tracker();
+	}
+
+	/**
+	 * Helper: create an event and return its post ID.
+	 */
+	private function create_event(): int {
+		return Event::create( [
+			'title'     => 'Test Event',
+			'content'   => 'A test event.',
+			'start_utc' => '2026-06-01 18:00:00',
+			'end_utc'   => '2026-06-01 20:00:00',
+			'timezone'  => 'UTC',
+			'status'    => 'event-scheduled',
+		] );
+	}
+
+	/**
+	 * @covers ::check_newcomer
+	 */
+	public function test_first_rsvp_gets_first_event_flag(): void {
+		$user_id  = self::factory()->user->create();
+		$event_id = $this->create_event();
+
+		$comment_id = Rsvp::create( $event_id, $user_id );
+
+		$this->assertNotWPError( $comment_id );
+		$this->assertEquals( 1, get_comment_meta( $comment_id, '_rsvp_is_first_event', true ) );
+	}
+
+	/**
+	 * @covers ::check_newcomer
+	 */
+	public function test_second_rsvp_does_not_get_first_event_flag(): void {
+		$user_id   = self::factory()->user->create();
+		$event_id  = $this->create_event();
+		$event_id2 = $this->create_event();
+
+		// First RSVP — mark attendance confirmed so the user counts as
+		// having attended.
+		$first_comment = Rsvp::create( $event_id, $user_id );
+		$this->assertNotWPError( $first_comment );
+		Rsvp::mark_attendance( $event_id, $user_id, true );
+
+		// Second RSVP — should NOT be flagged as first event.
+		$second_comment = Rsvp::create( $event_id2, $user_id );
+		$this->assertNotWPError( $second_comment );
+
+		$flag = get_comment_meta( $second_comment, '_rsvp_is_first_event', true );
+		$this->assertEmpty( $flag, 'Second RSVP should not have _rsvp_is_first_event set.' );
+	}
+
+	/**
+	 * @covers ::check_newcomer
+	 */
+	public function test_newcomer_detected_action_fires(): void {
+		$user_id  = self::factory()->user->create();
+		$event_id = $this->create_event();
+		$fired    = false;
+
+		add_action(
+			'groups_newcomer_detected',
+			function ( $u_id, $e_id, $c_id ) use ( $user_id, $event_id, &$fired ) {
+				$fired = true;
+				$this->assertSame( $user_id, $u_id );
+				$this->assertSame( $event_id, $e_id );
+				$this->assertIsInt( $c_id );
+			},
+			10,
+			3
+		);
+
+		Rsvp::create( $event_id, $user_id );
+
+		$this->assertTrue( $fired, 'The groups_newcomer_detected action should have fired for a newcomer.' );
+	}
+
+	/**
+	 * @covers ::has_attended_before
+	 */
+	public function test_has_attended_before_caches_result(): void {
+		$user_id  = self::factory()->user->create();
+		$event_id = $this->create_event();
+
+		// No attendance yet.
+		$this->assertFalse( Newcomer_Tracker::has_attended_before( $user_id ) );
+
+		// Create RSVP and confirm attendance.
+		$comment_id = Rsvp::create( $event_id, $user_id );
+		Rsvp::mark_attendance( $event_id, $user_id, true );
+
+		// Clear any in-memory state by re-checking.
+		$this->assertTrue( Newcomer_Tracker::has_attended_before( $user_id ) );
+
+		// Verify the cache meta was set.
+		$this->assertSame( '1', get_user_meta( $user_id, Newcomer_Tracker::HAS_ATTENDED_META, true ) );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Newcomer_Tracker` class (`Groups\Analytics` namespace) that hooks into `groups_rsvp_created` to detect first-time attendees
- When a user has no prior confirmed attendance (`_rsvp_attendance_confirmed` = true) across any network site, sets `_rsvp_is_first_event` = 1 on the RSVP comment meta and fires `groups_newcomer_detected` action
- Caches the "has attended before" result as user meta (`_groups_has_attended`) to avoid repeated cross-site queries
- Wired into the Plugin class via `init_components()`
- Includes PHPUnit tests covering first-event flag, no-flag on second RSVP, action hook firing, and cache behavior

Closes #17

## Test plan
- [ ] Verify first RSVP for a new user gets `_rsvp_is_first_event` = 1
- [ ] Verify second RSVP after confirmed attendance does NOT get the flag
- [ ] Verify `groups_newcomer_detected` action fires for newcomers only
- [ ] Verify `_groups_has_attended` user meta is cached after attendance is confirmed
- [ ] Run PHPUnit: `phpunit --filter=Test_Newcomer_Tracker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)