### PR TITLE
Fix Test_Email_Templates PHPUnit failures

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/notifications/class-email-templates.php
+++ b/wp-content/plugins/wordpress-groups/includes/notifications/class-email-templates.php
@@ -155,7 +155,10 @@ class Email_Templates {
 			$value = (string) $value;
 
 			if ( in_array( $key, self::HTML_ALLOWED_PLACEHOLDERS, true ) ) {
-				$escaped_value = wp_kses_post( $value );
+				// Strip script/style tags and their content before sanitizing,
+				// since wp_kses_post() removes the tags but leaves inner text.
+				$sanitized = preg_replace( '/<(script|style)\b[^>]*>.*?<\/\1>/is', '', $value );
+				$escaped_value = wp_kses_post( $sanitized );
 			} else {
 				$escaped_value = esc_html( $value );
 			}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Email_Templates.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Email_Templates.php
@@ -275,7 +275,7 @@ class Test_Email_Templates extends WP_UnitTestCase {
 			$this->assertStringContainsString( '<!DOCTYPE html>', $html, "Template {$template_name} missing DOCTYPE." );
 			$this->assertStringContainsString( 'WordPress.org', $html, "Template {$template_name} missing WordPress.org branding." );
 			$this->assertStringContainsString( 'Community Groups', $html, "Template {$template_name} missing Community Groups text." );
-			$this->assertStringContainsString( 'email-preferences', $html, "Template {$template_name} missing unsubscribe link." );
+			$this->assertStringContainsString( 'Manage email preferences', $html, "Template {$template_name} missing unsubscribe link." );
 			$this->assertStringContainsString( 'prefers-color-scheme: dark', $html, "Template {$template_name} missing dark mode support." );
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixed `test_all_templates_wrapped_in_base` assertion to check for `Manage email preferences` (the actual link text in `base.html`) instead of the hyphenated `email-preferences` which does not appear in the rendered output.
- Fixed `test_html_allowed_placeholders_strip_scripts_but_keep_safe_html` by stripping `<script>` and `<style>` tags **and their content** before passing HTML-allowed placeholders through `wp_kses_post()`. Previously, `wp_kses_post()` removed the disallowed tags but preserved their inner text (e.g., `alert("xss")`).

## Test plan
- [x] Run `npx wp-env run cli --env-cwd=wp-content/plugins/wordpress-groups vendor/bin/phpunit --filter Test_Email_Templates` -- all 22 tests pass (94 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)