### PR TITLE
Fix Test_Membership_Controller PHPUnit failures

### DIFF
--- a/wp-content/plugins/wordpress-groups/tests/phpunit/rest/Test_Membership_Controller.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/rest/Test_Membership_Controller.php
@@ -8,7 +8,6 @@
 
 use Groups\Models\Membership;
 use Groups\REST\Membership_Controller;
-use WP_REST_Server;
 
 /**
  * @coversDefaultClass \Groups\REST\Membership_Controller
@@ -55,19 +54,22 @@ class Test_Membership_Controller extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Multisite tests require a multisite installation.' );
 		}
 
-		global $wp_rest_server;
-		$this->server = $wp_rest_server = new WP_REST_Server();
-
 		$this->blog_id = self::factory()->blog->create();
 
 		// Register custom roles on the test site.
 		switch_to_blog( $this->blog_id );
 		Membership::register_roles();
-
-		$controller = new Membership_Controller();
-		$controller->register_routes();
-
 		restore_current_blog();
+
+		// Boot the REST server via the rest_api_init action so routes are registered properly.
+		add_action( 'rest_api_init', static function () {
+			$controller = new Membership_Controller();
+			$controller->register_routes();
+		} );
+
+		global $wp_rest_server;
+		$this->server = $wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init', $this->server );
 
 		// Create users.
 		$this->user_id      = self::factory()->user->create( [ 'display_name' => 'Test User' ] );


### PR DESCRIPTION
## Summary
- Register Membership_Controller REST routes via the `rest_api_init` action hook instead of calling `register_routes()` directly, which triggered a `_doing_it_wrong` notice that `WP_UnitTestCase` treats as a test failure.
- Remove the no-op `use WP_REST_Server` statement (the test file has no namespace, so the import had no effect and produced a PHP warning).
- All 14 tests now pass locally.

## Test plan
- [x] Run `npx wp-env run cli --env-cwd=wp-content/plugins/wordpress-groups vendor/bin/phpunit --filter Test_Membership_Controller` and verify all 14 tests pass.
- [ ] Verify no regressions in the full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)