### PR TITLE
Add location-based search using Haversine queries

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/models/class-location-query.php
+++ b/wp-content/plugins/wordpress-groups/includes/models/class-location-query.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Location-based search using the Haversine formula.
+ *
+ * @package Groups\Models
+ */
+
+namespace Groups\Models;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Queries posts by geographic proximity using Haversine distance calculation.
+ */
+class Location_Query {
+
+	/**
+	 * Earth's mean radius in kilometres.
+	 *
+	 * @var float
+	 */
+	const EARTH_RADIUS_KM = 6371.0;
+
+	/**
+	 * Meta key mappings for supported post types.
+	 *
+	 * @var array<string, array{lat: string, lon: string}>
+	 */
+	const META_KEYS = [
+		'wp_meetup' => [
+			'lat' => '_meetup_latitude',
+			'lon' => '_meetup_longitude',
+		],
+		'venue' => [
+			'lat' => '_venue_latitude',
+			'lon' => '_venue_longitude',
+		],
+	];
+
+	/**
+	 * Find posts within a given radius of a geographic point.
+	 *
+	 * Uses the Haversine formula in SQL to calculate the great-circle
+	 * distance between two points on the Earth's surface.
+	 *
+	 * @param float $lat       Latitude of the search origin (-90 to 90).
+	 * @param float $lon       Longitude of the search origin (-180 to 180).
+	 * @param float $radius_km Search radius in kilometres.
+	 * @param array $args {
+	 *     Optional arguments.
+	 *
+	 *     @type string $post_type   Post type to query. Default 'venue'.
+	 *                               Accepts 'venue' or 'wp_meetup'.
+	 *     @type string $post_status Post status to filter by. Default 'publish'.
+	 *     @type int    $limit       Maximum number of results. Default 50.
+	 * }
+	 * @return object[]|\WP_Error Array of post objects with a `distance` property
+	 *                            (in km), ordered by distance ascending, or WP_Error
+	 *                            on invalid arguments.
+	 */
+	public static function find_nearby( float $lat, float $lon, float $radius_km, array $args = [] ): array|\WP_Error {
+		global $wpdb;
+
+		// Validate coordinates.
+		if ( $lat < -90.0 || $lat > 90.0 ) {
+			return new \WP_Error(
+				'invalid_latitude',
+				__( 'Latitude must be between -90 and 90.', 'wordpress-groups' )
+			);
+		}
+
+		if ( $lon < -180.0 || $lon > 180.0 ) {
+			return new \WP_Error(
+				'invalid_longitude',
+				__( 'Longitude must be between -180 and 180.', 'wordpress-groups' )
+			);
+		}
+
+		if ( $radius_km <= 0.0 ) {
+			return new \WP_Error(
+				'invalid_radius',
+				__( 'Radius must be a positive number.', 'wordpress-groups' )
+			);
+		}
+
+		$post_type   = $args['post_type'] ?? 'venue';
+		$post_status = $args['post_status'] ?? 'publish';
+		$limit       = isset( $args['limit'] ) ? absint( $args['limit'] ) : 50;
+
+		if ( ! isset( self::META_KEYS[ $post_type ] ) ) {
+			return new \WP_Error(
+				'unsupported_post_type',
+				sprintf(
+					/* translators: %s: post type name */
+					__( 'Location queries are not supported for the "%s" post type.', 'wordpress-groups' ),
+					$post_type
+				)
+			);
+		}
+
+		$lat_key = self::META_KEYS[ $post_type ]['lat'];
+		$lon_key = self::META_KEYS[ $post_type ]['lon'];
+
+		/*
+		 * Haversine formula:
+		 *   d = R * acos(
+		 *       cos(radians(lat1)) * cos(radians(lat2)) *
+		 *       cos(radians(lon2) - radians(lon1)) +
+		 *       sin(radians(lat1)) * sin(radians(lat2))
+		 *   )
+		 *
+		 * We use %f for all float parameters in $wpdb->prepare().
+		 */
+		$haversine = sprintf(
+			'( %f * ACOS( LEAST( 1, COS( RADIANS(%%f) ) * COS( RADIANS( lat_meta.meta_value ) ) * COS( RADIANS( lon_meta.meta_value ) - RADIANS(%%f) ) + SIN( RADIANS(%%f) ) * SIN( RADIANS( lat_meta.meta_value ) ) ) ) )',
+			self::EARTH_RADIUS_KM
+		);
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$sql = $wpdb->prepare(
+			"SELECT p.*, {$haversine} AS distance
+			FROM {$wpdb->posts} p
+			INNER JOIN {$wpdb->postmeta} lat_meta
+				ON p.ID = lat_meta.post_id AND lat_meta.meta_key = %s
+			INNER JOIN {$wpdb->postmeta} lon_meta
+				ON p.ID = lon_meta.post_id AND lon_meta.meta_key = %s
+			WHERE p.post_type = %s
+				AND p.post_status = %s
+				AND lat_meta.meta_value != ''
+				AND lon_meta.meta_value != ''
+			HAVING distance <= %f
+			ORDER BY distance ASC
+			LIMIT %d",
+			$lat,
+			$lon,
+			$lat,
+			$lat_key,
+			$lon_key,
+			$post_type,
+			$post_status,
+			$radius_km,
+			$limit
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is fully prepared above.
+		$results = $wpdb->get_results( $sql );
+
+		if ( null === $results ) {
+			return new \WP_Error(
+				'query_failed',
+				__( 'Location query failed.', 'wordpress-groups' )
+			);
+		}
+
+		// Cast distance to float for each result.
+		foreach ( $results as $result ) {
+			$result->distance = (float) $result->distance;
+		}
+
+		return $results;
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/models/Test_Location_Query.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/models/Test_Location_Query.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * Tests for the Location_Query model.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Models\Location_Query;
+use Groups\Post_Types\Venue;
+
+/**
+ * @coversDefaultClass \Groups\Models\Location_Query
+ */
+class Test_Location_Query extends WP_UnitTestCase {
+
+	/**
+	 * Register the venue CPT before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$venue_cpt = new Venue();
+		$venue_cpt->register_post_type();
+		$venue_cpt->register_meta_fields();
+	}
+
+	/**
+	 * Helper: create a venue post with lat/lon meta.
+	 *
+	 * @param string $title     Venue title.
+	 * @param float  $latitude  Latitude.
+	 * @param float  $longitude Longitude.
+	 * @return int Post ID.
+	 */
+	private function create_venue( string $title, float $latitude, float $longitude ): int {
+		$post_id = $this->factory()->post->create(
+			[
+				'post_type'   => 'venue',
+				'post_title'  => $title,
+				'post_status' => 'publish',
+			]
+		);
+
+		update_post_meta( $post_id, '_venue_latitude', $latitude );
+		update_post_meta( $post_id, '_venue_longitude', $longitude );
+
+		return $post_id;
+	}
+
+	/**
+	 * Helper: create a wp_meetup post with lat/lon meta.
+	 *
+	 * @param string $title     Post title.
+	 * @param float  $latitude  Latitude.
+	 * @param float  $longitude Longitude.
+	 * @return int Post ID.
+	 */
+	private function create_meetup( string $title, float $latitude, float $longitude ): int {
+		$post_id = $this->factory()->post->create(
+			[
+				'post_type'   => 'wp_meetup',
+				'post_title'  => $title,
+				'post_status' => 'publish',
+			]
+		);
+
+		update_post_meta( $post_id, '_meetup_latitude', $latitude );
+		update_post_meta( $post_id, '_meetup_longitude', $longitude );
+
+		return $post_id;
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_finds_venues_within_radius(): void {
+		// Melbourne: -37.8136, 144.9631
+		$this->create_venue( 'Melbourne Venue', -37.8136, 144.9631 );
+
+		// Geelong: ~75 km from Melbourne.
+		$this->create_venue( 'Geelong Venue', -38.1499, 144.3617 );
+
+		$results = Location_Query::find_nearby( -37.8136, 144.9631, 100.0 );
+
+		$this->assertNotWPError( $results );
+		$this->assertCount( 2, $results );
+
+		$titles = wp_list_pluck( $results, 'post_title' );
+		$this->assertContains( 'Melbourne Venue', $titles );
+		$this->assertContains( 'Geelong Venue', $titles );
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_excludes_venues_outside_radius(): void {
+		// Melbourne.
+		$this->create_venue( 'Melbourne Venue', -37.8136, 144.9631 );
+
+		// Sydney: ~714 km from Melbourne.
+		$this->create_venue( 'Sydney Venue', -33.8688, 151.2093 );
+
+		// Search 100 km around Melbourne — Sydney should be excluded.
+		$results = Location_Query::find_nearby( -37.8136, 144.9631, 100.0 );
+
+		$this->assertNotWPError( $results );
+		$this->assertCount( 1, $results );
+		$this->assertSame( 'Melbourne Venue', $results[0]->post_title );
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_results_ordered_by_distance_ascending(): void {
+		// Melbourne.
+		$this->create_venue( 'Melbourne Venue', -37.8136, 144.9631 );
+
+		// Geelong: ~75 km.
+		$this->create_venue( 'Geelong Venue', -38.1499, 144.3617 );
+
+		// Sydney: ~714 km.
+		$this->create_venue( 'Sydney Venue', -33.8688, 151.2093 );
+
+		// Search 1000 km from Melbourne — all three should appear.
+		$results = Location_Query::find_nearby( -37.8136, 144.9631, 1000.0 );
+
+		$this->assertNotWPError( $results );
+		$this->assertCount( 3, $results );
+
+		// Distance should increase: Melbourne (0) < Geelong (~75) < Sydney (~714).
+		$this->assertSame( 'Melbourne Venue', $results[0]->post_title );
+		$this->assertSame( 'Geelong Venue', $results[1]->post_title );
+		$this->assertSame( 'Sydney Venue', $results[2]->post_title );
+
+		// Verify distances are actually ascending.
+		$this->assertLessThan( $results[1]->distance, $results[0]->distance );
+		$this->assertLessThan( $results[2]->distance, $results[1]->distance );
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_known_distance_melbourne_to_sydney(): void {
+		// Melbourne.
+		$this->create_venue( 'Melbourne Venue', -37.8136, 144.9631 );
+
+		// Sydney.
+		$this->create_venue( 'Sydney Venue', -33.8688, 151.2093 );
+
+		// Search from Melbourne with a large radius to get Sydney.
+		$results = Location_Query::find_nearby( -37.8136, 144.9631, 1000.0 );
+
+		$this->assertNotWPError( $results );
+
+		// Find the Sydney result.
+		$sydney = null;
+		foreach ( $results as $result ) {
+			if ( 'Sydney Venue' === $result->post_title ) {
+				$sydney = $result;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $sydney, 'Sydney venue should be found.' );
+
+		// Haversine distance Melbourne-Sydney is approximately 714 km.
+		// Allow a tolerance of 20 km for floating-point precision.
+		$this->assertEqualsWithDelta( 714.0, $sydney->distance, 20.0 );
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_distance_property_is_float(): void {
+		$this->create_venue( 'Test Venue', -37.8136, 144.9631 );
+
+		$results = Location_Query::find_nearby( -37.8136, 144.9631, 10.0 );
+
+		$this->assertNotWPError( $results );
+		$this->assertCount( 1, $results );
+		$this->assertIsFloat( $results[0]->distance );
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_respects_limit_argument(): void {
+		$this->create_venue( 'Venue A', -37.8136, 144.9631 );
+		$this->create_venue( 'Venue B', -37.8200, 144.9700 );
+		$this->create_venue( 'Venue C', -37.8300, 144.9800 );
+
+		$results = Location_Query::find_nearby( -37.8136, 144.9631, 100.0, [ 'limit' => 2 ] );
+
+		$this->assertNotWPError( $results );
+		$this->assertCount( 2, $results );
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_filters_by_post_status(): void {
+		$this->create_venue( 'Published Venue', -37.8136, 144.9631 );
+
+		// Create a draft venue.
+		$draft_id = $this->factory()->post->create(
+			[
+				'post_type'   => 'venue',
+				'post_title'  => 'Draft Venue',
+				'post_status' => 'draft',
+			]
+		);
+		update_post_meta( $draft_id, '_venue_latitude', -37.8200 );
+		update_post_meta( $draft_id, '_venue_longitude', 144.9700 );
+
+		// Default status is publish — draft should be excluded.
+		$results = Location_Query::find_nearby( -37.8136, 144.9631, 100.0 );
+
+		$this->assertNotWPError( $results );
+		$this->assertCount( 1, $results );
+		$this->assertSame( 'Published Venue', $results[0]->post_title );
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_queries_wp_meetup_post_type(): void {
+		// Register wp_meetup CPT for this test.
+		register_post_type( 'wp_meetup', [ 'public' => true ] );
+
+		$this->create_meetup( 'Melbourne Group', -37.8136, 144.9631 );
+		$this->create_meetup( 'Sydney Group', -33.8688, 151.2093 );
+
+		// Search meetups near Melbourne.
+		$results = Location_Query::find_nearby(
+			-37.8136,
+			144.9631,
+			100.0,
+			[ 'post_type' => 'wp_meetup' ]
+		);
+
+		$this->assertNotWPError( $results );
+		$this->assertCount( 1, $results );
+		$this->assertSame( 'Melbourne Group', $results[0]->post_title );
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_returns_empty_array_when_no_matches(): void {
+		// Create venue far from search point.
+		$this->create_venue( 'Far Away', 40.7128, -74.0060 ); // New York City.
+
+		// Search near Melbourne.
+		$results = Location_Query::find_nearby( -37.8136, 144.9631, 100.0 );
+
+		$this->assertNotWPError( $results );
+		$this->assertIsArray( $results );
+		$this->assertCount( 0, $results );
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_invalid_latitude_returns_error(): void {
+		$result = Location_Query::find_nearby( 91.0, 144.9631, 100.0 );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_latitude', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_invalid_longitude_returns_error(): void {
+		$result = Location_Query::find_nearby( -37.8136, 181.0, 100.0 );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_longitude', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_invalid_radius_returns_error(): void {
+		$result = Location_Query::find_nearby( -37.8136, 144.9631, 0.0 );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_radius', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_unsupported_post_type_returns_error(): void {
+		$result = Location_Query::find_nearby( -37.8136, 144.9631, 100.0, [ 'post_type' => 'page' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'unsupported_post_type', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::find_nearby
+	 */
+	public function test_venues_without_coordinates_excluded(): void {
+		$this->create_venue( 'With Coords', -37.8136, 144.9631 );
+
+		// Create venue without coordinates.
+		$this->factory()->post->create(
+			[
+				'post_type'   => 'venue',
+				'post_title'  => 'No Coords',
+				'post_status' => 'publish',
+			]
+		);
+
+		$results = Location_Query::find_nearby( -37.8136, 144.9631, 100.0 );
+
+		$this->assertNotWPError( $results );
+		$this->assertCount( 1, $results );
+		$this->assertSame( 'With Coords', $results[0]->post_title );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Location_Query` model (`Groups\Models`) with `find_nearby()` static method for geographic proximity search
- Uses the Haversine formula in SQL to calculate great-circle distance between coordinates
- Supports both `venue` (per-site) and `wp_meetup` (central tracker) post types with their respective lat/lon meta keys
- Returns post objects with a `distance` property (in km), ordered by proximity ascending
- Accepts configurable `post_type`, `post_status`, and `limit` arguments
- All SQL queries use `$wpdb->prepare()` for safety

## Test plan
- [x] PHPUnit tests for finding venues within radius
- [x] PHPUnit tests for excluding venues outside radius
- [x] PHPUnit tests for results ordered by distance ascending
- [x] PHPUnit test with known coordinates (Melbourne to Sydney ~714km)
- [x] PHPUnit tests for limit, post_status filtering, wp_meetup post type
- [x] PHPUnit tests for input validation (invalid lat/lon/radius, unsupported post type)
- [x] PHPUnit test for venues without coordinates being excluded

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)