### PR TITLE
Theme: groups-directory with front-page discovery layout

### DIFF
--- a/wp-content/themes/groups-directory/functions.php
+++ b/wp-content/themes/groups-directory/functions.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Groups Directory theme functions.
+ *
+ * @package Groups_Directory
+ */
+
+defined( 'ABSPATH' ) || exit;

--- a/wp-content/themes/groups-directory/parts/footer.html
+++ b/wp-content/themes/groups-directory/parts/footer.html
@@ -1,0 +1,15 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"charcoal-2","textColor":"white","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-white-color has-charcoal-2-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
+	<div class="wp-block-group">
+		<!-- wp:paragraph {"fontSize":"small"} -->
+		<p class="has-small-font-size">Powered by <a href="https://wordpress.org/">WordPress.org</a></p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph {"fontSize":"small"} -->
+		<p class="has-small-font-size"><a href="https://wordpress.org/about/privacy/">Privacy</a> · <a href="https://www.wordpress.org/about/license/">License</a></p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-content/themes/groups-directory/parts/header.html
+++ b/wp-content/themes/groups-directory/parts/header.html
@@ -1,0 +1,19 @@
+<!-- wp:html -->
+<a class="skip-link screen-reader-text" href="#main">Skip to content</a>
+<!-- /wp:html -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-white-background-color has-background" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
+	<div class="wp-block-group">
+		<!-- wp:site-title /-->
+
+		<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right"}} -->
+			<!-- wp:navigation-link {"label":"Groups","url":"/","kind":"custom"} /-->
+			<!-- wp:navigation-link {"label":"Events","url":"/events/","kind":"custom"} /-->
+			<!-- wp:navigation-link {"label":"Apply","url":"/apply/","kind":"custom"} /-->
+		<!-- /wp:navigation -->
+	</div>
+	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/wp-content/themes/groups-directory/patterns/group-grid.php
+++ b/wp-content/themes/groups-directory/patterns/group-grid.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Title: Group Grid
+ * Slug: groups-directory/group-grid
+ * Categories: featured
+ * Description: A grid of featured WordPress community groups.
+ */
+?>
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:heading {"textAlign":"center","level":2,"fontSize":"heading-2","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
+	<h2 class="wp-block-heading has-text-align-center has-heading-2-font-size" style="margin-bottom:var(--wp--preset--spacing--40)">Featured Groups</h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:groups/group-directory /-->
+
+</div>
+<!-- /wp:group -->

--- a/wp-content/themes/groups-directory/patterns/group-hero.php
+++ b/wp-content/themes/groups-directory/patterns/group-hero.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Title: Group Hero
+ * Slug: groups-directory/group-hero
+ * Categories: featured
+ * Description: Hero section with heading, description, and search bar for the groups directory.
+ */
+?>
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"blueberry-4","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-blueberry-4-background-color has-background" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:heading {"textAlign":"center","level":1,"fontSize":"heading-1"} -->
+	<h1 class="wp-block-heading has-text-align-center has-heading-1-font-size">Find your local WordPress community</h1>
+	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"align":"center","fontSize":"large","textColor":"charcoal-3"} -->
+	<p class="has-text-align-center has-charcoal-3-color has-text-color has-large-font-size">Join one of hundreds of WordPress groups around the world for meetups, workshops, and learning opportunities.</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:search {"label":"Search groups","showLabel":false,"placeholder":"Search by city, country, or group name\u2026","buttonText":"Search","width":75,"widthUnit":"%","align":"center"} /-->
+
+</div>
+<!-- /wp:group -->

--- a/wp-content/themes/groups-directory/style.css
+++ b/wp-content/themes/groups-directory/style.css
@@ -1,0 +1,13 @@
+/*
+Theme Name: Groups Directory
+Theme URI: https://events.wordpress.org/
+Description: Block theme for the WordPress community groups directory. Provides discovery, search, and group directory layouts for the central site.
+Version: 0.1.0
+Requires at least: 6.7
+Requires PHP: 8.3
+Author: WordPress.org Meta Team
+Author URI: https://make.wordpress.org/meta/
+License: GNU General Public License v2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: groups-directory
+*/

--- a/wp-content/themes/groups-directory/templates/404.html
+++ b/wp-content/themes/groups-directory/templates/404.html
@@ -1,0 +1,19 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:heading {"level":1,"fontSize":"heading-1","textAlign":"center"} -->
+	<h1 class="wp-block-heading has-text-align-center has-heading-1-font-size">Page Not Found</h1>
+	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"align":"center","textColor":"charcoal-4"} -->
+	<p class="has-text-align-center has-charcoal-4-color has-text-color">The page you are looking for does not exist. It may have been moved or deleted.</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search groups and events\u2026","buttonText":"Search","buttonUseIcon":true,"align":"center"} /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp-content/themes/groups-directory/templates/archive-wp_meetup.html
+++ b/wp-content/themes/groups-directory/templates/archive-wp_meetup.html
@@ -1,0 +1,25 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:heading {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} -->
+	<h1 class="wp-block-heading has-heading-1-font-size" style="margin-bottom:var(--wp--preset--spacing--20)">WordPress Groups Directory</h1>
+	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"textColor":"charcoal-4","fontSize":"large"} -->
+	<p class="has-charcoal-4-color has-text-color has-large-font-size">Browse all active WordPress community groups worldwide.</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:search {"label":"Search groups","showLabel":false,"placeholder":"Search groups\u2026","buttonText":"Search","buttonUseIcon":true} /-->
+
+	<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
+	<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+
+	<!-- wp:groups/group-directory /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp-content/themes/groups-directory/templates/front-page.html
+++ b/wp-content/themes/groups-directory/templates/front-page.html
@@ -1,0 +1,71 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group" id="main">
+
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"blueberry-4","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull has-blueberry-4-background-color has-background" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:heading {"textAlign":"center","level":1,"fontSize":"heading-1"} -->
+		<h1 class="wp-block-heading has-text-align-center has-heading-1-font-size">Find your local WordPress community</h1>
+		<!-- /wp:heading -->
+
+		<!-- wp:paragraph {"align":"center","fontSize":"large","textColor":"charcoal-3"} -->
+		<p class="has-text-align-center has-charcoal-3-color has-text-color has-large-font-size">Join one of hundreds of WordPress groups around the world for meetups, workshops, and learning opportunities.</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:search {"label":"Search groups","showLabel":false,"placeholder":"Search by city, country, or group name\u2026","buttonText":"Search","width":75,"widthUnit":"%","align":"center"} /-->
+
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:heading {"textAlign":"center","level":2,"fontSize":"heading-2","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
+		<h2 class="wp-block-heading has-text-align-center has-heading-2-font-size" style="margin-bottom:var(--wp--preset--spacing--40)">Featured Groups</h2>
+		<!-- /wp:heading -->
+
+		<!-- wp:groups/group-directory /-->
+
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"light-grey-2","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull has-light-grey-2-background-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:heading {"textAlign":"center","level":2,"fontSize":"heading-2","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
+		<h2 class="wp-block-heading has-text-align-center has-heading-2-font-size" style="margin-bottom:var(--wp--preset--spacing--40)">Upcoming Events</h2>
+		<!-- /wp:heading -->
+
+		<!-- wp:groups/event-directory /-->
+
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
+
+		<!-- wp:heading {"textAlign":"center","level":2,"fontSize":"heading-2","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} -->
+		<h2 class="wp-block-heading has-text-align-center has-heading-2-font-size" style="margin-bottom:var(--wp--preset--spacing--20)">Start a WordPress Group</h2>
+		<!-- /wp:heading -->
+
+		<!-- wp:paragraph {"align":"center","textColor":"charcoal-4","fontSize":"large"} -->
+		<p class="has-text-align-center has-charcoal-4-color has-text-color has-large-font-size">No WordPress group in your area? Start one and help grow the community.</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+		<div class="wp-block-buttons">
+			<!-- wp:button -->
+			<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/apply/">Apply to Start a Group</a></div>
+			<!-- /wp:button -->
+		</div>
+		<!-- /wp:buttons -->
+
+	</div>
+	<!-- /wp:group -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp-content/themes/groups-directory/templates/index.html
+++ b/wp-content/themes/groups-directory/templates/index.html
@@ -1,0 +1,28 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date"}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template -->
+			<!-- wp:post-title {"isLink":true} /-->
+			<!-- wp:post-excerpt /-->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:paragraph -->
+			<p>No content found.</p>
+			<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp-content/themes/groups-directory/templates/page-apply.html
+++ b/wp-content/themes/groups-directory/templates/page-apply.html
@@ -1,0 +1,23 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:heading {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} -->
+	<h1 class="wp-block-heading has-heading-1-font-size" style="margin-bottom:var(--wp--preset--spacing--20)">Start a WordPress Group</h1>
+	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"textColor":"charcoal-4","fontSize":"large"} -->
+	<p class="has-charcoal-4-color has-text-color has-large-font-size">Apply to start a new WordPress community group in your area. Our team will review your application and help you get started.</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
+	<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+
+	<!-- wp:groups/application-form /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp-content/themes/groups-directory/templates/page-deputy-dashboard.html
+++ b/wp-content/themes/groups-directory/templates/page-deputy-dashboard.html
@@ -1,0 +1,23 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1160px"}} -->
+<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:heading {"level":1,"fontSize":"heading-1","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"}}}} -->
+	<h1 class="wp-block-heading has-heading-1-font-size" style="margin-bottom:var(--wp--preset--spacing--20)">Deputy Dashboard</h1>
+	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"textColor":"charcoal-4"} -->
+	<p class="has-charcoal-4-color has-text-color">Manage group applications, monitor active groups, and review network-wide analytics.</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
+	<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+
+	<!-- wp:groups/deputy-dashboard /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp-content/themes/groups-directory/templates/search.html
+++ b/wp-content/themes/groups-directory/templates/search.html
@@ -1,0 +1,38 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:query-title {"type":"search","fontSize":"heading-1"} /-->
+
+	<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search groups and events\u2026","buttonText":"Search","buttonUseIcon":true} /-->
+
+	<!-- wp:spacer {"height":"var:preset|spacing|30"} -->
+	<div style="height:var(--wp--preset--spacing--30)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+
+	<!-- wp:query {"queryId":4,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"relevance","search":""}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template -->
+			<!-- wp:post-title {"isLink":true,"fontSize":"heading-4"} /-->
+			<!-- wp:post-excerpt {"moreText":"Continue reading"} /-->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:paragraph {"textColor":"charcoal-4"} -->
+			<p class="has-charcoal-4-color has-text-color">No results found. Try a different search term.</p>
+			<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:query -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp-content/themes/groups-directory/templates/single-wp_meetup.html
+++ b/wp-content/themes/groups-directory/templates/single-wp_meetup.html
@@ -1,0 +1,55 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+
+	<!-- wp:post-title {"level":1,"fontSize":"heading-1"} /-->
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10","margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
+	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40)">
+		<!-- wp:post-terms {"term":"category","fontSize":"small","textColor":"charcoal-4"} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:heading {"level":2,"fontSize":"heading-3"} -->
+		<h2 class="wp-block-heading has-heading-3-font-size">About This Group</h2>
+		<!-- /wp:heading -->
+
+		<!-- wp:post-content /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:heading {"level":2,"fontSize":"heading-3"} -->
+		<h2 class="wp-block-heading has-heading-3-font-size">Upcoming Events</h2>
+		<!-- /wp:heading -->
+
+		<!-- wp:groups/upcoming-events /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40)">
+		<!-- wp:heading {"level":2,"fontSize":"heading-3"} -->
+		<h2 class="wp-block-heading has-heading-3-font-size">Group Stats</h2>
+		<!-- /wp:heading -->
+
+		<!-- wp:groups/group-stats /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:buttons -->
+	<div class="wp-block-buttons">
+		<!-- wp:button -->
+		<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Visit Group Site</a></div>
+		<!-- /wp:button -->
+	</div>
+	<!-- /wp:buttons -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/wp-content/themes/groups-directory/theme.json
+++ b/wp-content/themes/groups-directory/theme.json
@@ -1,0 +1,459 @@
+{
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
+	"version": 3,
+	"settings": {
+		"appearanceTools": true,
+		"color": {
+			"gradients": [],
+			"palette": [
+				{
+					"slug": "charcoal-0",
+					"color": "#1a1919",
+					"name": "Charcoal 0"
+				},
+				{
+					"slug": "charcoal-1",
+					"color": "#1e1e1e",
+					"name": "Charcoal"
+				},
+				{
+					"slug": "charcoal-2",
+					"color": "#23282d",
+					"name": "Charcoal 2"
+				},
+				{
+					"slug": "charcoal-3",
+					"color": "#40464d",
+					"name": "Charcoal 3"
+				},
+				{
+					"slug": "charcoal-4",
+					"color": "#656a71",
+					"name": "Charcoal 4"
+				},
+				{
+					"slug": "charcoal-5",
+					"color": "#979aa1",
+					"name": "Charcoal 5"
+				},
+				{
+					"slug": "light-grey-1",
+					"color": "#d9d9d9",
+					"name": "Light Grey"
+				},
+				{
+					"slug": "light-grey-2",
+					"color": "#f6f6f6",
+					"name": "Light Grey 2"
+				},
+				{
+					"slug": "white",
+					"color": "#ffffff",
+					"name": "White"
+				},
+				{
+					"slug": "white-opacity-15",
+					"color": "#ffffff26",
+					"name": "White 15%"
+				},
+				{
+					"slug": "black-opacity-15",
+					"color": "#00000026",
+					"name": "Black 15%"
+				},
+				{
+					"slug": "dark-blueberry",
+					"color": "#1d35b4",
+					"name": "Dark Blueberry"
+				},
+				{
+					"slug": "deep-blueberry",
+					"color": "#213fd4",
+					"name": "Deep Blueberry"
+				},
+				{
+					"slug": "blueberry-1",
+					"color": "#3858e9",
+					"name": "Blueberry"
+				},
+				{
+					"slug": "blueberry-2",
+					"color": "#9fb1ff",
+					"name": "Blueberry 2"
+				},
+				{
+					"slug": "blueberry-3",
+					"color": "#c7d1ff",
+					"name": "Blueberry 3"
+				},
+				{
+					"slug": "blueberry-4",
+					"color": "#eff2ff",
+					"name": "Blueberry 4"
+				},
+				{
+					"slug": "pomegrade-1",
+					"color": "#e26f56",
+					"name": "Pomegrade"
+				},
+				{
+					"slug": "pomegrade-2",
+					"color": "#ffb7a7",
+					"name": "Pomegrade 2"
+				},
+				{
+					"slug": "pomegrade-3",
+					"color": "#ffe9de",
+					"name": "Pomegrade 3"
+				},
+				{
+					"slug": "acid-green-1",
+					"color": "#33f078",
+					"name": "Acid Green"
+				},
+				{
+					"slug": "acid-green-2",
+					"color": "#c7ffdb",
+					"name": "Acid Green 2"
+				},
+				{
+					"slug": "acid-green-3",
+					"color": "#e2ffed",
+					"name": "Acid Green 3"
+				},
+				{
+					"slug": "lemon-1",
+					"color": "#fff972",
+					"name": "Lemon"
+				},
+				{
+					"slug": "lemon-2",
+					"color": "#fffcb5",
+					"name": "Lemon 2"
+				},
+				{
+					"slug": "lemon-3",
+					"color": "#fffdd6",
+					"name": "Lemon 3"
+				}
+			]
+		},
+		"typography": {
+			"fluid": true,
+			"fontFamilies": [
+				{
+					"fontFamily": "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+					"name": "Inter",
+					"slug": "inter"
+				},
+				{
+					"fontFamily": "'EB Garamond', serif",
+					"name": "EB Garamond",
+					"slug": "eb-garamond"
+				},
+				{
+					"fontFamily": "'IBM Plex Mono', monospace",
+					"name": "IBM Plex Mono",
+					"slug": "ibm-plex-mono"
+				}
+			],
+			"fontSizes": [
+				{
+					"name": "Extra Small",
+					"size": "12px",
+					"slug": "extra-small"
+				},
+				{
+					"name": "Small",
+					"size": "clamp(14px, 0.875rem + 0.1vw, 15px)",
+					"slug": "small"
+				},
+				{
+					"name": "Normal",
+					"size": "clamp(16px, 1rem + 0.125vw, 17px)",
+					"slug": "normal"
+				},
+				{
+					"name": "Large",
+					"size": "clamp(18px, 1.125rem + 0.25vw, 21px)",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "clamp(24px, 1.5rem + 0.5vw, 28px)",
+					"slug": "extra-large"
+				},
+				{
+					"name": "Heading 5",
+					"size": "clamp(20px, 1.25rem + 0.5vw, 26px)",
+					"slug": "heading-5"
+				},
+				{
+					"name": "Heading 4",
+					"size": "clamp(22px, 1.375rem + 0.625vw, 30px)",
+					"slug": "heading-4"
+				},
+				{
+					"name": "Heading 3",
+					"size": "clamp(26px, 1.625rem + 0.75vw, 36px)",
+					"slug": "heading-3"
+				},
+				{
+					"name": "Heading 2",
+					"size": "clamp(32px, 2rem + 1.5vw, 50px)",
+					"slug": "heading-2"
+				},
+				{
+					"name": "Heading 1",
+					"size": "clamp(36px, 2.25rem + 2.5vw, 70px)",
+					"slug": "heading-1"
+				}
+			]
+		},
+		"spacing": {
+			"spacingScale": {
+				"steps": 0
+			},
+			"spacingSizes": [
+				{
+					"name": "3X-Small",
+					"size": "10px",
+					"slug": "10"
+				},
+				{
+					"name": "2X-Small",
+					"size": "clamp(10px, 2vw, 20px)",
+					"slug": "20"
+				},
+				{
+					"name": "X-Small",
+					"size": "clamp(20px, 3vw, 30px)",
+					"slug": "30"
+				},
+				{
+					"name": "Small",
+					"size": "clamp(20px, 4vw, 40px)",
+					"slug": "40"
+				},
+				{
+					"name": "Medium",
+					"size": "clamp(30px, 5vw, 50px)",
+					"slug": "50"
+				},
+				{
+					"name": "Large",
+					"size": "clamp(30px, 6vw, 60px)",
+					"slug": "60"
+				},
+				{
+					"name": "X-Large",
+					"size": "clamp(40px, 8vw, 80px)",
+					"slug": "70"
+				},
+				{
+					"name": "Edge Space",
+					"size": "clamp(20px, 4vw, 80px)",
+					"slug": "edge-space"
+				}
+			],
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw",
+				"%"
+			]
+		},
+		"layout": {
+			"contentSize": "680px",
+			"wideSize": "1160px"
+		},
+		"custom": {
+			"body": {
+				"typography": {
+					"lineHeight": 1.875
+				}
+			},
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontWeight": 400,
+					"lineHeight": 1.3
+				}
+			},
+			"button": {
+				"typography": {
+					"lineHeight": "16px"
+				},
+				"spacing": {
+					"padding": {
+						"top": "17px",
+						"right": "32px",
+						"bottom": "17px",
+						"left": "32px"
+					}
+				}
+			}
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--white)",
+			"text": "var(--wp--preset--color--charcoal-1)"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--inter)",
+			"fontSize": "var(--wp--preset--font-size--normal)",
+			"lineHeight": "var(--wp--custom--body--typography--line-height)"
+		},
+		"spacing": {
+			"blockGap": "var(--wp--preset--spacing--20)"
+		},
+		"elements": {
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontWeight": "400",
+					"lineHeight": "1.3"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--charcoal-0)"
+				}
+			},
+			"h1": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-1)"
+				}
+			},
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-2)"
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-3)"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-4)"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-5)"
+				}
+			},
+			"link": {
+				"color": {
+					"text": "var(--wp--preset--color--blueberry-1)"
+				},
+				":hover": {
+					"color": {
+						"text": "var(--wp--preset--color--deep-blueberry)"
+					}
+				}
+			},
+			"button": {
+				"color": {
+					"background": "var(--wp--preset--color--blueberry-1)",
+					"text": "var(--wp--preset--color--white)"
+				},
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--inter)",
+					"fontSize": "var(--wp--preset--font-size--normal)",
+					"fontWeight": "600",
+					"lineHeight": "var(--wp--custom--button--typography--line-height)"
+				},
+				"border": {
+					"radius": "2px"
+				},
+				":hover": {
+					"color": {
+						"background": "var(--wp--preset--color--deep-blueberry)"
+					}
+				}
+			}
+		},
+		"blocks": {
+			"core/site-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--large)",
+					"fontWeight": "700"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--charcoal-0)"
+						},
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				}
+			},
+			"core/navigation": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)",
+					"fontWeight": "500"
+				}
+			},
+			"core/post-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-1)"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var(--wp--preset--color--charcoal-0)"
+						},
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
+			"core/query-pagination": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--small)"
+				}
+			},
+			"core/separator": {
+				"color": {
+					"text": "var(--wp--preset--color--light-grey-1)"
+				}
+			}
+		}
+	},
+	"templateParts": [
+		{
+			"name": "header",
+			"title": "Header",
+			"area": "header"
+		},
+		{
+			"name": "footer",
+			"title": "Footer",
+			"area": "footer"
+		}
+	],
+	"customTemplates": [
+		{
+			"name": "page-apply",
+			"title": "Application Page",
+			"postTypes": [ "page" ]
+		},
+		{
+			"name": "page-deputy-dashboard",
+			"title": "Deputy Dashboard",
+			"postTypes": [ "page" ]
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- Adds the `groups-directory` block theme for the central/directory site at `wp-content/themes/groups-directory/`
- Front page features a hero section ("Find your local WordPress community"), search bar, featured groups grid (`wp:groups/group-directory`), upcoming events section (`wp:groups/event-directory`), and a CTA to start a group
- Includes templates for `wp_meetup` archive/single views, application page (`wp:groups/application-form`), deputy dashboard (`wp:groups/deputy-dashboard`), search, and 404
- Design tokens (colors, typography, spacing, layout) copied from the `groups-site` theme for visual consistency
- Header/footer parts and two patterns (group-hero, group-grid) included

## Files (15)
- `style.css` - Theme metadata, requires WP 6.7+
- `functions.php` - Minimal bootstrap
- `theme.json` - Shared design tokens matching groups-site
- `templates/` - 8 templates (index, front-page, archive-wp_meetup, single-wp_meetup, page-apply, page-deputy-dashboard, 404, search)
- `parts/` - header.html, footer.html
- `patterns/` - group-hero.php, group-grid.php

## Test plan
- [ ] Activate theme on a WordPress 6.7+ site and verify front page renders hero, search, groups grid, events, and CTA sections
- [ ] Verify archive-wp_meetup template loads the group-directory block
- [ ] Verify single-wp_meetup template shows group details, upcoming events, stats, and "Visit Group Site" button
- [ ] Verify page-apply template renders the application-form block
- [ ] Verify page-deputy-dashboard template renders the deputy-dashboard block
- [ ] Verify 404 and search templates work correctly
- [ ] Confirm theme.json tokens match groups-site theme.json

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)