### PR TITLE
Fix Location_Query SQL for MySQL strict mode

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/models/class-location-query.php
+++ b/wp-content/plugins/wordpress-groups/includes/models/class-location-query.php
@@ -112,23 +112,25 @@ class Location_Query {
 		 * We use %f for all float parameters in $wpdb->prepare().
 		 */
 		$haversine = sprintf(
-			'( %f * ACOS( LEAST( 1, COS( RADIANS(%%f) ) * COS( RADIANS( lat_meta.meta_value ) ) * COS( RADIANS( lon_meta.meta_value ) - RADIANS(%%f) ) + SIN( RADIANS(%%f) ) * SIN( RADIANS( lat_meta.meta_value ) ) ) ) )',
+			'( %f * ACOS( GREATEST( -1, LEAST( 1, COS( RADIANS(%%f) ) * COS( RADIANS( lat_meta.meta_value ) ) * COS( RADIANS( lon_meta.meta_value ) - RADIANS(%%f) ) + SIN( RADIANS(%%f) ) * SIN( RADIANS( lat_meta.meta_value ) ) ) ) ) )',
 			self::EARTH_RADIUS_KM
 		);
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$sql = $wpdb->prepare(
-			"SELECT p.*, {$haversine} AS distance
-			FROM {$wpdb->posts} p
-			INNER JOIN {$wpdb->postmeta} lat_meta
-				ON p.ID = lat_meta.post_id AND lat_meta.meta_key = %s
-			INNER JOIN {$wpdb->postmeta} lon_meta
-				ON p.ID = lon_meta.post_id AND lon_meta.meta_key = %s
-			WHERE p.post_type = %s
-				AND p.post_status = %s
-				AND lat_meta.meta_value != ''
-				AND lon_meta.meta_value != ''
-			HAVING distance <= %f
+			"SELECT * FROM (
+				SELECT p.*, {$haversine} AS distance
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->postmeta} lat_meta
+					ON p.ID = lat_meta.post_id AND lat_meta.meta_key = %s
+				INNER JOIN {$wpdb->postmeta} lon_meta
+					ON p.ID = lon_meta.post_id AND lon_meta.meta_key = %s
+				WHERE p.post_type = %s
+					AND p.post_status = %s
+					AND lat_meta.meta_value != ''
+					AND lon_meta.meta_value != ''
+			) AS nearby
+			WHERE distance <= %f
 			ORDER BY distance ASC
 			LIMIT %d",
 			$lat,


### PR DESCRIPTION
## Summary
- Rewrote the Haversine distance query to use a derived table (subquery) instead of `HAVING distance <= %f` without `GROUP BY`, which fails on MySQL strict mode (`ONLY_FULL_GROUP_BY`).
- Added `GREATEST(-1, ...)` clamping around the `ACOS()` input alongside the existing `LEAST(1, ...)`, preventing domain errors for antipodal points where floating-point imprecision could push the value outside `[-1, 1]`.

Closes #87

## Test plan
- [x] All 14 `Test_Location_Query` PHPUnit tests pass locally via `wp-env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)