### PR TITLE
Add recurrence rules model for recurring events

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/models/class-recurrence.php
+++ b/wp-content/plugins/wordpress-groups/includes/models/class-recurrence.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * Recurrence model — rules for recurring events.
+ *
+ * @package Groups\Models
+ */
+
+namespace Groups\Models;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles recurrence rule storage, retrieval, and occurrence calculation.
+ */
+class Recurrence {
+
+	/**
+	 * Post meta key for the recurrence rule.
+	 *
+	 * @var string
+	 */
+	const META_KEY = '_event_recurrence_rule';
+
+	/**
+	 * Valid frequency values.
+	 *
+	 * @var string[]
+	 */
+	const VALID_FREQUENCIES = [
+		'weekly',
+		'biweekly',
+		'monthly-day',
+		'monthly-date',
+	];
+
+	/**
+	 * Save a recurrence rule to event post meta.
+	 *
+	 * Validates the rule before saving. The rule is stored as a JSON string.
+	 *
+	 * @param int   $event_id The event post ID.
+	 * @param array $rule {
+	 *     Recurrence rule.
+	 *
+	 *     @type string $frequency     One of: weekly, biweekly, monthly-day, monthly-date. Required.
+	 *     @type int    $day_of_week   Day of week (0 = Sunday, 6 = Saturday). Required for weekly, biweekly, monthly-day.
+	 *     @type int    $day_of_month  Day of month (1-31). Required for monthly-date.
+	 *     @type string $end_date      End date in Y-m-d format. Optional.
+	 * }
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public static function save_rule( int $event_id, array $rule ): true|\WP_Error {
+		$validated = self::validate_rule( $rule );
+
+		if ( is_wp_error( $validated ) ) {
+			return $validated;
+		}
+
+		update_post_meta( $event_id, self::META_KEY, wp_json_encode( $validated ) );
+
+		return true;
+	}
+
+	/**
+	 * Get the recurrence rule for an event.
+	 *
+	 * @param int $event_id The event post ID.
+	 * @return array|null The rule array, or null if no rule is set.
+	 */
+	public static function get_rule( int $event_id ): ?array {
+		$raw = get_post_meta( $event_id, self::META_KEY, true );
+
+		if ( empty( $raw ) ) {
+			return null;
+		}
+
+		$rule = json_decode( $raw, true );
+
+		if ( ! is_array( $rule ) ) {
+			return null;
+		}
+
+		return $rule;
+	}
+
+	/**
+	 * Check whether an event has a recurrence rule.
+	 *
+	 * @param int $event_id The event post ID.
+	 * @return bool True if the event has a recurrence rule.
+	 */
+	public static function is_recurring( int $event_id ): bool {
+		return null !== self::get_rule( $event_id );
+	}
+
+	/**
+	 * Calculate the next N occurrences for a recurrence rule.
+	 *
+	 * @param array  $rule       The recurrence rule array.
+	 * @param string $start_date Start date in Y-m-d format.
+	 * @param int    $count      Number of occurrences to generate. Default 10.
+	 * @return \DateTime[] Array of DateTime objects for each occurrence.
+	 */
+	public static function calculate_occurrences( array $rule, string $start_date, int $count = 10 ): array {
+		$frequency = $rule['frequency'] ?? '';
+		$end_date  = isset( $rule['end_date'] ) ? new \DateTime( $rule['end_date'] ) : null;
+
+		$occurrences = [];
+		$current     = new \DateTime( $start_date );
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			if ( $end_date && $current > $end_date ) {
+				break;
+			}
+
+			$occurrences[] = clone $current;
+
+			switch ( $frequency ) {
+				case 'weekly':
+					$current->modify( '+1 week' );
+					break;
+
+				case 'biweekly':
+					$current->modify( '+2 weeks' );
+					break;
+
+				case 'monthly-day':
+					$current = self::next_monthly_day( $current, (int) $rule['day_of_week'] );
+					break;
+
+				case 'monthly-date':
+					$current = self::next_monthly_date( $current, (int) $rule['day_of_month'] );
+					break;
+			}
+		}
+
+		return $occurrences;
+	}
+
+	/**
+	 * Validate a recurrence rule array.
+	 *
+	 * @param array $rule The rule to validate.
+	 * @return array|\WP_Error The sanitised rule on success, WP_Error on failure.
+	 */
+	private static function validate_rule( array $rule ): array|\WP_Error {
+		if ( empty( $rule['frequency'] ) || ! in_array( $rule['frequency'], self::VALID_FREQUENCIES, true ) ) {
+			return new \WP_Error(
+				'invalid_frequency',
+				__( 'Recurrence frequency must be one of: weekly, biweekly, monthly-day, monthly-date.', 'wordpress-groups' )
+			);
+		}
+
+		$sanitised = [
+			'frequency' => $rule['frequency'],
+		];
+
+		// Validate day_of_week for frequencies that need it.
+		if ( in_array( $rule['frequency'], [ 'weekly', 'biweekly', 'monthly-day' ], true ) ) {
+			if ( ! isset( $rule['day_of_week'] ) || ! is_numeric( $rule['day_of_week'] ) ) {
+				return new \WP_Error(
+					'missing_day_of_week',
+					__( 'day_of_week is required for this frequency.', 'wordpress-groups' )
+				);
+			}
+
+			$day_of_week = (int) $rule['day_of_week'];
+
+			if ( $day_of_week < 0 || $day_of_week > 6 ) {
+				return new \WP_Error(
+					'invalid_day_of_week',
+					__( 'day_of_week must be between 0 (Sunday) and 6 (Saturday).', 'wordpress-groups' )
+				);
+			}
+
+			$sanitised['day_of_week'] = $day_of_week;
+		}
+
+		// Validate day_of_month for monthly-date.
+		if ( 'monthly-date' === $rule['frequency'] ) {
+			if ( ! isset( $rule['day_of_month'] ) || ! is_numeric( $rule['day_of_month'] ) ) {
+				return new \WP_Error(
+					'missing_day_of_month',
+					__( 'day_of_month is required for monthly-date frequency.', 'wordpress-groups' )
+				);
+			}
+
+			$day_of_month = (int) $rule['day_of_month'];
+
+			if ( $day_of_month < 1 || $day_of_month > 31 ) {
+				return new \WP_Error(
+					'invalid_day_of_month',
+					__( 'day_of_month must be between 1 and 31.', 'wordpress-groups' )
+				);
+			}
+
+			$sanitised['day_of_month'] = $day_of_month;
+		}
+
+		// Validate optional end_date.
+		if ( ! empty( $rule['end_date'] ) ) {
+			$date = \DateTime::createFromFormat( 'Y-m-d', $rule['end_date'] );
+
+			if ( ! $date || $date->format( 'Y-m-d' ) !== $rule['end_date'] ) {
+				return new \WP_Error(
+					'invalid_end_date',
+					__( 'end_date must be a valid date in Y-m-d format.', 'wordpress-groups' )
+				);
+			}
+
+			$sanitised['end_date'] = $rule['end_date'];
+		}
+
+		return $sanitised;
+	}
+
+	/**
+	 * Calculate the next occurrence of a specific weekday-of-month pattern.
+	 *
+	 * Given a current date (e.g., the first Tuesday of April), find the same
+	 * ordinal weekday in the next month (e.g., the first Tuesday of May).
+	 *
+	 * @param \DateTime $current     The current occurrence date.
+	 * @param int       $day_of_week Target day of week (0 = Sunday, 6 = Saturday).
+	 * @return \DateTime The next monthly-day occurrence.
+	 */
+	private static function next_monthly_day( \DateTime $current, int $day_of_week ): \DateTime {
+		// Determine the ordinal week of the current date (1st, 2nd, 3rd, etc.).
+		$day_number = (int) $current->format( 'j' );
+		$ordinal    = (int) ceil( $day_number / 7 );
+
+		$day_names = [ 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday' ];
+		$day_name  = $day_names[ $day_of_week ];
+
+		// Move to next month.
+		$next = clone $current;
+		$next->modify( 'first day of next month' );
+
+		// Find the Nth occurrence of the target weekday in that month.
+		$ordinal_map = [ 1 => 'first', 2 => 'second', 3 => 'third', 4 => 'fourth', 5 => 'fifth' ];
+		$ordinal_str = $ordinal_map[ $ordinal ] ?? 'fourth';
+
+		$next->modify( "{$ordinal_str} {$day_name} of this month" );
+
+		// If the calculated date is not in the expected month (e.g., "fifth Tuesday"
+		// overflows), fall back to the fourth occurrence.
+		$expected_month = (int) ( clone $current )->modify( 'first day of next month' )->format( 'n' );
+
+		if ( (int) $next->format( 'n' ) !== $expected_month ) {
+			$next = clone $current;
+			$next->modify( 'first day of next month' );
+			$next->modify( "fourth {$day_name} of this month" );
+		}
+
+		return $next;
+	}
+
+	/**
+	 * Calculate the next monthly-date occurrence.
+	 *
+	 * If the target day doesn't exist in the next month (e.g., 31st in February),
+	 * the last day of that month is used instead.
+	 *
+	 * @param \DateTime $current       The current occurrence date.
+	 * @param int       $day_of_month  Target day of month (1-31).
+	 * @return \DateTime The next monthly-date occurrence.
+	 */
+	private static function next_monthly_date( \DateTime $current, int $day_of_month ): \DateTime {
+		$next = clone $current;
+		$next->modify( 'first day of next month' );
+
+		$days_in_month = (int) $next->format( 't' );
+		$target_day    = min( $day_of_month, $days_in_month );
+
+		$next->setDate(
+			(int) $next->format( 'Y' ),
+			(int) $next->format( 'n' ),
+			$target_day
+		);
+
+		return $next;
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/models/Test_Recurrence.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/models/Test_Recurrence.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * Tests for the Recurrence model.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Models\Recurrence;
+
+/**
+ * @coversDefaultClass \Groups\Models\Recurrence
+ */
+class Test_Recurrence extends WP_UnitTestCase {
+
+	/**
+	 * Helper to create a simple post to use as an event.
+	 *
+	 * @return int Post ID.
+	 */
+	private function create_event_post(): int {
+		return self::factory()->post->create( [ 'post_type' => 'event' ] );
+	}
+
+	/**
+	 * @covers ::save_rule
+	 * @covers ::get_rule
+	 */
+	public function test_save_and_get_rule_round_trip(): void {
+		$event_id = $this->create_event_post();
+		$rule     = [
+			'frequency'   => 'weekly',
+			'day_of_week' => 2,
+		];
+
+		$result = Recurrence::save_rule( $event_id, $rule );
+
+		$this->assertTrue( $result );
+
+		$retrieved = Recurrence::get_rule( $event_id );
+
+		$this->assertIsArray( $retrieved );
+		$this->assertSame( 'weekly', $retrieved['frequency'] );
+		$this->assertSame( 2, $retrieved['day_of_week'] );
+	}
+
+	/**
+	 * @covers ::save_rule
+	 */
+	public function test_save_rule_with_end_date(): void {
+		$event_id = $this->create_event_post();
+		$rule     = [
+			'frequency'   => 'weekly',
+			'day_of_week' => 3,
+			'end_date'    => '2026-12-31',
+		];
+
+		$result    = Recurrence::save_rule( $event_id, $rule );
+		$retrieved = Recurrence::get_rule( $event_id );
+
+		$this->assertTrue( $result );
+		$this->assertSame( '2026-12-31', $retrieved['end_date'] );
+	}
+
+	/**
+	 * @covers ::save_rule
+	 */
+	public function test_save_rule_rejects_invalid_frequency(): void {
+		$event_id = $this->create_event_post();
+		$result   = Recurrence::save_rule( $event_id, [ 'frequency' => 'daily' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_frequency', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::save_rule
+	 */
+	public function test_save_rule_rejects_missing_day_of_week(): void {
+		$event_id = $this->create_event_post();
+		$result   = Recurrence::save_rule( $event_id, [ 'frequency' => 'weekly' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'missing_day_of_week', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::save_rule
+	 */
+	public function test_save_rule_rejects_invalid_day_of_week(): void {
+		$event_id = $this->create_event_post();
+		$result   = Recurrence::save_rule( $event_id, [
+			'frequency'   => 'weekly',
+			'day_of_week' => 7,
+		] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_day_of_week', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::save_rule
+	 */
+	public function test_save_rule_rejects_missing_day_of_month(): void {
+		$event_id = $this->create_event_post();
+		$result   = Recurrence::save_rule( $event_id, [ 'frequency' => 'monthly-date' ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'missing_day_of_month', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::save_rule
+	 */
+	public function test_save_rule_rejects_invalid_day_of_month(): void {
+		$event_id = $this->create_event_post();
+		$result   = Recurrence::save_rule( $event_id, [
+			'frequency'    => 'monthly-date',
+			'day_of_month' => 32,
+		] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_day_of_month', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::save_rule
+	 */
+	public function test_save_rule_rejects_invalid_end_date(): void {
+		$event_id = $this->create_event_post();
+		$result   = Recurrence::save_rule( $event_id, [
+			'frequency'   => 'weekly',
+			'day_of_week' => 1,
+			'end_date'    => 'not-a-date',
+		] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_end_date', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::get_rule
+	 */
+	public function test_get_rule_returns_null_when_no_rule(): void {
+		$event_id = $this->create_event_post();
+
+		$this->assertNull( Recurrence::get_rule( $event_id ) );
+	}
+
+	/**
+	 * @covers ::is_recurring
+	 */
+	public function test_is_recurring_returns_false_without_rule(): void {
+		$event_id = $this->create_event_post();
+
+		$this->assertFalse( Recurrence::is_recurring( $event_id ) );
+	}
+
+	/**
+	 * @covers ::is_recurring
+	 */
+	public function test_is_recurring_returns_true_with_rule(): void {
+		$event_id = $this->create_event_post();
+		Recurrence::save_rule( $event_id, [
+			'frequency'   => 'weekly',
+			'day_of_week' => 4,
+		] );
+
+		$this->assertTrue( Recurrence::is_recurring( $event_id ) );
+	}
+
+	/**
+	 * @covers ::calculate_occurrences
+	 */
+	public function test_weekly_recurrence_generates_correct_dates(): void {
+		$rule = [
+			'frequency'   => 'weekly',
+			'day_of_week' => 2, // Tuesday.
+		];
+
+		$occurrences = Recurrence::calculate_occurrences( $rule, '2026-04-07', 4 );
+
+		$this->assertCount( 4, $occurrences );
+		$this->assertSame( '2026-04-07', $occurrences[0]->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-04-14', $occurrences[1]->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-04-21', $occurrences[2]->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-04-28', $occurrences[3]->format( 'Y-m-d' ) );
+	}
+
+	/**
+	 * @covers ::calculate_occurrences
+	 */
+	public function test_biweekly_recurrence_generates_correct_dates(): void {
+		$rule = [
+			'frequency'   => 'biweekly',
+			'day_of_week' => 3, // Wednesday.
+		];
+
+		$occurrences = Recurrence::calculate_occurrences( $rule, '2026-04-01', 4 );
+
+		$this->assertCount( 4, $occurrences );
+		$this->assertSame( '2026-04-01', $occurrences[0]->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-04-15', $occurrences[1]->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-04-29', $occurrences[2]->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-05-13', $occurrences[3]->format( 'Y-m-d' ) );
+	}
+
+	/**
+	 * @covers ::calculate_occurrences
+	 */
+	public function test_monthly_day_recurrence_first_tuesday(): void {
+		// First Tuesday of April 2026 is April 7.
+		$rule = [
+			'frequency'   => 'monthly-day',
+			'day_of_week' => 2, // Tuesday.
+		];
+
+		$occurrences = Recurrence::calculate_occurrences( $rule, '2026-04-07', 4 );
+
+		$this->assertCount( 4, $occurrences );
+		$this->assertSame( '2026-04-07', $occurrences[0]->format( 'Y-m-d' ) );
+		// First Tuesday of May 2026 is May 5.
+		$this->assertSame( '2026-05-05', $occurrences[1]->format( 'Y-m-d' ) );
+		// First Tuesday of June 2026 is June 2.
+		$this->assertSame( '2026-06-02', $occurrences[2]->format( 'Y-m-d' ) );
+		// First Tuesday of July 2026 is July 7.
+		$this->assertSame( '2026-07-07', $occurrences[3]->format( 'Y-m-d' ) );
+	}
+
+	/**
+	 * @covers ::calculate_occurrences
+	 */
+	public function test_monthly_day_recurrence_third_wednesday(): void {
+		// Third Wednesday of April 2026 is April 15.
+		$rule = [
+			'frequency'   => 'monthly-day',
+			'day_of_week' => 3, // Wednesday.
+		];
+
+		$occurrences = Recurrence::calculate_occurrences( $rule, '2026-04-15', 3 );
+
+		$this->assertCount( 3, $occurrences );
+		$this->assertSame( '2026-04-15', $occurrences[0]->format( 'Y-m-d' ) );
+		// Third Wednesday of May 2026 is May 20.
+		$this->assertSame( '2026-05-20', $occurrences[1]->format( 'Y-m-d' ) );
+		// Third Wednesday of June 2026 is June 17.
+		$this->assertSame( '2026-06-17', $occurrences[2]->format( 'Y-m-d' ) );
+	}
+
+	/**
+	 * @covers ::calculate_occurrences
+	 */
+	public function test_monthly_date_recurrence_generates_correct_dates(): void {
+		$rule = [
+			'frequency'    => 'monthly-date',
+			'day_of_month' => 15,
+		];
+
+		$occurrences = Recurrence::calculate_occurrences( $rule, '2026-04-15', 4 );
+
+		$this->assertCount( 4, $occurrences );
+		$this->assertSame( '2026-04-15', $occurrences[0]->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-05-15', $occurrences[1]->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-06-15', $occurrences[2]->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-07-15', $occurrences[3]->format( 'Y-m-d' ) );
+	}
+
+	/**
+	 * @covers ::calculate_occurrences
+	 */
+	public function test_monthly_date_clamps_to_last_day_of_short_month(): void {
+		$rule = [
+			'frequency'    => 'monthly-date',
+			'day_of_month' => 31,
+		];
+
+		$occurrences = Recurrence::calculate_occurrences( $rule, '2026-01-31', 3 );
+
+		$this->assertCount( 3, $occurrences );
+		$this->assertSame( '2026-01-31', $occurrences[0]->format( 'Y-m-d' ) );
+		// February has 28 days in 2026.
+		$this->assertSame( '2026-02-28', $occurrences[1]->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-03-31', $occurrences[2]->format( 'Y-m-d' ) );
+	}
+
+	/**
+	 * @covers ::calculate_occurrences
+	 */
+	public function test_end_date_stops_occurrence_generation(): void {
+		$rule = [
+			'frequency'   => 'weekly',
+			'day_of_week' => 1,
+			'end_date'    => '2026-04-20',
+		];
+
+		$occurrences = Recurrence::calculate_occurrences( $rule, '2026-04-06', 10 );
+
+		$this->assertCount( 3, $occurrences );
+		$this->assertSame( '2026-04-06', $occurrences[0]->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-04-13', $occurrences[1]->format( 'Y-m-d' ) );
+		$this->assertSame( '2026-04-20', $occurrences[2]->format( 'Y-m-d' ) );
+	}
+
+	/**
+	 * @covers ::calculate_occurrences
+	 */
+	public function test_end_date_is_inclusive(): void {
+		$rule = [
+			'frequency'   => 'weekly',
+			'day_of_week' => 1,
+			'end_date'    => '2026-04-13',
+		];
+
+		$occurrences = Recurrence::calculate_occurrences( $rule, '2026-04-06', 10 );
+
+		$this->assertCount( 2, $occurrences );
+		$this->assertSame( '2026-04-13', $occurrences[1]->format( 'Y-m-d' ) );
+	}
+
+	/**
+	 * @covers ::calculate_occurrences
+	 */
+	public function test_default_count_is_ten(): void {
+		$rule = [
+			'frequency'   => 'weekly',
+			'day_of_week' => 5,
+		];
+
+		$occurrences = Recurrence::calculate_occurrences( $rule, '2026-01-02' );
+
+		$this->assertCount( 10, $occurrences );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/wp-tests-config.php
+++ b/wp-content/plugins/wordpress-groups/tests/wp-tests-config.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Custom wp-tests-config.php for running PHPUnit tests in wp-env.
+ *
+ * This avoids the multisite bootstrap chicken-and-egg problem where MULTISITE
+ * is defined before the test installer creates the required database tables.
+ * Instead, we use WP_TESTS_MULTISITE to let the test framework handle it.
+ */
+
+define( 'DB_NAME', 'tests-wordpress' );
+define( 'DB_USER', 'root' );
+define( 'DB_PASSWORD', 'password' );
+define( 'DB_HOST', 'tests-mysql' );
+define( 'DB_CHARSET', 'utf8mb4' );
+define( 'DB_COLLATE', '' );
+
+$table_prefix = 'wptests_';
+
+define( 'AUTH_KEY', 'test-auth-key' );
+define( 'SECURE_AUTH_KEY', 'test-secure-auth-key' );
+define( 'LOGGED_IN_KEY', 'test-logged-in-key' );
+define( 'NONCE_KEY', 'test-nonce-key' );
+define( 'AUTH_SALT', 'test-auth-salt' );
+define( 'SECURE_AUTH_SALT', 'test-secure-auth-salt' );
+define( 'LOGGED_IN_SALT', 'test-logged-in-salt' );
+define( 'NONCE_SALT', 'test-nonce-salt' );
+
+define( 'WP_TESTS_DOMAIN', 'localhost' );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_TITLE', 'Test Blog' );
+define( 'WP_PHP_BINARY', 'php' );
+define( 'ABSPATH', '/var/www/html/' );
+define( 'WP_DEFAULT_THEME', 'default' );
+
+// Use WP_TESTS_MULTISITE instead of defining MULTISITE directly.
+// This lets the test installer set up the multisite tables properly.
+define( 'WP_TESTS_MULTISITE', true );


### PR DESCRIPTION
## Summary
- Adds `Groups\Models\Recurrence` class with static methods for saving, retrieving, and calculating recurrence rules stored as JSON in `_event_recurrence_rule` post meta
- Supports four frequency types: weekly, biweekly, monthly-day (e.g. "first Tuesday of the month"), and monthly-date (e.g. "15th of each month")
- Includes validation for rule structure, optional end_date support, and edge case handling (e.g. day 31 in short months)
- Fixes PHPUnit test bootstrap to load Composer autoloader and adds a custom `wp-tests-config.php` for proper multisite test execution in wp-env

## Test plan
- [x] 20 PHPUnit tests pass covering all recurrence types, validation, save/get round-trip, end_date cutoff, and edge cases
- [ ] Verify `calculate_occurrences` output for monthly-day with fifth-week fallback
- [ ] Integration test with actual event CPT when cron job (issue #34) is implemented

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)