### PR TITLE
Add dormancy detector for inactive group monitoring

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/analytics/class-dormancy-detector.php
+++ b/wp-content/plugins/wordpress-groups/includes/analytics/class-dormancy-detector.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * Dormancy detector — flags groups with no recent events as at-risk
+ * or dormant via a daily WP-Cron check.
+ *
+ * @package Groups\Analytics
+ */
+
+namespace Groups\Analytics;
+
+use Groups\Notifications\Email_Notifier;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Monitors wp_meetup posts for inactivity and manages the at-risk → dormant
+ * lifecycle via scheduled cron checks.
+ */
+class Dormancy_Detector {
+
+	/**
+	 * Cron hook name.
+	 *
+	 * @var string
+	 */
+	const CRON_HOOK = 'groups_dormancy_check';
+
+	/**
+	 * Days of inactivity before a group is flagged at-risk.
+	 *
+	 * @var int
+	 */
+	const AT_RISK_DAYS = 60;
+
+	/**
+	 * Days of inactivity before a group transitions to dormant.
+	 *
+	 * @var int
+	 */
+	const DORMANT_DAYS = 90;
+
+	/**
+	 * Post meta key for the last event date.
+	 *
+	 * @var string
+	 */
+	const LAST_EVENT_META = '_meetup_last_event_date';
+
+	/**
+	 * Post meta key for at-risk flag.
+	 *
+	 * @var string
+	 */
+	const AT_RISK_META = '_meetup_at_risk';
+
+	/**
+	 * Post meta key for the assigned deputy.
+	 *
+	 * @var string
+	 */
+	const DEPUTY_META = '_meetup_deputy_assigned';
+
+	/**
+	 * Constructor. Registers hooks.
+	 */
+	public function __construct() {
+		add_action( self::CRON_HOOK, [ $this, 'run' ] );
+	}
+
+	/**
+	 * Schedule the daily cron event if not already scheduled.
+	 *
+	 * Should be called during plugin initialisation.
+	 */
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Unschedule the cron event.
+	 *
+	 * Called on plugin deactivation.
+	 */
+	public static function unschedule_cron(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Run the dormancy check across all active groups.
+	 */
+	public function run(): void {
+		$posts = get_posts( [
+			'post_type'      => 'wp_meetup',
+			'post_status'    => 'meetup-active',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+		] );
+
+		foreach ( $posts as $post_id ) {
+			self::check_group( (int) $post_id );
+		}
+	}
+
+	/**
+	 * Check a single group for dormancy.
+	 *
+	 * Evaluates the group's last event date and applies the at-risk or
+	 * dormant status as appropriate.
+	 *
+	 * @param int $post_id The wp_meetup post ID.
+	 * @return string|null 'dormant', 'at_risk', or null if no action taken.
+	 */
+	public static function check_group( int $post_id ): ?string {
+		$post = get_post( $post_id );
+
+		if ( ! $post || 'wp_meetup' !== $post->post_type ) {
+			return null;
+		}
+
+		// Skip groups that are not active.
+		if ( 'meetup-active' !== $post->post_status ) {
+			return null;
+		}
+
+		$last_event_date = self::get_last_event_date( $post_id );
+
+		if ( ! $last_event_date ) {
+			// No event date recorded — use activation date or post date as fallback.
+			$activation_date = get_post_meta( $post_id, '_meetup_activation_date', true );
+			$last_event_date = $activation_date ?: $post->post_date_gmt;
+		}
+
+		$last_event_time = strtotime( $last_event_date );
+
+		if ( false === $last_event_time ) {
+			return null;
+		}
+
+		$days_inactive = (int) floor( ( current_time( 'timestamp', true ) - $last_event_time ) / DAY_IN_SECONDS );
+
+		if ( $days_inactive >= self::DORMANT_DAYS ) {
+			return self::mark_dormant( $post_id, $days_inactive );
+		}
+
+		if ( $days_inactive >= self::AT_RISK_DAYS ) {
+			return self::mark_at_risk( $post_id, $days_inactive );
+		}
+
+		// Group is active and healthy — clear at-risk flag if previously set.
+		if ( get_post_meta( $post_id, self::AT_RISK_META, true ) ) {
+			delete_post_meta( $post_id, self::AT_RISK_META );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the last event date for a group.
+	 *
+	 * Reads from post meta first. If not set, attempts to query the
+	 * group's site for the most recent event.
+	 *
+	 * @param int $post_id The wp_meetup post ID.
+	 * @return string|null Date string or null if not available.
+	 */
+	private static function get_last_event_date( int $post_id ): ?string {
+		$date = get_post_meta( $post_id, self::LAST_EVENT_META, true );
+
+		if ( $date ) {
+			return $date;
+		}
+
+		// Attempt to query the group's site for the most recent event.
+		$site_id = get_post_meta( $post_id, '_meetup_site_id', true );
+
+		if ( ! $site_id || ! is_multisite() ) {
+			return null;
+		}
+
+		$site_id = (int) $site_id;
+
+		switch_to_blog( $site_id );
+
+		$latest_event = get_posts( [
+			'post_type'      => 'event',
+			'post_status'    => [ 'event-past', 'event-active', 'event-scheduled', 'publish' ],
+			'posts_per_page' => 1,
+			'orderby'        => 'meta_value',
+			'meta_key'       => '_event_start_utc',
+			'order'          => 'DESC',
+			'fields'         => 'ids',
+		] );
+
+		$event_date = null;
+
+		if ( $latest_event ) {
+			$event_date = get_post_meta( $latest_event[0], '_event_start_utc', true );
+
+			if ( $event_date ) {
+				// Cache the date back on the meetup post.
+				restore_current_blog();
+				update_post_meta( $post_id, self::LAST_EVENT_META, $event_date );
+				return $event_date;
+			}
+		}
+
+		restore_current_blog();
+
+		return null;
+	}
+
+	/**
+	 * Mark a group as at-risk.
+	 *
+	 * @param int $post_id        The wp_meetup post ID.
+	 * @param int $days_inactive  Number of days since last event.
+	 * @return string 'at_risk'
+	 */
+	private static function mark_at_risk( int $post_id, int $days_inactive ): string {
+		// Only notify if not already flagged.
+		$already_flagged = (bool) get_post_meta( $post_id, self::AT_RISK_META, true );
+
+		update_post_meta( $post_id, self::AT_RISK_META, 1 );
+
+		/**
+		 * Fires when a group is flagged as at-risk due to inactivity.
+		 *
+		 * @param int $post_id       The wp_meetup post ID.
+		 * @param int $days_inactive Days since last event.
+		 */
+		do_action( 'groups_group_at_risk', $post_id, $days_inactive );
+
+		if ( ! $already_flagged ) {
+			self::notify_deputy( $post_id, $days_inactive );
+		}
+
+		return 'at_risk';
+	}
+
+	/**
+	 * Mark a group as dormant by transitioning its status.
+	 *
+	 * @param int $post_id        The wp_meetup post ID.
+	 * @param int $days_inactive  Number of days since last event.
+	 * @return string 'dormant'
+	 */
+	private static function mark_dormant( int $post_id, int $days_inactive ): string {
+		wp_update_post( [
+			'ID'          => $post_id,
+			'post_status' => 'meetup-dormant',
+		] );
+
+		// Clear the at-risk flag since the group is now dormant.
+		delete_post_meta( $post_id, self::AT_RISK_META );
+
+		/**
+		 * Fires when a group transitions to dormant due to inactivity.
+		 *
+		 * @param int $post_id       The wp_meetup post ID.
+		 * @param int $days_inactive Days since last event.
+		 */
+		do_action( 'groups_group_dormant', $post_id, $days_inactive );
+
+		self::notify_deputy( $post_id, $days_inactive );
+
+		return 'dormant';
+	}
+
+	/**
+	 * Send a dormancy alert email to the assigned deputy.
+	 *
+	 * @param int $post_id        The wp_meetup post ID.
+	 * @param int $days_inactive  Number of days since last event.
+	 */
+	private static function notify_deputy( int $post_id, int $days_inactive ): void {
+		$deputy_username = get_post_meta( $post_id, self::DEPUTY_META, true );
+
+		if ( ! $deputy_username ) {
+			return;
+		}
+
+		$deputy = get_user_by( 'login', $deputy_username );
+
+		if ( ! $deputy || ! $deputy->user_email ) {
+			return;
+		}
+
+		$post       = get_post( $post_id );
+		$group_name = $post ? $post->post_title : __( 'Unknown Group', 'wordpress-groups' );
+
+		$notifier = new Email_Notifier();
+		$notifier->send(
+			$deputy->user_email,
+			sprintf(
+				/* translators: %s: Group name. */
+				__( 'Dormancy Alert: %s needs attention', 'wordpress-groups' ),
+				$group_name
+			),
+			'dormancy-alert',
+			[
+				'deputy_name'   => $deputy->display_name,
+				'group_name'    => $group_name,
+				'days_inactive' => (string) $days_inactive,
+				'group_url'     => get_edit_post_link( $post_id, 'raw' ) ?: admin_url( 'post.php?post=' . $post_id . '&action=edit' ),
+				'dashboard_url' => admin_url( 'admin.php?page=groups-deputy-dashboard' ),
+			]
+		);
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -50,6 +50,8 @@ class Plugin {
 		new Blocks\Block_Registrar();
 		new Analytics\Newcomer_Tracker();
 		new Analytics\Activity_Logger();
+		new Analytics\Dormancy_Detector();
+		Analytics\Dormancy_Detector::schedule_cron();
 		new Calendar\ICal_Export();
 		new Workflow\Application_Workflow();
 		new Workflow\Status_Transition();

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/analytics/Test_Dormancy_Detector.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/analytics/Test_Dormancy_Detector.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * Tests for the Dormancy Detector.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Analytics\Dormancy_Detector;
+
+/**
+ * @coversDefaultClass \Groups\Analytics\Dormancy_Detector
+ */
+class Test_Dormancy_Detector extends WP_UnitTestCase {
+
+	/**
+	 * Register the wp_meetup post type and statuses for tests.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// Register the wp_meetup post type if not already registered.
+		if ( ! post_type_exists( 'wp_meetup' ) ) {
+			register_post_type( 'wp_meetup', [
+				'public' => false,
+			] );
+		}
+
+		// Register custom statuses used by the workflow.
+		foreach ( [ 'meetup-active', 'meetup-dormant' ] as $status ) {
+			if ( ! get_post_status_object( $status ) ) {
+				register_post_status( $status, [
+					'label'                     => ucfirst( str_replace( 'meetup-', '', $status ) ),
+					'public'                    => true,
+					'exclude_from_search'       => false,
+					'show_in_admin_all_list'    => true,
+					'show_in_admin_status_list' => true,
+				] );
+			}
+		}
+	}
+
+	/**
+	 * Helper: create a wp_meetup post with a given status and last event date.
+	 *
+	 * @param string      $status          Post status.
+	 * @param string|null $last_event_date Last event date (Y-m-d H:i:s format).
+	 * @param string|null $deputy_username Deputy username.
+	 * @return int Post ID.
+	 */
+	private function create_group( string $status = 'meetup-active', ?string $last_event_date = null, ?string $deputy_username = null ): int {
+		$post_id = self::factory()->post->create( [
+			'post_type'   => 'wp_meetup',
+			'post_status' => $status,
+			'post_title'  => 'Test WordPress Group',
+		] );
+
+		if ( $last_event_date ) {
+			update_post_meta( $post_id, Dormancy_Detector::LAST_EVENT_META, $last_event_date );
+		}
+
+		if ( $deputy_username ) {
+			update_post_meta( $post_id, Dormancy_Detector::DEPUTY_META, $deputy_username );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * @covers ::check_group
+	 */
+	public function test_recent_event_not_flagged(): void {
+		$last_event = gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) );
+		$post_id    = $this->create_group( 'meetup-active', $last_event );
+
+		$result = Dormancy_Detector::check_group( $post_id );
+
+		$this->assertNull( $result, 'Group with recent event should not be flagged.' );
+		$this->assertEmpty(
+			get_post_meta( $post_id, Dormancy_Detector::AT_RISK_META, true ),
+			'At-risk meta should not be set for active group.'
+		);
+	}
+
+	/**
+	 * @covers ::check_group
+	 */
+	public function test_60_days_inactive_gets_at_risk(): void {
+		$last_event = gmdate( 'Y-m-d H:i:s', strtotime( '-65 days' ) );
+		$post_id    = $this->create_group( 'meetup-active', $last_event );
+
+		$result = Dormancy_Detector::check_group( $post_id );
+
+		$this->assertSame( 'at_risk', $result );
+		$this->assertEquals( 1, get_post_meta( $post_id, Dormancy_Detector::AT_RISK_META, true ) );
+
+		// Post status should still be active.
+		$post = get_post( $post_id );
+		$this->assertSame( 'meetup-active', $post->post_status );
+	}
+
+	/**
+	 * @covers ::check_group
+	 */
+	public function test_90_days_inactive_transitions_to_dormant(): void {
+		$last_event = gmdate( 'Y-m-d H:i:s', strtotime( '-95 days' ) );
+		$post_id    = $this->create_group( 'meetup-active', $last_event );
+
+		$result = Dormancy_Detector::check_group( $post_id );
+
+		$this->assertSame( 'dormant', $result );
+
+		// Post status should now be dormant.
+		$post = get_post( $post_id );
+		$this->assertSame( 'meetup-dormant', $post->post_status );
+
+		// At-risk flag should be cleared.
+		$this->assertEmpty(
+			get_post_meta( $post_id, Dormancy_Detector::AT_RISK_META, true ),
+			'At-risk meta should be cleared when group becomes dormant.'
+		);
+	}
+
+	/**
+	 * @covers ::check_group
+	 */
+	public function test_already_dormant_group_not_reprocessed(): void {
+		$last_event = gmdate( 'Y-m-d H:i:s', strtotime( '-120 days' ) );
+		$post_id    = $this->create_group( 'meetup-dormant', $last_event );
+
+		$result = Dormancy_Detector::check_group( $post_id );
+
+		$this->assertNull( $result, 'Already dormant group should not be re-processed.' );
+	}
+
+	/**
+	 * @covers ::check_group
+	 */
+	public function test_at_risk_action_fires(): void {
+		$last_event = gmdate( 'Y-m-d H:i:s', strtotime( '-65 days' ) );
+		$post_id    = $this->create_group( 'meetup-active', $last_event );
+		$fired      = false;
+
+		add_action(
+			'groups_group_at_risk',
+			function ( $id, $days ) use ( $post_id, &$fired ) {
+				$fired = true;
+				$this->assertSame( $post_id, $id );
+				$this->assertGreaterThanOrEqual( 60, $days );
+			},
+			10,
+			2
+		);
+
+		Dormancy_Detector::check_group( $post_id );
+
+		$this->assertTrue( $fired, 'The groups_group_at_risk action should have fired.' );
+	}
+
+	/**
+	 * @covers ::check_group
+	 */
+	public function test_dormant_action_fires(): void {
+		$last_event = gmdate( 'Y-m-d H:i:s', strtotime( '-95 days' ) );
+		$post_id    = $this->create_group( 'meetup-active', $last_event );
+		$fired      = false;
+
+		add_action(
+			'groups_group_dormant',
+			function ( $id, $days ) use ( $post_id, &$fired ) {
+				$fired = true;
+				$this->assertSame( $post_id, $id );
+				$this->assertGreaterThanOrEqual( 90, $days );
+			},
+			10,
+			2
+		);
+
+		Dormancy_Detector::check_group( $post_id );
+
+		$this->assertTrue( $fired, 'The groups_group_dormant action should have fired.' );
+	}
+
+	/**
+	 * @covers ::check_group
+	 */
+	public function test_at_risk_flag_cleared_when_event_recent(): void {
+		$post_id = $this->create_group( 'meetup-active', gmdate( 'Y-m-d H:i:s', strtotime( '-5 days' ) ) );
+
+		// Simulate a previously set at-risk flag.
+		update_post_meta( $post_id, Dormancy_Detector::AT_RISK_META, 1 );
+
+		$result = Dormancy_Detector::check_group( $post_id );
+
+		$this->assertNull( $result );
+		$this->assertEmpty(
+			get_post_meta( $post_id, Dormancy_Detector::AT_RISK_META, true ),
+			'At-risk meta should be cleared when group has recent events.'
+		);
+	}
+
+	/**
+	 * @covers ::run
+	 */
+	public function test_run_processes_active_groups(): void {
+		$active_recent  = $this->create_group( 'meetup-active', gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) ) );
+		$active_at_risk = $this->create_group( 'meetup-active', gmdate( 'Y-m-d H:i:s', strtotime( '-70 days' ) ) );
+		$dormant_group  = $this->create_group( 'meetup-dormant', gmdate( 'Y-m-d H:i:s', strtotime( '-120 days' ) ) );
+
+		$detector = new Dormancy_Detector();
+		$detector->run();
+
+		// Active recent group should not be flagged.
+		$this->assertEmpty( get_post_meta( $active_recent, Dormancy_Detector::AT_RISK_META, true ) );
+
+		// Active at-risk group should be flagged.
+		$this->assertEquals( 1, get_post_meta( $active_at_risk, Dormancy_Detector::AT_RISK_META, true ) );
+
+		// Already dormant group should remain unchanged.
+		$this->assertSame( 'meetup-dormant', get_post( $dormant_group )->post_status );
+	}
+
+	/**
+	 * @covers ::schedule_cron
+	 * @covers ::unschedule_cron
+	 */
+	public function test_cron_scheduling(): void {
+		// Unschedule first in case it was already scheduled.
+		Dormancy_Detector::unschedule_cron();
+		$this->assertFalse( wp_next_scheduled( Dormancy_Detector::CRON_HOOK ) );
+
+		Dormancy_Detector::schedule_cron();
+		$this->assertNotFalse( wp_next_scheduled( Dormancy_Detector::CRON_HOOK ) );
+
+		// Scheduling again should not create a duplicate.
+		$first_timestamp = wp_next_scheduled( Dormancy_Detector::CRON_HOOK );
+		Dormancy_Detector::schedule_cron();
+		$this->assertSame( $first_timestamp, wp_next_scheduled( Dormancy_Detector::CRON_HOOK ) );
+
+		// Cleanup.
+		Dormancy_Detector::unschedule_cron();
+		$this->assertFalse( wp_next_scheduled( Dormancy_Detector::CRON_HOOK ) );
+	}
+
+	/**
+	 * @covers ::check_group
+	 */
+	public function test_deputy_email_sent_on_at_risk(): void {
+		// Create a deputy user.
+		$deputy_id = self::factory()->user->create( [
+			'user_login' => 'testdeputy',
+			'user_email' => 'deputy@example.org',
+		] );
+
+		$last_event = gmdate( 'Y-m-d H:i:s', strtotime( '-65 days' ) );
+		$post_id    = $this->create_group( 'meetup-active', $last_event, 'testdeputy' );
+
+		// Capture wp_mail calls.
+		$emails = [];
+		add_filter( 'pre_wp_mail', function ( $null, $atts ) use ( &$emails ) {
+			$emails[] = $atts;
+			return true; // Short-circuit actual sending.
+		}, 10, 2 );
+
+		Dormancy_Detector::check_group( $post_id );
+
+		$this->assertNotEmpty( $emails, 'A dormancy alert email should have been sent.' );
+		$this->assertSame( 'deputy@example.org', $emails[0]['to'] );
+		$this->assertStringContainsString( 'Dormancy Alert', $emails[0]['subject'] );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Dormancy_Detector` class (`Groups\Analytics` namespace) with daily WP-Cron event `groups_dormancy_check`
- Groups inactive 60+ days get `_meetup_at_risk` meta flag; 90+ days auto-transition to `meetup-dormant` status
- Sends dormancy-alert email to assigned deputy (`_meetup_deputy_assigned` meta)
- Fires `groups_group_at_risk` and `groups_group_dormant` actions for extensibility
- Static `check_group( int $post_id )` method for on-demand single-group checks
- Wired into Plugin class with cron scheduling on init

## Test plan
- [x] 10 PHPUnit tests covering all scenarios (229 total suite passing)
- [x] Group with recent event is not flagged
- [x] Group 60+ days inactive gets at_risk meta
- [x] Group 90+ days inactive transitions to dormant
- [x] Already dormant group is not re-processed
- [x] At-risk flag cleared when group becomes active again
- [x] Actions fire correctly for at-risk and dormant transitions
- [x] Deputy email sent on at-risk detection
- [x] Cron scheduling/unscheduling works correctly
- [x] `run()` method processes only active groups

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)