### PR TITLE
Add event reminder cron jobs (24h and 1h before event)

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -53,6 +53,7 @@ class Plugin {
 		new Analytics\Dormancy_Detector();
 		Analytics\Dormancy_Detector::schedule_cron();
 		new Calendar\ICal_Export();
+		new Notifications\Scheduler();
 		new Workflow\Application_Workflow();
 		new Workflow\Status_Transition();
 		new Workflow\Site_Provisioner();

--- a/wp-content/plugins/wordpress-groups/includes/notifications/class-scheduler.php
+++ b/wp-content/plugins/wordpress-groups/includes/notifications/class-scheduler.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Event reminder scheduling via wp_cron.
+ *
+ * Schedules 24-hour and 1-hour reminder emails before events, and
+ * unschedules them when events are cancelled.
+ *
+ * @package Groups\Notifications
+ */
+
+namespace Groups\Notifications;
+
+use Groups\Models\Event;
+use Groups\Models\Rsvp;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages event reminder cron jobs.
+ */
+class Scheduler {
+
+	/**
+	 * Cron hook for 24-hour reminders.
+	 *
+	 * @var string
+	 */
+	const HOOK_24H = 'groups_event_reminder_24h';
+
+	/**
+	 * Cron hook for 1-hour reminders.
+	 *
+	 * @var string
+	 */
+	const HOOK_1H = 'groups_event_reminder_1h';
+
+	/**
+	 * Constructor — registers hooks.
+	 */
+	public function __construct() {
+		add_action( 'transition_post_status', [ $this, 'on_status_transition' ], 10, 3 );
+		add_action( self::HOOK_24H, [ $this, 'send_reminder' ], 10, 1 );
+		add_action( self::HOOK_1H, [ $this, 'send_reminder' ], 10, 1 );
+	}
+
+	/**
+	 * Handle event post status transitions.
+	 *
+	 * Schedules reminders when an event moves to `event-scheduled`, and
+	 * unschedules them when an event moves to `event-cancelled`.
+	 *
+	 * @param string   $new_status New post status.
+	 * @param string   $old_status Old post status.
+	 * @param \WP_Post $post       Post object.
+	 */
+	public function on_status_transition( string $new_status, string $old_status, \WP_Post $post ): void {
+		if ( 'event' !== $post->post_type ) {
+			return;
+		}
+
+		if ( 'event-scheduled' === $new_status ) {
+			$this->schedule_reminders( $post->ID );
+		}
+
+		if ( 'event-cancelled' === $new_status ) {
+			$this->unschedule_reminders( $post->ID );
+		}
+	}
+
+	/**
+	 * Schedule 24h and 1h reminder cron events for an event post.
+	 *
+	 * Clears any existing reminders first to avoid duplicates (e.g. when
+	 * the event start time is updated).
+	 *
+	 * @param int $event_id The event post ID.
+	 */
+	public function schedule_reminders( int $event_id ): void {
+		$start_utc = get_post_meta( $event_id, '_event_start_utc', true );
+
+		if ( empty( $start_utc ) ) {
+			return;
+		}
+
+		$start_timestamp = strtotime( $start_utc );
+
+		if ( false === $start_timestamp ) {
+			return;
+		}
+
+		// Clear existing reminders to avoid duplicates.
+		$this->unschedule_reminders( $event_id );
+
+		$time_24h = $start_timestamp - DAY_IN_SECONDS;
+		$time_1h  = $start_timestamp - HOUR_IN_SECONDS;
+		$now      = time();
+
+		if ( $time_24h > $now ) {
+			wp_schedule_single_event( $time_24h, self::HOOK_24H, [ $event_id ] );
+		}
+
+		if ( $time_1h > $now ) {
+			wp_schedule_single_event( $time_1h, self::HOOK_1H, [ $event_id ] );
+		}
+	}
+
+	/**
+	 * Unschedule any pending reminder cron events for an event post.
+	 *
+	 * @param int $event_id The event post ID.
+	 */
+	public function unschedule_reminders( int $event_id ): void {
+		$timestamp_24h = wp_next_scheduled( self::HOOK_24H, [ $event_id ] );
+
+		if ( $timestamp_24h ) {
+			wp_unschedule_event( $timestamp_24h, self::HOOK_24H, [ $event_id ] );
+		}
+
+		$timestamp_1h = wp_next_scheduled( self::HOOK_1H, [ $event_id ] );
+
+		if ( $timestamp_1h ) {
+			wp_unschedule_event( $timestamp_1h, self::HOOK_1H, [ $event_id ] );
+		}
+	}
+
+	/**
+	 * Send reminder emails to all attending RSVPs for an event.
+	 *
+	 * Called by the cron hooks. Skips sending if the event is cancelled.
+	 *
+	 * @param int $event_id The event post ID.
+	 */
+	public function send_reminder( int $event_id ): void {
+		$event_data = Event::get( $event_id );
+
+		if ( is_wp_error( $event_data ) ) {
+			return;
+		}
+
+		// Don't send reminders for cancelled events.
+		if ( 'event-cancelled' === $event_data['status'] ) {
+			return;
+		}
+
+		$rsvps = Rsvp::get_rsvps( $event_id, 'attending' );
+
+		if ( empty( $rsvps ) ) {
+			return;
+		}
+
+		$notifier = new Email_Notifier();
+
+		foreach ( $rsvps as $rsvp ) {
+			$user = get_userdata( (int) $rsvp->user_id );
+
+			if ( ! $user ) {
+				continue;
+			}
+
+			/**
+			 * Filters whether to send a reminder email to a specific user.
+			 *
+			 * @param bool $send     Whether to send the reminder. Default true.
+			 * @param int  $event_id The event post ID.
+			 * @param int  $user_id  The user ID.
+			 */
+			if ( ! apply_filters( 'groups_send_event_reminder', true, $event_id, (int) $rsvp->user_id ) ) {
+				continue;
+			}
+
+			$notifier->send(
+				$user->user_email,
+				sprintf(
+					/* translators: %s: event title */
+					__( 'Reminder: %s', 'wordpress-groups' ),
+					$event_data['title']
+				),
+				'event-reminder',
+				[
+					'event_title' => $event_data['title'],
+					'event_date'  => $event_data['start_utc'],
+					'event_url'   => get_permalink( $event_id ),
+					'user_name'   => $user->display_name,
+				]
+			);
+		}
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/bootstrap.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/bootstrap.php
@@ -23,6 +23,66 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 
 require_once $_tests_dir . '/includes/functions.php';
 
+/*
+ * Workaround for wp-env multisite test environments.
+ *
+ * When wp-tests-config.php defines MULTISITE = true, the WP test installer's
+ * populate_network() skips creating the wp_blogs row (it only does so when
+ * is_multisite() returns false, i.e. upgrading from single to multi). This
+ * leaves ms-settings.php unable to find the current site during bootstrap.
+ *
+ * We detect this and insert the missing row after the install subprocess
+ * runs but before WP loads, by wrapping the bootstrap include.
+ */
+if ( '1' !== getenv( 'WP_TESTS_SKIP_INSTALL' ) ) {
+	// The WP bootstrap's install subprocess will have run by the time
+	// require_once wp-settings.php is called. We need to ensure the blog
+	// row exists before that. So we run a pre-check: load the config,
+	// run the install, then fix up.
+	$_config_file = $_tests_dir . '/wp-tests-config.php';
+	if ( file_exists( $_config_file ) ) {
+		$_cfg = file_get_contents( $_config_file );
+		if ( preg_match( '/define\s*\(\s*[\'"]MULTISITE[\'"]\s*,\s*true\s*\)/', $_cfg ) ) {
+			// Run the install subprocess ourselves, same as the WP bootstrap does.
+			$_php    = defined( 'PHP_BINARY' ) ? PHP_BINARY : 'php';
+			$_ms     = 'run_ms_tests';
+			$_core   = ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) ? 'run_core_tests' : 'no_core_tests';
+			$_retval = 0;
+			system(
+				$_php . ' ' . escapeshellarg( $_tests_dir . '/includes/install.php' )
+				. ' ' . escapeshellarg( $_config_file )
+				. ' ' . $_ms . ' ' . $_core,
+				$_retval
+			);
+
+			// Now fix the missing wp_blogs row.
+			require_once $_config_file;
+			$_prefix = isset( $table_prefix ) ? $table_prefix : 'wp_';
+			$_db     = new mysqli( DB_HOST, DB_USER, DB_PASSWORD, DB_NAME );
+			if ( ! $_db->connect_error ) {
+				$_result = $_db->query( "SELECT blog_id FROM {$_prefix}blogs LIMIT 1" );
+				if ( $_result && 0 === $_result->num_rows ) {
+					$_domain = defined( 'WP_TESTS_DOMAIN' ) ? WP_TESTS_DOMAIN : 'localhost';
+					$_db->query( sprintf(
+						"INSERT INTO {$_prefix}blogs (blog_id, site_id, domain, path, registered, last_updated, public) VALUES (1, 1, '%s', '/', NOW(), NOW(), 1)",
+						$_db->real_escape_string( $_domain )
+					) );
+				}
+				if ( $_result ) {
+					$_result->free();
+				}
+				$_db->close();
+			}
+			unset( $_db, $_result, $_domain, $_prefix, $_php, $_ms, $_core, $_retval );
+
+			// Tell the WP bootstrap to skip its own install since we already ran it.
+			putenv( 'WP_TESTS_SKIP_INSTALL=1' );
+		}
+		unset( $_cfg );
+	}
+	unset( $_config_file );
+}
+
 tests_add_filter(
 	'muplugins_loaded',
 	static function () {

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Scheduler.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Scheduler.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * Tests for the event reminder Scheduler.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Models\Event;
+use Groups\Models\Rsvp;
+use Groups\Notifications\Scheduler;
+use Groups\Post_Types\Event as Event_Post_Type;
+
+/**
+ * @coversDefaultClass \Groups\Notifications\Scheduler
+ */
+class Test_Scheduler extends WP_UnitTestCase {
+
+	/**
+	 * Scheduler instance under test.
+	 *
+	 * @var Scheduler
+	 */
+	private Scheduler $scheduler;
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$event_cpt = new Event_Post_Type();
+		$event_cpt->register_post_type();
+		$event_cpt->register_post_statuses();
+
+		$this->scheduler = new Scheduler();
+	}
+
+	/**
+	 * Helper to create a scheduled event post.
+	 *
+	 * @param array $overrides Optional overrides for event args.
+	 * @return int Post ID.
+	 */
+	private function create_scheduled_event( array $overrides = [] ): int {
+		$args = array_merge(
+			[
+				'title'     => 'Test Meetup',
+				'content'   => 'A test event.',
+				'start_utc' => gmdate( 'Y-m-d H:i:s', time() + ( 2 * DAY_IN_SECONDS ) ),
+				'end_utc'   => gmdate( 'Y-m-d H:i:s', time() + ( 2 * DAY_IN_SECONDS ) + ( 2 * HOUR_IN_SECONDS ) ),
+				'timezone'  => 'UTC',
+				'status'    => 'event-scheduled',
+			],
+			$overrides
+		);
+
+		return Event::create( $args );
+	}
+
+	/**
+	 * @covers ::on_status_transition
+	 * @covers ::schedule_reminders
+	 */
+	public function test_scheduling_creates_cron_events_at_correct_times(): void {
+		$start_time = time() + ( 2 * DAY_IN_SECONDS );
+		$event_id   = $this->create_scheduled_event(
+			[
+				'start_utc' => gmdate( 'Y-m-d H:i:s', $start_time ),
+				'end_utc'   => gmdate( 'Y-m-d H:i:s', $start_time + ( 2 * HOUR_IN_SECONDS ) ),
+				'status'    => 'event-draft',
+			]
+		);
+
+		// Transition to scheduled — should create cron events.
+		Event::transition_status( $event_id, 'event-scheduled' );
+
+		$expected_24h = $start_time - DAY_IN_SECONDS;
+		$expected_1h  = $start_time - HOUR_IN_SECONDS;
+
+		$scheduled_24h = wp_next_scheduled( Scheduler::HOOK_24H, [ $event_id ] );
+		$scheduled_1h  = wp_next_scheduled( Scheduler::HOOK_1H, [ $event_id ] );
+
+		$this->assertSame( $expected_24h, $scheduled_24h, '24h reminder should be scheduled at start_time - 24 hours.' );
+		$this->assertSame( $expected_1h, $scheduled_1h, '1h reminder should be scheduled at start_time - 1 hour.' );
+	}
+
+	/**
+	 * @covers ::on_status_transition
+	 * @covers ::unschedule_reminders
+	 */
+	public function test_cancellation_removes_cron_events(): void {
+		$start_time = time() + ( 2 * DAY_IN_SECONDS );
+		$event_id   = $this->create_scheduled_event(
+			[
+				'start_utc' => gmdate( 'Y-m-d H:i:s', $start_time ),
+				'end_utc'   => gmdate( 'Y-m-d H:i:s', $start_time + ( 2 * HOUR_IN_SECONDS ) ),
+				'status'    => 'event-draft',
+			]
+		);
+
+		// Schedule reminders.
+		Event::transition_status( $event_id, 'event-scheduled' );
+
+		// Verify they exist.
+		$this->assertNotFalse( wp_next_scheduled( Scheduler::HOOK_24H, [ $event_id ] ) );
+		$this->assertNotFalse( wp_next_scheduled( Scheduler::HOOK_1H, [ $event_id ] ) );
+
+		// Cancel the event.
+		Event::transition_status( $event_id, 'event-cancelled' );
+
+		$this->assertFalse( wp_next_scheduled( Scheduler::HOOK_24H, [ $event_id ] ), '24h reminder should be unscheduled after cancellation.' );
+		$this->assertFalse( wp_next_scheduled( Scheduler::HOOK_1H, [ $event_id ] ), '1h reminder should be unscheduled after cancellation.' );
+	}
+
+	/**
+	 * @covers ::send_reminder
+	 */
+	public function test_reminder_does_not_send_for_cancelled_events(): void {
+		$event_id = $this->create_scheduled_event();
+
+		// Create an attending RSVP.
+		$user_id = self::factory()->user->create( [ 'user_email' => 'attendee@example.org' ] );
+		Rsvp::create( $event_id, $user_id );
+
+		// Cancel the event.
+		Event::transition_status( $event_id, 'event-cancelled' );
+
+		// Track emails sent.
+		$emails_sent = 0;
+		add_action(
+			'groups_before_email_send',
+			function () use ( &$emails_sent ) {
+				$emails_sent++;
+			}
+		);
+
+		// Fire the reminder handler.
+		$this->scheduler->send_reminder( $event_id );
+
+		$this->assertSame( 0, $emails_sent, 'No reminder emails should be sent for cancelled events.' );
+	}
+
+	/**
+	 * @covers ::send_reminder
+	 */
+	public function test_reminder_sends_to_attending_rsvps(): void {
+		$event_id = $this->create_scheduled_event();
+
+		// Create attending RSVPs.
+		$user1 = self::factory()->user->create( [ 'user_email' => 'user1@example.org' ] );
+		$user2 = self::factory()->user->create( [ 'user_email' => 'user2@example.org' ] );
+		Rsvp::create( $event_id, $user1 );
+		Rsvp::create( $event_id, $user2 );
+
+		// Track emails sent.
+		$recipients = [];
+		add_action(
+			'groups_before_email_send',
+			function ( $to ) use ( &$recipients ) {
+				$recipients[] = $to;
+			}
+		);
+
+		$this->scheduler->send_reminder( $event_id );
+
+		$this->assertCount( 2, $recipients, 'Should send reminders to all attending users.' );
+		$this->assertContains( 'user1@example.org', $recipients );
+		$this->assertContains( 'user2@example.org', $recipients );
+	}
+
+	/**
+	 * @covers ::schedule_reminders
+	 */
+	public function test_reschedule_clears_old_reminders(): void {
+		$start_time = time() + ( 2 * DAY_IN_SECONDS );
+		$event_id   = $this->create_scheduled_event(
+			[
+				'start_utc' => gmdate( 'Y-m-d H:i:s', $start_time ),
+				'end_utc'   => gmdate( 'Y-m-d H:i:s', $start_time + ( 2 * HOUR_IN_SECONDS ) ),
+				'status'    => 'event-draft',
+			]
+		);
+
+		Event::transition_status( $event_id, 'event-scheduled' );
+
+		$old_24h = wp_next_scheduled( Scheduler::HOOK_24H, [ $event_id ] );
+
+		// Update start time and reschedule.
+		$new_start = time() + ( 3 * DAY_IN_SECONDS );
+		update_post_meta( $event_id, '_event_start_utc', gmdate( 'Y-m-d H:i:s', $new_start ) );
+		$this->scheduler->schedule_reminders( $event_id );
+
+		$new_24h = wp_next_scheduled( Scheduler::HOOK_24H, [ $event_id ] );
+
+		$this->assertNotSame( $old_24h, $new_24h, 'Rescheduling should update the cron timestamp.' );
+		$this->assertSame( $new_start - DAY_IN_SECONDS, $new_24h );
+	}
+
+	/**
+	 * @covers ::schedule_reminders
+	 */
+	public function test_past_reminder_times_are_not_scheduled(): void {
+		// Event starting in 30 minutes — 24h reminder is in the past, 1h reminder is in the past.
+		$start_time = time() + ( 30 * MINUTE_IN_SECONDS );
+		$event_id   = $this->create_scheduled_event(
+			[
+				'start_utc' => gmdate( 'Y-m-d H:i:s', $start_time ),
+				'end_utc'   => gmdate( 'Y-m-d H:i:s', $start_time + HOUR_IN_SECONDS ),
+			]
+		);
+
+		$this->assertFalse( wp_next_scheduled( Scheduler::HOOK_24H, [ $event_id ] ), '24h reminder should not be scheduled for events starting in 30 minutes.' );
+		$this->assertFalse( wp_next_scheduled( Scheduler::HOOK_1H, [ $event_id ] ), '1h reminder should not be scheduled for events starting in 30 minutes.' );
+	}
+
+	/**
+	 * @covers ::on_status_transition
+	 */
+	public function test_non_event_post_type_is_ignored(): void {
+		$post_id = self::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+		// Should not schedule anything for a regular post.
+		$this->assertFalse( wp_next_scheduled( Scheduler::HOOK_24H, [ $post_id ] ) );
+		$this->assertFalse( wp_next_scheduled( Scheduler::HOOK_1H, [ $post_id ] ) );
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Scheduler` class in `Groups\Notifications` namespace that schedules wp_cron reminders when events are published (`event-scheduled` status)
- Schedule `groups_event_reminder_24h` at start_time - 24h and `groups_event_reminder_1h` at start_time - 1h using `wp_schedule_single_event()`
- On reminder fire, send `event-reminder` emails to all attending RSVPs via `Email_Notifier`; skip cancelled events
- On event cancellation, unschedule pending reminders via `wp_unschedule_event()`
- Wire `Scheduler` into `Plugin::init_components()`
- Fix PHPUnit bootstrap for wp-env multisite environments (missing `wp_blogs` row)

## Test plan
- [x] 7 tests, 16 assertions all passing locally
- [x] Full suite (226 tests, 675 assertions) passes with no regressions
- [ ] Verify scheduling creates cron events at correct times
- [ ] Verify cancellation removes cron events
- [ ] Verify reminder does not send for cancelled events
- [ ] Verify reminder sends to attending RSVPs
- [ ] Verify rescheduling clears old reminders
- [ ] Verify past reminder times are not scheduled
- [ ] Verify non-event post types are ignored

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)