### PR TITLE
Add cron job to generate recurring event instances

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -57,6 +57,8 @@ class Plugin {
 		new Workflow\Application_Workflow();
 		new Workflow\Status_Transition();
 		new Workflow\Site_Provisioner();
+		new Models\Recurrence_Generator();
+		Models\Recurrence_Generator::schedule_cron();
 
 		add_action( 'init', [ Models\Membership::class, 'register_roles' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );

--- a/wp-content/plugins/wordpress-groups/includes/models/class-recurrence-generator.php
+++ b/wp-content/plugins/wordpress-groups/includes/models/class-recurrence-generator.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * Recurrence generator — creates future event instances from recurring templates.
+ *
+ * @package Groups\Models
+ */
+
+namespace Groups\Models;
+
+use Groups\Post_Types\Event as Event_Post_Type;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Generates recurring event instances via WP-Cron.
+ *
+ * Queries all events with a recurrence rule, calculates upcoming occurrences
+ * up to 4 weeks ahead, and creates new event posts for each occurrence that
+ * does not already exist.
+ */
+class Recurrence_Generator {
+
+	/**
+	 * Cron hook name.
+	 *
+	 * @var string
+	 */
+	const CRON_HOOK = 'groups_generate_recurring_events';
+
+	/**
+	 * Post meta key linking a generated instance back to its template event.
+	 *
+	 * @var string
+	 */
+	const TEMPLATE_META_KEY = '_event_recurrence_template_id';
+
+	/**
+	 * How many weeks ahead to generate instances.
+	 *
+	 * @var int
+	 */
+	const WEEKS_AHEAD = 4;
+
+	/**
+	 * Constructor. Registers the cron callback.
+	 */
+	public function __construct() {
+		add_action( self::CRON_HOOK, [ $this, 'run' ] );
+	}
+
+	/**
+	 * Schedule the daily cron event if not already scheduled.
+	 *
+	 * Should be called during plugin initialisation.
+	 */
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Unschedule the cron event.
+	 *
+	 * Called on plugin deactivation.
+	 */
+	public static function unschedule_cron(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Run the generator for all recurring events on the current site.
+	 */
+	public function run(): void {
+		$template_ids = get_posts( [
+			'post_type'      => Event_Post_Type::POST_TYPE,
+			'post_status'    => [ 'event-draft', 'event-scheduled', 'event-active', 'publish' ],
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'     => Recurrence::META_KEY,
+					'compare' => 'EXISTS',
+				],
+			],
+		] );
+
+		foreach ( $template_ids as $template_id ) {
+			self::generate_for_event( (int) $template_id );
+		}
+	}
+
+	/**
+	 * Generate future instances for a single recurring event template.
+	 *
+	 * @param int $template_event_id The template event post ID.
+	 * @return int[] Array of newly created event post IDs.
+	 */
+	public static function generate_for_event( int $template_event_id ): array {
+		$rule = Recurrence::get_rule( $template_event_id );
+
+		if ( ! $rule ) {
+			return [];
+		}
+
+		$template_post = get_post( $template_event_id );
+
+		if ( ! $template_post || Event_Post_Type::POST_TYPE !== $template_post->post_type ) {
+			return [];
+		}
+
+		$start_utc = get_post_meta( $template_event_id, '_event_start_utc', true );
+		$end_utc   = get_post_meta( $template_event_id, '_event_end_utc', true );
+
+		if ( ! $start_utc || ! $end_utc ) {
+			return [];
+		}
+
+		$start_dt = new \DateTime( $start_utc, new \DateTimeZone( 'UTC' ) );
+		$end_dt   = new \DateTime( $end_utc, new \DateTimeZone( 'UTC' ) );
+
+		// Calculate the duration of the original event.
+		$duration = $start_dt->diff( $end_dt );
+
+		// Extract the time portion from the template event.
+		$time_of_day = $start_dt->format( 'H:i:s' );
+
+		// Calculate occurrences starting from the template's start date.
+		// We generate enough to cover at least 4 weeks from now.
+		$today       = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
+		$horizon     = ( clone $today )->modify( '+' . self::WEEKS_AHEAD . ' weeks' );
+		$occurrences = Recurrence::calculate_occurrences(
+			$rule,
+			$start_dt->format( 'Y-m-d' ),
+			200 // Generate enough candidates; the horizon check will limit.
+		);
+
+		$created_ids = [];
+
+		foreach ( $occurrences as $occurrence ) {
+			// Skip occurrences in the past.
+			if ( $occurrence < $today ) {
+				continue;
+			}
+
+			// Stop once we've gone past the horizon.
+			if ( $occurrence > $horizon ) {
+				break;
+			}
+
+			$occurrence_date = $occurrence->format( 'Y-m-d' );
+
+			// Check if an instance already exists for this date.
+			if ( self::instance_exists( $template_event_id, $occurrence_date ) ) {
+				continue;
+			}
+
+			// Build the new event's start/end UTC.
+			$new_start = new \DateTime( $occurrence_date . ' ' . $time_of_day, new \DateTimeZone( 'UTC' ) );
+			$new_end   = ( clone $new_start )->add( $duration );
+
+			$new_event_id = self::create_instance( $template_event_id, $template_post, $new_start, $new_end );
+
+			if ( $new_event_id && ! is_wp_error( $new_event_id ) ) {
+				$created_ids[] = $new_event_id;
+			}
+		}
+
+		return $created_ids;
+	}
+
+	/**
+	 * Check whether an event instance already exists for a given template and date.
+	 *
+	 * @param int    $template_event_id The template event post ID.
+	 * @param string $date              The occurrence date in Y-m-d format.
+	 * @return bool True if an instance already exists.
+	 */
+	private static function instance_exists( int $template_event_id, string $date ): bool {
+		$existing = get_posts( [
+			'post_type'      => Event_Post_Type::POST_TYPE,
+			'post_status'    => 'any',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				'relation' => 'AND',
+				[
+					'key'   => self::TEMPLATE_META_KEY,
+					'value' => $template_event_id,
+				],
+				[
+					'key'     => '_event_start_utc',
+					'value'   => [ $date . ' 00:00:00', $date . ' 23:59:59' ],
+					'compare' => 'BETWEEN',
+					'type'    => 'DATETIME',
+				],
+			],
+		] );
+
+		return ! empty( $existing );
+	}
+
+	/**
+	 * Create a single event instance from a template.
+	 *
+	 * Copies the template's title, content, venue_id, online_link,
+	 * attendee_limit, waitlist_enabled, and timezone to the new event.
+	 *
+	 * @param int       $template_event_id The template event post ID.
+	 * @param \WP_Post  $template_post     The template post object.
+	 * @param \DateTime $start             The new event start datetime (UTC).
+	 * @param \DateTime $end               The new event end datetime (UTC).
+	 * @return int|\WP_Error New post ID on success, WP_Error on failure.
+	 */
+	private static function create_instance( int $template_event_id, \WP_Post $template_post, \DateTime $start, \DateTime $end ): int|\WP_Error {
+		$timezone = get_post_meta( $template_event_id, '_event_timezone', true );
+
+		$args = [
+			'title'     => $template_post->post_title,
+			'content'   => $template_post->post_content,
+			'status'    => 'event-scheduled',
+			'start_utc' => $start->format( 'Y-m-d H:i:s' ),
+			'end_utc'   => $end->format( 'Y-m-d H:i:s' ),
+			'timezone'  => $timezone ?: 'UTC',
+		];
+
+		// Copy optional meta from template.
+		$optional_meta = [
+			'venue_id'         => '_event_venue_id',
+			'online_link'      => '_event_online_link',
+			'attendee_limit'   => '_event_attendee_limit',
+			'waitlist_enabled' => '_event_waitlist_enabled',
+		];
+
+		foreach ( $optional_meta as $arg_key => $meta_key ) {
+			$value = get_post_meta( $template_event_id, $meta_key, true );
+			if ( '' !== $value && false !== $value ) {
+				$args[ $arg_key ] = $value;
+			}
+		}
+
+		$new_id = Event::create( $args );
+
+		if ( is_wp_error( $new_id ) ) {
+			return $new_id;
+		}
+
+		// Link the new instance back to its template.
+		update_post_meta( $new_id, self::TEMPLATE_META_KEY, $template_event_id );
+
+		return $new_id;
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/models/Test_Recurrence_Generator.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/models/Test_Recurrence_Generator.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * Tests for the Recurrence_Generator model.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Models\Event;
+use Groups\Models\Recurrence;
+use Groups\Models\Recurrence_Generator;
+use Groups\Post_Types\Event as Event_Post_Type;
+
+/**
+ * @coversDefaultClass \Groups\Models\Recurrence_Generator
+ */
+class Test_Recurrence_Generator extends WP_UnitTestCase {
+
+	/**
+	 * Ensure the event CPT and statuses are registered before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$event_cpt = new Event_Post_Type();
+		$event_cpt->register_post_type();
+		$event_cpt->register_post_statuses();
+	}
+
+	/**
+	 * Helper to create a recurring template event.
+	 *
+	 * @param array $overrides Optional overrides for event args.
+	 * @param array $rule      Optional overrides for recurrence rule.
+	 * @return int The template event post ID.
+	 */
+	private function create_template_event( array $overrides = [], array $rule = [] ): int {
+		// Default: an event starting next Monday at 18:00 UTC, 2 hours long.
+		$next_monday = new DateTime( 'next monday', new DateTimeZone( 'UTC' ) );
+
+		$defaults = [
+			'title'            => 'Weekly WordPress Meetup',
+			'content'          => 'Come join us every week!',
+			'status'           => 'event-scheduled',
+			'start_utc'        => $next_monday->format( 'Y-m-d' ) . ' 18:00:00',
+			'end_utc'          => $next_monday->format( 'Y-m-d' ) . ' 20:00:00',
+			'timezone'         => 'America/Chicago',
+			'venue_id'         => 42,
+			'online_link'      => 'https://meet.example.com/weekly',
+			'attendee_limit'   => 30,
+			'waitlist_enabled' => true,
+		];
+
+		$args     = array_merge( $defaults, $overrides );
+		$event_id = Event::create( $args );
+
+		$this->assertIsInt( $event_id );
+
+		$default_rule = array_merge(
+			[
+				'frequency'   => 'weekly',
+				'day_of_week' => (int) $next_monday->format( 'w' ),
+			],
+			$rule
+		);
+
+		$result = Recurrence::save_rule( $event_id, $default_rule );
+		$this->assertTrue( $result );
+
+		return $event_id;
+	}
+
+	/**
+	 * @covers ::generate_for_event
+	 */
+	public function test_generates_future_instances(): void {
+		// Create a template event starting today so occurrences fall within horizon.
+		$today    = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->create_template_event(
+			[
+				'start_utc' => $today->format( 'Y-m-d' ) . ' 18:00:00',
+				'end_utc'   => $today->format( 'Y-m-d' ) . ' 20:00:00',
+			],
+			[
+				'frequency'   => 'weekly',
+				'day_of_week' => (int) $today->format( 'w' ),
+			]
+		);
+
+		$created = Recurrence_Generator::generate_for_event( $event_id );
+
+		// Should create instances for upcoming weeks within the 4-week horizon.
+		// The first occurrence (today) counts as "not in the past" if it's today,
+		// but the template itself already exists. We expect at least 1 future instance.
+		$this->assertNotEmpty( $created, 'Should create at least one future instance.' );
+
+		// Each created instance should be a valid post.
+		foreach ( $created as $instance_id ) {
+			$post = get_post( $instance_id );
+			$this->assertSame( 'event', $post->post_type );
+			$this->assertSame( 'event-scheduled', $post->post_status );
+		}
+	}
+
+	/**
+	 * @covers ::generate_for_event
+	 */
+	public function test_does_not_create_duplicates_on_rerun(): void {
+		$today    = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->create_template_event(
+			[
+				'start_utc' => $today->format( 'Y-m-d' ) . ' 18:00:00',
+				'end_utc'   => $today->format( 'Y-m-d' ) . ' 20:00:00',
+			],
+			[
+				'frequency'   => 'weekly',
+				'day_of_week' => (int) $today->format( 'w' ),
+			]
+		);
+
+		$first_run  = Recurrence_Generator::generate_for_event( $event_id );
+		$second_run = Recurrence_Generator::generate_for_event( $event_id );
+
+		$this->assertNotEmpty( $first_run, 'First run should create instances.' );
+		$this->assertEmpty( $second_run, 'Second run should not create duplicates.' );
+	}
+
+	/**
+	 * @covers ::generate_for_event
+	 */
+	public function test_instances_inherit_template_properties(): void {
+		$today    = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		$event_id = $this->create_template_event(
+			[
+				'title'            => 'Inherited Props Meetup',
+				'content'          => 'Description to inherit.',
+				'start_utc'        => $today->format( 'Y-m-d' ) . ' 19:00:00',
+				'end_utc'          => $today->format( 'Y-m-d' ) . ' 21:00:00',
+				'timezone'         => 'Europe/London',
+				'venue_id'         => 99,
+				'online_link'      => 'https://zoom.us/j/inherited',
+				'attendee_limit'   => 25,
+				'waitlist_enabled' => true,
+			],
+			[
+				'frequency'   => 'weekly',
+				'day_of_week' => (int) $today->format( 'w' ),
+			]
+		);
+
+		$created = Recurrence_Generator::generate_for_event( $event_id );
+		$this->assertNotEmpty( $created );
+
+		$instance_id = $created[0];
+		$instance     = get_post( $instance_id );
+
+		// Title and content.
+		$this->assertSame( 'Inherited Props Meetup', $instance->post_title );
+		$this->assertSame( 'Description to inherit.', $instance->post_content );
+
+		// Meta fields.
+		$this->assertSame( 'Europe/London', get_post_meta( $instance_id, '_event_timezone', true ) );
+		$this->assertEquals( 99, get_post_meta( $instance_id, '_event_venue_id', true ) );
+		$this->assertSame( 'https://zoom.us/j/inherited', get_post_meta( $instance_id, '_event_online_link', true ) );
+		$this->assertEquals( 25, get_post_meta( $instance_id, '_event_attendee_limit', true ) );
+		$this->assertEquals( true, get_post_meta( $instance_id, '_event_waitlist_enabled', true ) );
+
+		// Template link.
+		$this->assertEquals( $event_id, get_post_meta( $instance_id, Recurrence_Generator::TEMPLATE_META_KEY, true ) );
+
+		// Duration should be preserved (2 hours).
+		$instance_start = new DateTime( get_post_meta( $instance_id, '_event_start_utc', true ) );
+		$instance_end   = new DateTime( get_post_meta( $instance_id, '_event_end_utc', true ) );
+		$diff           = $instance_start->diff( $instance_end );
+		$this->assertSame( 2, $diff->h );
+		$this->assertSame( 0, $diff->i );
+	}
+
+	/**
+	 * @covers ::generate_for_event
+	 */
+	public function test_returns_empty_for_non_recurring_event(): void {
+		$event_id = Event::create( [
+			'title'     => 'One-off Event',
+			'start_utc' => '2026-04-15 18:00:00',
+			'end_utc'   => '2026-04-15 20:00:00',
+			'timezone'  => 'UTC',
+		] );
+
+		$created = Recurrence_Generator::generate_for_event( $event_id );
+
+		$this->assertEmpty( $created );
+	}
+
+	/**
+	 * @covers ::generate_for_event
+	 */
+	public function test_respects_recurrence_end_date(): void {
+		$today    = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		// End date is 1 week from now — should only create at most 1 instance.
+		$end_date = ( clone $today )->modify( '+8 days' )->format( 'Y-m-d' );
+
+		$event_id = $this->create_template_event(
+			[
+				'start_utc' => $today->format( 'Y-m-d' ) . ' 18:00:00',
+				'end_utc'   => $today->format( 'Y-m-d' ) . ' 20:00:00',
+			],
+			[
+				'frequency'   => 'weekly',
+				'day_of_week' => (int) $today->format( 'w' ),
+				'end_date'    => $end_date,
+			]
+		);
+
+		$created = Recurrence_Generator::generate_for_event( $event_id );
+
+		// With a 1-week-and-a-day end date, we expect exactly 1 future instance (next week).
+		$this->assertCount( 1, $created );
+	}
+
+	/**
+	 * @covers ::schedule_cron
+	 */
+	public function test_schedule_cron_registers_event(): void {
+		// Clear any existing schedule.
+		$ts = wp_next_scheduled( Recurrence_Generator::CRON_HOOK );
+		if ( $ts ) {
+			wp_unschedule_event( $ts, Recurrence_Generator::CRON_HOOK );
+		}
+
+		Recurrence_Generator::schedule_cron();
+
+		$this->assertNotFalse(
+			wp_next_scheduled( Recurrence_Generator::CRON_HOOK ),
+			'Cron event should be scheduled.'
+		);
+	}
+
+	/**
+	 * @covers ::schedule_cron
+	 */
+	public function test_schedule_cron_does_not_duplicate(): void {
+		// Clear any existing schedule.
+		$ts = wp_next_scheduled( Recurrence_Generator::CRON_HOOK );
+		if ( $ts ) {
+			wp_unschedule_event( $ts, Recurrence_Generator::CRON_HOOK );
+		}
+
+		Recurrence_Generator::schedule_cron();
+		$first = wp_next_scheduled( Recurrence_Generator::CRON_HOOK );
+
+		Recurrence_Generator::schedule_cron();
+		$second = wp_next_scheduled( Recurrence_Generator::CRON_HOOK );
+
+		$this->assertSame( $first, $second, 'Should not create a duplicate cron schedule.' );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `Recurrence_Generator` class with a daily WP-Cron hook (`groups_generate_recurring_events`) that queries all events with `_event_recurrence_rule` meta, calculates upcoming occurrences up to 4 weeks ahead, and creates new `event-scheduled` posts for each date not already covered
- Each generated instance copies title, content, venue_id, online_link, attendee_limit, waitlist_enabled, and timezone from the template event, with start/end UTC adjusted to the occurrence date while preserving the original time and duration
- Instances are linked to their template via `_event_recurrence_template_id` post meta; duplicate detection uses a meta query on template ID + start date range
- Exposes `Recurrence_Generator::generate_for_event( $template_event_id )` as a static method for manual/programmatic triggering
- Wires cron scheduling into the Plugin class alongside existing cron jobs

## Test plan
- [x] `Test_Recurrence_Generator::test_generates_future_instances` -- weekly template creates instances within 4-week horizon
- [x] `Test_Recurrence_Generator::test_does_not_create_duplicates_on_rerun` -- second invocation returns empty array
- [x] `Test_Recurrence_Generator::test_instances_inherit_template_properties` -- title, content, timezone, venue_id, online_link, attendee_limit, waitlist_enabled, duration, and template link meta all match
- [x] `Test_Recurrence_Generator::test_returns_empty_for_non_recurring_event` -- no-op for events without recurrence rule
- [x] `Test_Recurrence_Generator::test_respects_recurrence_end_date` -- end_date in rule limits instance generation
- [x] `Test_Recurrence_Generator::test_schedule_cron_registers_event` -- cron hook is scheduled
- [x] `Test_Recurrence_Generator::test_schedule_cron_does_not_duplicate` -- idempotent scheduling
- [x] All 7 tests pass locally (PHPUnit 9, 34 assertions); existing test suite unaffected

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)