### PR TITLE
Add daily aggregation cron for groups_analytics_daily

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/analytics/class-aggregator.php
+++ b/wp-content/plugins/wordpress-groups/includes/analytics/class-aggregator.php
@@ -1,0 +1,273 @@
+<?php
+/**
+ * Daily aggregation cron — summarizes data into groups_analytics_daily.
+ *
+ * @package Groups\Analytics
+ */
+
+namespace Groups\Analytics;
+
+use Groups\Database\Analytics_Table;
+use Groups\Database\Activity_Log_Table;
+use Groups\Post_Types\Event as Event_Post_Type;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Iterates all active wp_meetup groups on a daily cron schedule,
+ * collecting per-group metrics and writing them to the
+ * groups_analytics_daily table via Analytics_Table::insert().
+ *
+ * Idempotent: re-running for the same date updates existing rows
+ * thanks to INSERT ON DUPLICATE KEY UPDATE in Analytics_Table.
+ */
+class Aggregator {
+
+	/**
+	 * Cron hook name.
+	 *
+	 * @var string
+	 */
+	const CRON_HOOK = 'groups_daily_aggregation';
+
+	/**
+	 * Constructor. Registers the cron action hook.
+	 */
+	public function __construct() {
+		add_action( self::CRON_HOOK, [ __CLASS__, 'run_daily' ] );
+	}
+
+	/**
+	 * Schedule the daily cron event if not already scheduled.
+	 *
+	 * Should be called during plugin initialisation.
+	 */
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Unschedule the cron event.
+	 *
+	 * Called on plugin deactivation.
+	 */
+	public static function unschedule_cron(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Daily cron callback — aggregates for yesterday's date.
+	 */
+	public static function run_daily(): void {
+		$yesterday = gmdate( 'Y-m-d', strtotime( '-1 day' ) );
+		self::aggregate_for_date( $yesterday );
+	}
+
+	/**
+	 * Aggregate metrics for all active groups on a given date.
+	 *
+	 * This is the main public entry point, also usable for backfilling.
+	 *
+	 * @param string $date Date in Y-m-d format.
+	 */
+	public static function aggregate_for_date( string $date ): void {
+		$posts = get_posts( [
+			'post_type'      => 'wp_meetup',
+			'post_status'    => 'meetup-active',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+		] );
+
+		foreach ( $posts as $post_id ) {
+			self::aggregate_group( (int) $post_id, $date );
+		}
+	}
+
+	/**
+	 * Aggregate metrics for a single group on a given date.
+	 *
+	 * Switches to the group's blog, collects metrics, writes to
+	 * the analytics daily table, then restores the original blog.
+	 *
+	 * @param int    $post_id The wp_meetup post ID on the central tracker.
+	 * @param string $date    Date in Y-m-d format.
+	 */
+	public static function aggregate_group( int $post_id, string $date ): void {
+		$site_id = get_post_meta( $post_id, '_meetup_site_id', true );
+
+		if ( ! $site_id ) {
+			return;
+		}
+
+		$site_id = (int) $site_id;
+		$metrics = self::collect_metrics( $site_id, $date );
+
+		foreach ( $metrics as $metric => $value ) {
+			Analytics_Table::insert( $date, $site_id, $metric, $value );
+		}
+	}
+
+	/**
+	 * Collect all metrics for a group site on a given date.
+	 *
+	 * @param int    $blog_id The blog ID of the group site.
+	 * @param string $date    Date in Y-m-d format.
+	 * @return array<string, int> Associative array of metric => value.
+	 */
+	public static function collect_metrics( int $blog_id, string $date ): array {
+		$metrics = [];
+
+		// Switch to the group's blog for per-site queries.
+		switch_to_blog( $blog_id );
+
+		$metrics['members']    = self::count_members();
+		$metrics['events_held'] = self::count_events_held( $date );
+
+		$rsvp_data = self::count_rsvp_metrics( $date );
+
+		$metrics['rsvps_total']    = $rsvp_data['rsvps_total'];
+		$metrics['attendees']      = $rsvp_data['attendees'];
+		$metrics['newcomers']      = $rsvp_data['newcomers'];
+		$metrics['no_shows']       = $rsvp_data['no_shows'];
+
+		restore_current_blog();
+
+		// Activity log queries are network-wide, no blog switch needed.
+		$metrics['members_joined']  = self::count_activity( $blog_id, $date, 'member_joined' );
+		$metrics['members_left']    = self::count_activity( $blog_id, $date, 'member_left' );
+		$metrics['events_created']  = self::count_activity( $blog_id, $date, 'event_created' );
+
+		return $metrics;
+	}
+
+	/**
+	 * Count current members on the switched-to blog.
+	 *
+	 * @return int
+	 */
+	private static function count_members(): int {
+		$users = get_users( [
+			'blog_id' => get_current_blog_id(),
+			'fields'  => 'ID',
+		] );
+
+		return count( $users );
+	}
+
+	/**
+	 * Count events with event-past status held on the given date.
+	 *
+	 * Uses the _event_start_utc meta to determine the event date.
+	 *
+	 * @param string $date Date in Y-m-d format.
+	 * @return int
+	 */
+	private static function count_events_held( string $date ): int {
+		$events = get_posts( [
+			'post_type'      => Event_Post_Type::POST_TYPE,
+			'post_status'    => 'event-past',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'     => '_event_start_utc',
+					'value'   => [ $date . ' 00:00:00', $date . ' 23:59:59' ],
+					'compare' => 'BETWEEN',
+					'type'    => 'DATETIME',
+				],
+			],
+		] );
+
+		return count( $events );
+	}
+
+	/**
+	 * Count RSVP-related metrics for events held on the given date.
+	 *
+	 * Iterates events held on the date and examines RSVP comments
+	 * (stored as comments with meta) on each event.
+	 *
+	 * @param string $date Date in Y-m-d format.
+	 * @return array{rsvps_total: int, attendees: int, newcomers: int, no_shows: int}
+	 */
+	private static function count_rsvp_metrics( string $date ): array {
+		$result = [
+			'rsvps_total' => 0,
+			'attendees'   => 0,
+			'newcomers'   => 0,
+			'no_shows'    => 0,
+		];
+
+		$events = get_posts( [
+			'post_type'      => Event_Post_Type::POST_TYPE,
+			'post_status'    => 'event-past',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'meta_query'     => [
+				[
+					'key'     => '_event_start_utc',
+					'value'   => [ $date . ' 00:00:00', $date . ' 23:59:59' ],
+					'compare' => 'BETWEEN',
+					'type'    => 'DATETIME',
+				],
+			],
+		] );
+
+		foreach ( $events as $event_id ) {
+			$comments = get_comments( [
+				'post_id' => $event_id,
+				'status'  => 'approve',
+				'number'  => 0, // No limit.
+			] );
+
+			foreach ( $comments as $comment ) {
+				$rsvp_status = get_comment_meta( $comment->comment_ID, 'rsvp_status', true );
+
+				if ( ! $rsvp_status ) {
+					continue;
+				}
+
+				$result['rsvps_total']++;
+
+				if ( 'attending' === $rsvp_status ) {
+					$result['attendees']++;
+
+					if ( get_comment_meta( $comment->comment_ID, 'is_first_event', true ) ) {
+						$result['newcomers']++;
+					}
+				}
+
+				if ( 'no_show' === $rsvp_status ) {
+					$result['no_shows']++;
+				}
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Count activity log entries for a given blog, date, and action.
+	 *
+	 * @param int    $blog_id Blog ID.
+	 * @param string $date    Date in Y-m-d format.
+	 * @param string $action  Action name (e.g. 'member_joined').
+	 * @return int
+	 */
+	private static function count_activity( int $blog_id, string $date, string $action ): int {
+		$entries = Activity_Log_Table::query( [
+			'blog_id'   => $blog_id,
+			'action'    => $action,
+			'date_from' => $date,
+			'date_to'   => $date,
+			'limit'     => 10000,
+		] );
+
+		return count( $entries );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -50,6 +50,8 @@ class Plugin {
 		new Blocks\Block_Registrar();
 		new Analytics\Newcomer_Tracker();
 		new Analytics\Activity_Logger();
+		new Analytics\Aggregator();
+		Analytics\Aggregator::schedule_cron();
 		new Analytics\Dormancy_Detector();
 		Analytics\Dormancy_Detector::schedule_cron();
 		new Calendar\ICal_Export();

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/analytics/Test_Aggregator.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/analytics/Test_Aggregator.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * Tests for the daily aggregation cron.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Analytics\Aggregator;
+use Groups\Database\Analytics_Table;
+use Groups\Database\Activity_Log_Table;
+
+/**
+ * @coversDefaultClass \Groups\Analytics\Aggregator
+ */
+class Test_Aggregator extends WP_UnitTestCase {
+
+	/**
+	 * The blog ID of the test group site.
+	 *
+	 * @var int
+	 */
+	private int $group_blog_id;
+
+	/**
+	 * The wp_meetup post ID on the central tracker.
+	 *
+	 * @var int
+	 */
+	private int $meetup_post_id;
+
+	/**
+	 * The date to aggregate for.
+	 *
+	 * @var string
+	 */
+	private string $test_date;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->test_date = gmdate( 'Y-m-d' );
+
+		// Register the wp_meetup post type and statuses.
+		if ( ! post_type_exists( 'wp_meetup' ) ) {
+			register_post_type( 'wp_meetup', [ 'public' => false ] );
+		}
+
+		if ( ! get_post_status_object( 'meetup-active' ) ) {
+			register_post_status( 'meetup-active', [
+				'label'  => 'Active',
+				'public' => true,
+			] );
+		}
+
+		// Register event post type and status.
+		if ( ! post_type_exists( 'event' ) ) {
+			register_post_type( 'event', [ 'public' => true ] );
+		}
+
+		if ( ! get_post_status_object( 'event-past' ) ) {
+			register_post_status( 'event-past', [
+				'label'  => 'Past',
+				'public' => true,
+			] );
+		}
+
+		// Use the current blog as the "group site" since we cannot create
+		// subsites in the standard WP unit test environment.
+		$this->group_blog_id = get_current_blog_id();
+
+		// Create the wp_meetup post linking to this blog.
+		$this->meetup_post_id = self::factory()->post->create( [
+			'post_type'   => 'wp_meetup',
+			'post_status' => 'meetup-active',
+			'post_title'  => 'Test Group',
+		] );
+
+		update_post_meta( $this->meetup_post_id, '_meetup_site_id', $this->group_blog_id );
+	}
+
+	/**
+	 * @covers ::schedule_cron
+	 * @covers ::unschedule_cron
+	 */
+	public function test_cron_scheduling(): void {
+		Aggregator::unschedule_cron();
+		$this->assertFalse( wp_next_scheduled( Aggregator::CRON_HOOK ) );
+
+		Aggregator::schedule_cron();
+		$this->assertNotFalse( wp_next_scheduled( Aggregator::CRON_HOOK ) );
+
+		// Scheduling again should not create a duplicate.
+		$first = wp_next_scheduled( Aggregator::CRON_HOOK );
+		Aggregator::schedule_cron();
+		$this->assertSame( $first, wp_next_scheduled( Aggregator::CRON_HOOK ) );
+
+		Aggregator::unschedule_cron();
+		$this->assertFalse( wp_next_scheduled( Aggregator::CRON_HOOK ) );
+	}
+
+	/**
+	 * @covers ::aggregate_for_date
+	 * @covers ::aggregate_group
+	 * @covers ::collect_metrics
+	 */
+	public function test_aggregation_creates_metric_rows(): void {
+		// Create a past event for today.
+		$event_id = self::factory()->post->create( [
+			'post_type'   => 'event',
+			'post_status' => 'event-past',
+			'post_title'  => 'Test Event',
+		] );
+
+		update_post_meta( $event_id, '_event_start_utc', $this->test_date . ' 18:00:00' );
+
+		// Create an RSVP comment on the event.
+		$comment_id = self::factory()->comment->create( [
+			'comment_post_ID'  => $event_id,
+			'comment_approved' => 1,
+			'user_id'          => 1,
+		] );
+
+		update_comment_meta( $comment_id, 'rsvp_status', 'attending' );
+
+		// Create a user on this blog so we have at least 1 member.
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		Aggregator::aggregate_for_date( $this->test_date );
+
+		// Query all rows for this blog and date.
+		$rows = Analytics_Table::query( [
+			'blog_id'   => $this->group_blog_id,
+			'date_from' => $this->test_date,
+			'date_to'   => $this->test_date,
+		] );
+
+		// We expect rows for all 9 metrics.
+		$metrics = wp_list_pluck( $rows, 'value', 'metric' );
+
+		$this->assertArrayHasKey( 'members', $metrics );
+		$this->assertArrayHasKey( 'events_held', $metrics );
+		$this->assertArrayHasKey( 'rsvps_total', $metrics );
+		$this->assertArrayHasKey( 'attendees', $metrics );
+		$this->assertArrayHasKey( 'newcomers', $metrics );
+		$this->assertArrayHasKey( 'no_shows', $metrics );
+		$this->assertArrayHasKey( 'members_joined', $metrics );
+		$this->assertArrayHasKey( 'members_left', $metrics );
+		$this->assertArrayHasKey( 'events_created', $metrics );
+
+		// Verify some specific values.
+		$this->assertEquals( 1, (int) $metrics['events_held'], 'Should have 1 event held.' );
+		$this->assertEquals( 1, (int) $metrics['rsvps_total'], 'Should have 1 RSVP.' );
+		$this->assertEquals( 1, (int) $metrics['attendees'], 'Should have 1 attendee.' );
+		$this->assertGreaterThanOrEqual( 1, (int) $metrics['members'], 'Should have at least 1 member.' );
+	}
+
+	/**
+	 * @covers ::aggregate_for_date
+	 */
+	public function test_idempotent_rerun_updates_existing_rows(): void {
+		// Create a past event.
+		$event_id = self::factory()->post->create( [
+			'post_type'   => 'event',
+			'post_status' => 'event-past',
+		] );
+
+		update_post_meta( $event_id, '_event_start_utc', $this->test_date . ' 18:00:00' );
+
+		// First aggregation.
+		Aggregator::aggregate_for_date( $this->test_date );
+
+		$rows_first = Analytics_Table::query( [
+			'blog_id'   => $this->group_blog_id,
+			'date_from' => $this->test_date,
+			'date_to'   => $this->test_date,
+		] );
+
+		// Second aggregation — should not duplicate rows.
+		Aggregator::aggregate_for_date( $this->test_date );
+
+		$rows_second = Analytics_Table::query( [
+			'blog_id'   => $this->group_blog_id,
+			'date_from' => $this->test_date,
+			'date_to'   => $this->test_date,
+		] );
+
+		$this->assertCount( count( $rows_first ), $rows_second, 'Re-running should not create duplicate rows.' );
+
+		// Values should be identical.
+		$metrics_first  = wp_list_pluck( $rows_first, 'value', 'metric' );
+		$metrics_second = wp_list_pluck( $rows_second, 'value', 'metric' );
+
+		$this->assertSame( $metrics_first, $metrics_second, 'Re-running should produce identical values.' );
+	}
+
+	/**
+	 * @covers ::collect_metrics
+	 */
+	public function test_metrics_correct_for_known_data(): void {
+		// Create 2 past events for the test date.
+		for ( $i = 0; $i < 2; $i++ ) {
+			$event_id = self::factory()->post->create( [
+				'post_type'   => 'event',
+				'post_status' => 'event-past',
+			] );
+
+			update_post_meta( $event_id, '_event_start_utc', $this->test_date . ' 18:00:00' );
+
+			// Create RSVPs on each event.
+			$attending = self::factory()->comment->create( [
+				'comment_post_ID'  => $event_id,
+				'comment_approved' => 1,
+				'user_id'          => $i + 10,
+			] );
+			update_comment_meta( $attending, 'rsvp_status', 'attending' );
+
+			// Add a newcomer on the first event.
+			if ( 0 === $i ) {
+				$newcomer = self::factory()->comment->create( [
+					'comment_post_ID'  => $event_id,
+					'comment_approved' => 1,
+					'user_id'          => 100,
+				] );
+				update_comment_meta( $newcomer, 'rsvp_status', 'attending' );
+				update_comment_meta( $newcomer, 'is_first_event', 1 );
+			}
+
+			// Add a no-show on the second event.
+			if ( 1 === $i ) {
+				$no_show = self::factory()->comment->create( [
+					'comment_post_ID'  => $event_id,
+					'comment_approved' => 1,
+					'user_id'          => 200,
+				] );
+				update_comment_meta( $no_show, 'rsvp_status', 'no_show' );
+			}
+		}
+
+		// Add activity log entries for the test date.
+		Activity_Log_Table::insert( $this->group_blog_id, 1, 'member_joined', 1 );
+		Activity_Log_Table::insert( $this->group_blog_id, 2, 'member_joined', 2 );
+		Activity_Log_Table::insert( $this->group_blog_id, 3, 'member_left', 3 );
+		Activity_Log_Table::insert( $this->group_blog_id, 4, 'event_created', 10 );
+
+		$metrics = Aggregator::collect_metrics( $this->group_blog_id, $this->test_date );
+
+		$this->assertSame( 2, $metrics['events_held'], 'Should count 2 past events.' );
+		// 2 attending + 1 newcomer attending + 1 no_show = 4 RSVPs total.
+		$this->assertSame( 4, $metrics['rsvps_total'], 'Should count 4 RSVPs total.' );
+		// 2 attending + 1 newcomer attending = 3 attendees.
+		$this->assertSame( 3, $metrics['attendees'], 'Should count 3 attendees.' );
+		$this->assertSame( 1, $metrics['newcomers'], 'Should count 1 newcomer.' );
+		$this->assertSame( 1, $metrics['no_shows'], 'Should count 1 no-show.' );
+		$this->assertSame( 2, $metrics['members_joined'], 'Should count 2 members joined.' );
+		$this->assertSame( 1, $metrics['members_left'], 'Should count 1 member left.' );
+		$this->assertSame( 1, $metrics['events_created'], 'Should count 1 event created.' );
+	}
+
+	/**
+	 * @covers ::aggregate_group
+	 */
+	public function test_group_without_site_id_skipped(): void {
+		$post_id = self::factory()->post->create( [
+			'post_type'   => 'wp_meetup',
+			'post_status' => 'meetup-active',
+		] );
+
+		// No _meetup_site_id meta set.
+		Aggregator::aggregate_group( $post_id, $this->test_date );
+
+		$rows = Analytics_Table::query( [
+			'date_from' => $this->test_date,
+			'date_to'   => $this->test_date,
+			'metric'    => 'members',
+		] );
+
+		// Filter to only rows that would have blog_id = 0 or similar.
+		// Since no site_id was set, no rows should be written for this group.
+		$blog_ids = wp_list_pluck( $rows, 'blog_id' );
+		$this->assertNotContains( '0', $blog_ids, 'Group without site ID should not produce rows.' );
+	}
+}


### PR DESCRIPTION
## Summary
- Implements `Groups\Analytics\Aggregator` class with daily WP-Cron event (`groups_daily_aggregation`) that iterates all active `wp_meetup` groups, switches to each group's blog, and collects 9 metrics: members, events_held, rsvps_total, attendees, newcomers, no_shows, members_joined, members_left, events_created
- Writes metrics to `groups_analytics_daily` via `Analytics_Table::insert()` with INSERT ON DUPLICATE KEY UPDATE for idempotent re-runs
- Exposes static `aggregate_for_date( string $date )` method for backfilling historical data
- Wired into Plugin class initialization with cron scheduling

## Test plan
- [x] Test aggregation creates all 9 metric rows for a group with known data
- [x] Test re-running aggregation for the same date is idempotent (no duplicate rows, same values)
- [x] Test metrics are correct for known fixture data (2 events, 3 attendees, 1 newcomer, 1 no-show, activity log entries)
- [x] Test cron scheduling and unscheduling
- [x] Test groups without `_meetup_site_id` are skipped gracefully
- [x] All 5 new tests pass; all 282 existing tests unaffected

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)