### PR TITLE
Add RSVP confirmation and promotion emails

### DIFF
--- a/wp-content/plugins/wordpress-groups/email-templates/rsvp-promotion.html
+++ b/wp-content/plugins/wordpress-groups/email-templates/rsvp-promotion.html
@@ -1,0 +1,68 @@
+<h1 style="margin: 0 0 24px 0; font-size: 24px; font-weight: 700; color: #1e1e1e; line-height: 1.3;">
+	You're In! A Spot Opened Up
+</h1>
+
+<p style="margin: 0 0 20px 0;">
+	Hi {{user_name}},
+</p>
+
+<p style="margin: 0 0 20px 0;">
+	Great news — a spot has opened up and you've been moved from the waitlist to the attending list for <strong>{{event_title}}</strong>! We look forward to seeing you there.
+</p>
+
+<!-- Event Details Card -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 0 28px 0;">
+	<tr>
+		<td class="info-box" style="background-color: #f0f6fc; border-left: 4px solid #3858E9; border-radius: 0 8px 8px 0; padding: 20px 24px;">
+			<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+				<tr>
+					<td style="padding-bottom: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;">
+						<span style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #3858E9;">Event Details</span>
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 8px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 18px; font-weight: 600; color: #1e1e1e;">
+						{{event_title}}
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 4px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#128197;&nbsp; {{event_date}} at {{event_time}}
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 4px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#128205;&nbsp; {{venue_name}}
+					</td>
+				</tr>
+				<tr>
+					<td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#128101;&nbsp; {{group_name}}
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+
+<!-- Status Badge -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 28px 0;">
+	<tr>
+		<td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 13px; font-weight: 600; color: #ffffff; padding: 6px 16px; border-radius: 20px; background-color: #00a32a;">
+			{{rsvp_status}}
+		</td>
+	</tr>
+</table>
+
+<!-- CTA Button -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 28px 0;">
+	<tr>
+		<td style="border-radius: 8px; background-color: #3858E9;" class="cta-button">
+			<a href="{{event_url}}" target="_blank" style="display: inline-block; padding: 14px 32px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none; border-radius: 8px;">View Event Details</a>
+		</td>
+	</tr>
+</table>
+
+<p style="margin: 0 0 8px 0; font-size: 14px; color: #646970;">
+	If your plans change, please update your RSVP so others on the waitlist can attend.
+</p>

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -56,6 +56,7 @@ class Plugin {
 		Analytics\Dormancy_Detector::schedule_cron();
 		new Calendar\ICal_Export();
 		new Notifications\Scheduler();
+		new Notifications\Rsvp_Notifications();
 		new Workflow\Application_Workflow();
 		new Workflow\Status_Transition();
 		new Workflow\Site_Provisioner();

--- a/wp-content/plugins/wordpress-groups/includes/notifications/class-rsvp-notifications.php
+++ b/wp-content/plugins/wordpress-groups/includes/notifications/class-rsvp-notifications.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * RSVP notification emails.
+ *
+ * Sends confirmation emails on RSVP creation and promotion from waitlist.
+ *
+ * @package Groups\Notifications
+ */
+
+namespace Groups\Notifications;
+
+use Groups\Models\Event;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles RSVP-related email notifications.
+ */
+class Rsvp_Notifications {
+
+	/**
+	 * Email notifier instance.
+	 *
+	 * @var Email_Notifier
+	 */
+	private Email_Notifier $notifier;
+
+	/**
+	 * Constructor — registers hooks.
+	 *
+	 * @param Email_Notifier|null $notifier Optional. Email notifier instance.
+	 */
+	public function __construct( ?Email_Notifier $notifier = null ) {
+		$this->notifier = $notifier ?? new Email_Notifier();
+
+		add_action( 'groups_rsvp_created', [ $this, 'on_rsvp_created' ], 10, 4 );
+		add_action( 'groups_rsvp_promoted', [ $this, 'on_rsvp_promoted' ], 10, 3 );
+	}
+
+	/**
+	 * Send a confirmation email when an RSVP is created.
+	 *
+	 * @param int    $comment_id The RSVP comment ID.
+	 * @param int    $event_id   The event post ID.
+	 * @param int    $user_id    The user ID.
+	 * @param string $status     The RSVP status (attending or waitlisted).
+	 */
+	public function on_rsvp_created( int $comment_id, int $event_id, int $user_id, string $status ): void {
+		$user = get_userdata( $user_id );
+
+		if ( ! $user ) {
+			return;
+		}
+
+		/**
+		 * Filters whether to send an RSVP confirmation email.
+		 *
+		 * @param bool   $send     Whether to send. Default true.
+		 * @param int    $event_id The event post ID.
+		 * @param int    $user_id  The user ID.
+		 * @param string $status   The RSVP status.
+		 */
+		if ( ! apply_filters( 'groups_send_rsvp_confirmation', true, $event_id, $user_id, $status ) ) {
+			return;
+		}
+
+		$data = $this->get_email_data( $event_id, $user, $status );
+
+		if ( null === $data ) {
+			return;
+		}
+
+		$subject = 'attending' === $status
+			? sprintf(
+				/* translators: %s: event title */
+				__( 'RSVP Confirmed: %s', 'wordpress-groups' ),
+				$data['event_title']
+			)
+			: sprintf(
+				/* translators: %s: event title */
+				__( 'Waitlisted: %s', 'wordpress-groups' ),
+				$data['event_title']
+			);
+
+		$this->notifier->send(
+			$user->user_email,
+			$subject,
+			'rsvp-confirmation',
+			$data
+		);
+	}
+
+	/**
+	 * Send a promotion email when a waitlisted RSVP is promoted to attending.
+	 *
+	 * @param int $comment_id The RSVP comment ID.
+	 * @param int $event_id   The event post ID.
+	 * @param int $user_id    The user ID.
+	 */
+	public function on_rsvp_promoted( int $comment_id, int $event_id, int $user_id ): void {
+		$user = get_userdata( $user_id );
+
+		if ( ! $user ) {
+			return;
+		}
+
+		/**
+		 * Filters whether to send an RSVP promotion email.
+		 *
+		 * @param bool $send     Whether to send. Default true.
+		 * @param int  $event_id The event post ID.
+		 * @param int  $user_id  The user ID.
+		 */
+		if ( ! apply_filters( 'groups_send_rsvp_promotion', true, $event_id, $user_id ) ) {
+			return;
+		}
+
+		$data = $this->get_email_data( $event_id, $user, 'attending' );
+
+		if ( null === $data ) {
+			return;
+		}
+
+		$data['is_promotion'] = true;
+
+		$subject = sprintf(
+			/* translators: %s: event title */
+			__( "You're In! %s", 'wordpress-groups' ),
+			$data['event_title']
+		);
+
+		$this->notifier->send(
+			$user->user_email,
+			$subject,
+			'rsvp-promotion',
+			$data
+		);
+	}
+
+	/**
+	 * Build the template data array for an RSVP email.
+	 *
+	 * @param int      $event_id The event post ID.
+	 * @param \WP_User $user     The user object.
+	 * @param string   $status   The RSVP status.
+	 * @return array|null Template data array, or null if event is invalid.
+	 */
+	private function get_email_data( int $event_id, \WP_User $user, string $status ): ?array {
+		$event_data = Event::get( $event_id );
+
+		if ( is_wp_error( $event_data ) ) {
+			return null;
+		}
+
+		$venue_name = '';
+		$venue_id   = $event_data['venue_id'] ?? 0;
+
+		if ( $venue_id ) {
+			$venue = get_post( (int) $venue_id );
+
+			if ( $venue ) {
+				$venue_name = $venue->post_title;
+			}
+		}
+
+		if ( empty( $venue_name ) && ! empty( $event_data['online_link'] ) ) {
+			$venue_name = __( 'Online Event', 'wordpress-groups' );
+		}
+
+		// Format date and time from UTC using the event timezone.
+		$timezone   = $event_data['timezone'] ?? 'UTC';
+		$start_utc  = $event_data['start_utc'] ?? '';
+		$event_date = '';
+		$event_time = '';
+
+		if ( $start_utc ) {
+			try {
+				$dt = new \DateTime( $start_utc, new \DateTimeZone( 'UTC' ) );
+				$dt->setTimezone( new \DateTimeZone( $timezone ) );
+				$event_date = $dt->format( 'l, F j, Y' );
+				$event_time = $dt->format( 'g:i A T' );
+			} catch ( \Exception $e ) {
+				$event_date = $start_utc;
+				$event_time = '';
+			}
+		}
+
+		$group_name = get_bloginfo( 'name' );
+
+		$display_status = 'attending' === $status
+			? __( 'Attending', 'wordpress-groups' )
+			: __( 'Waitlisted', 'wordpress-groups' );
+
+		return [
+			'user_name'   => $user->display_name,
+			'event_title' => $event_data['title'],
+			'event_date'  => $event_date,
+			'event_time'  => $event_time,
+			'venue_name'  => $venue_name,
+			'group_name'  => $group_name,
+			'rsvp_status' => $display_status,
+			'event_url'   => get_permalink( $event_id ),
+		];
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Rsvp_Notifications.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Rsvp_Notifications.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Tests for RSVP notification emails.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Models\Event;
+use Groups\Models\Rsvp;
+use Groups\Notifications\Rsvp_Notifications;
+use Groups\Post_Types\Event as Event_Post_Type;
+
+/**
+ * @coversDefaultClass \Groups\Notifications\Rsvp_Notifications
+ */
+class Test_Rsvp_Notifications extends WP_UnitTestCase {
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$event_cpt = new Event_Post_Type();
+		$event_cpt->register_post_type();
+		$event_cpt->register_post_statuses();
+
+		// Ensure the Rsvp_Notifications hooks are registered.
+		new Rsvp_Notifications();
+	}
+
+	/**
+	 * Helper to create a scheduled event post.
+	 *
+	 * @param array $overrides Optional overrides for event args.
+	 * @return int Post ID.
+	 */
+	private function create_event( array $overrides = [] ): int {
+		$args = array_merge(
+			[
+				'title'     => 'WordPress Meetup',
+				'content'   => 'A community meetup.',
+				'start_utc' => gmdate( 'Y-m-d H:i:s', time() + ( 2 * DAY_IN_SECONDS ) ),
+				'end_utc'   => gmdate( 'Y-m-d H:i:s', time() + ( 2 * DAY_IN_SECONDS ) + ( 2 * HOUR_IN_SECONDS ) ),
+				'timezone'  => 'America/New_York',
+				'status'    => 'event-scheduled',
+			],
+			$overrides
+		);
+
+		return Event::create( $args );
+	}
+
+	/**
+	 * @covers ::on_rsvp_created
+	 */
+	public function test_attending_rsvp_sends_confirmation_email(): void {
+		$event_id = $this->create_event();
+		$user_id  = self::factory()->user->create( [ 'user_email' => 'attendee@example.org' ] );
+
+		$sent_emails = [];
+		add_action(
+			'groups_before_email_send',
+			function ( $to, $subject, $template ) use ( &$sent_emails ) {
+				$sent_emails[] = [
+					'to'       => $to,
+					'subject'  => $subject,
+					'template' => $template,
+				];
+			},
+			10,
+			3
+		);
+
+		Rsvp::create( $event_id, $user_id );
+
+		$this->assertCount( 1, $sent_emails, 'Should send exactly one email on RSVP creation.' );
+		$this->assertSame( 'attendee@example.org', $sent_emails[0]['to'] );
+		$this->assertSame( 'rsvp-confirmation', $sent_emails[0]['template'] );
+		$this->assertStringContainsString( 'RSVP Confirmed', $sent_emails[0]['subject'] );
+		$this->assertStringContainsString( 'WordPress Meetup', $sent_emails[0]['subject'] );
+	}
+
+	/**
+	 * @covers ::on_rsvp_created
+	 */
+	public function test_waitlisted_rsvp_sends_waitlist_email(): void {
+		$event_id = $this->create_event( [
+			'attendee_limit'   => 1,
+			'waitlist_enabled' => true,
+		] );
+
+		// First user fills the only spot.
+		$user1 = self::factory()->user->create( [ 'user_email' => 'first@example.org' ] );
+		Rsvp::create( $event_id, $user1 );
+
+		$sent_emails = [];
+		add_action(
+			'groups_before_email_send',
+			function ( $to, $subject, $template ) use ( &$sent_emails ) {
+				$sent_emails[] = [
+					'to'       => $to,
+					'subject'  => $subject,
+					'template' => $template,
+				];
+			},
+			10,
+			3
+		);
+
+		// Second user should be waitlisted.
+		$user2 = self::factory()->user->create( [ 'user_email' => 'waitlisted@example.org' ] );
+		Rsvp::create( $event_id, $user2 );
+
+		$this->assertCount( 1, $sent_emails, 'Should send exactly one email for the waitlisted RSVP.' );
+		$this->assertSame( 'waitlisted@example.org', $sent_emails[0]['to'] );
+		$this->assertSame( 'rsvp-confirmation', $sent_emails[0]['template'] );
+		$this->assertStringContainsString( 'Waitlisted', $sent_emails[0]['subject'] );
+	}
+
+	/**
+	 * @covers ::on_rsvp_promoted
+	 */
+	public function test_promotion_sends_promotion_email(): void {
+		$event_id = $this->create_event( [
+			'attendee_limit'   => 1,
+			'waitlist_enabled' => true,
+		] );
+
+		// First user takes the spot.
+		$user1 = self::factory()->user->create( [ 'user_email' => 'first@example.org' ] );
+		Rsvp::create( $event_id, $user1 );
+
+		// Second user is waitlisted.
+		$user2 = self::factory()->user->create( [ 'user_email' => 'promoted@example.org' ] );
+		Rsvp::create( $event_id, $user2 );
+
+		// Now track emails and cancel the first RSVP to trigger promotion.
+		$sent_emails = [];
+		add_action(
+			'groups_before_email_send',
+			function ( $to, $subject, $template ) use ( &$sent_emails ) {
+				$sent_emails[] = [
+					'to'       => $to,
+					'subject'  => $subject,
+					'template' => $template,
+				];
+			},
+			10,
+			3
+		);
+
+		$rsvp1 = Rsvp::get_user_rsvp( $event_id, $user1 );
+		Rsvp::cancel( (int) $rsvp1->comment_ID );
+
+		$this->assertCount( 1, $sent_emails, 'Should send exactly one promotion email.' );
+		$this->assertSame( 'promoted@example.org', $sent_emails[0]['to'] );
+		$this->assertSame( 'rsvp-promotion', $sent_emails[0]['template'] );
+		$this->assertStringContainsString( "You're In!", $sent_emails[0]['subject'] );
+	}
+
+	/**
+	 * @covers ::on_rsvp_created
+	 */
+	public function test_confirmation_not_sent_when_filtered_out(): void {
+		$event_id = $this->create_event();
+		$user_id  = self::factory()->user->create( [ 'user_email' => 'nomail@example.org' ] );
+
+		add_filter( 'groups_send_rsvp_confirmation', '__return_false' );
+
+		$sent_emails = 0;
+		add_action(
+			'groups_before_email_send',
+			function () use ( &$sent_emails ) {
+				$sent_emails++;
+			}
+		);
+
+		Rsvp::create( $event_id, $user_id );
+
+		$this->assertSame( 0, $sent_emails, 'No email should be sent when filtered out.' );
+
+		remove_filter( 'groups_send_rsvp_confirmation', '__return_false' );
+	}
+
+	/**
+	 * @covers ::on_rsvp_promoted
+	 */
+	public function test_promotion_not_sent_when_filtered_out(): void {
+		$event_id = $this->create_event( [
+			'attendee_limit'   => 1,
+			'waitlist_enabled' => true,
+		] );
+
+		$user1 = self::factory()->user->create( [ 'user_email' => 'first@example.org' ] );
+		Rsvp::create( $event_id, $user1 );
+
+		$user2 = self::factory()->user->create( [ 'user_email' => 'promoted@example.org' ] );
+		Rsvp::create( $event_id, $user2 );
+
+		add_filter( 'groups_send_rsvp_promotion', '__return_false' );
+
+		$sent_emails = 0;
+		add_action(
+			'groups_before_email_send',
+			function () use ( &$sent_emails ) {
+				$sent_emails++;
+			}
+		);
+
+		$rsvp1 = Rsvp::get_user_rsvp( $event_id, $user1 );
+		Rsvp::cancel( (int) $rsvp1->comment_ID );
+
+		$this->assertSame( 0, $sent_emails, 'No promotion email should be sent when filtered out.' );
+
+		remove_filter( 'groups_send_rsvp_promotion', '__return_false' );
+	}
+}


### PR DESCRIPTION
## Summary
- Hook into `groups_rsvp_created` to send immediate confirmation emails (attending or waitlisted) using the existing `rsvp-confirmation` template
- Hook into `groups_rsvp_promoted` to send "You're in!" promotion emails when waitlisted users get a spot, using a new `rsvp-promotion` template
- New `Rsvp_Notifications` class in `Groups\Notifications` namespace, wired into Plugin class
- Emails include event title, date/time (timezone-aware), venue, group name, and RSVP status
- Filterable via `groups_send_rsvp_confirmation` and `groups_send_rsvp_promotion`

## Test plan
- [x] Test attending RSVP sends confirmation email with correct template and subject
- [x] Test waitlisted RSVP sends waitlist-specific email
- [x] Test waitlist promotion sends promotion email when attending user cancels
- [x] Test emails can be suppressed via filters
- [x] All 5 tests pass locally

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)