### PR TITLE
Add Slack webhook notifications

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -61,6 +61,7 @@ class Plugin {
 		new Workflow\Site_Provisioner();
 		new Models\Recurrence_Generator();
 		Models\Recurrence_Generator::schedule_cron();
+		new Integrations\Slack_Notifier();
 
 		add_action( 'init', [ Models\Membership::class, 'register_roles' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );

--- a/wp-content/plugins/wordpress-groups/includes/integrations/class-slack-notifier.php
+++ b/wp-content/plugins/wordpress-groups/includes/integrations/class-slack-notifier.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * Slack webhook notification integration.
+ *
+ * Sends rich Slack messages when meetup application statuses change,
+ * groups become at-risk, or groups go dormant.
+ *
+ * @package Groups
+ */
+
+namespace Groups\Integrations;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Slack_Notifier — sends webhook notifications to a configured Slack channel.
+ *
+ * Non-blocking: failures are logged but never affect application flow.
+ */
+class Slack_Notifier {
+
+	/**
+	 * Network option key for the Slack webhook URL.
+	 *
+	 * @var string
+	 */
+	const OPTION_WEBHOOK_URL = 'groups_slack_webhook_url';
+
+	/**
+	 * Human-readable labels for meetup statuses.
+	 *
+	 * @var array<string, string>
+	 */
+	const STATUS_LABELS = [
+		'meetup-pending'     => 'Pending Review',
+		'meetup-vetting'     => 'Under Vetting',
+		'meetup-feedback'    => 'Awaiting Feedback',
+		'meetup-orientation' => 'Orientation',
+		'meetup-scheduling'  => 'Scheduling First Event',
+		'meetup-active'      => 'Active',
+		'meetup-dormant'     => 'Dormant',
+		'meetup-suspended'   => 'Suspended',
+		'meetup-removed'     => 'Removed',
+		'meetup-declined'    => 'Declined',
+	];
+
+	/**
+	 * Constructor — registers action hooks.
+	 */
+	public function __construct() {
+		add_action( 'groups_meetup_status_transition', [ $this, 'on_status_transition' ], 30, 3 );
+		add_action( 'groups_group_at_risk', [ $this, 'on_group_at_risk' ], 10, 2 );
+		add_action( 'groups_group_dormant', [ $this, 'on_group_dormant' ], 10, 2 );
+	}
+
+	/**
+	 * Handle meetup application status transitions.
+	 *
+	 * @param int    $post_id    The wp_meetup post ID.
+	 * @param string $old_status Previous status slug.
+	 * @param string $new_status New status slug.
+	 */
+	public function on_status_transition( int $post_id, string $old_status, string $new_status ): void {
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return;
+		}
+
+		$group_name = $post->post_title ?: "(Post #{$post_id})";
+		$old_label  = self::STATUS_LABELS[ $old_status ] ?? $old_status;
+		$new_label  = self::STATUS_LABELS[ $new_status ] ?? $new_status;
+
+		$message = $this->build_status_transition_message( $group_name, $old_label, $new_label, $post_id );
+
+		$this->send( $message );
+	}
+
+	/**
+	 * Handle at-risk group notifications.
+	 *
+	 * @param int $post_id       The wp_meetup post ID.
+	 * @param int $days_inactive Days since last event.
+	 */
+	public function on_group_at_risk( int $post_id, int $days_inactive ): void {
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return;
+		}
+
+		$group_name = $post->post_title ?: "(Post #{$post_id})";
+
+		$message = $this->build_at_risk_message( $group_name, $days_inactive, $post_id );
+
+		$this->send( $message );
+	}
+
+	/**
+	 * Handle dormant group notifications.
+	 *
+	 * @param int $post_id       The wp_meetup post ID.
+	 * @param int $days_inactive Days since last event.
+	 */
+	public function on_group_dormant( int $post_id, int $days_inactive ): void {
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return;
+		}
+
+		$group_name = $post->post_title ?: "(Post #{$post_id})";
+
+		$message = $this->build_dormant_message( $group_name, $days_inactive, $post_id );
+
+		$this->send( $message );
+	}
+
+	/**
+	 * Build the Slack payload for a status transition.
+	 *
+	 * @param string $group_name Group display name.
+	 * @param string $old_label  Human-readable old status.
+	 * @param string $new_label  Human-readable new status.
+	 * @param int    $post_id    The wp_meetup post ID.
+	 * @return array Slack message payload.
+	 */
+	public function build_status_transition_message( string $group_name, string $old_label, string $new_label, int $post_id ): array {
+		$message = [
+			'blocks' => [
+				[
+					'type' => 'section',
+					'text' => [
+						'type' => 'mrkdwn',
+						'text' => ":arrows_counterclockwise: *Group Status Changed*\n*{$group_name}*",
+					],
+				],
+				[
+					'type'   => 'section',
+					'fields' => [
+						[
+							'type' => 'mrkdwn',
+							'text' => "*From:*\n{$old_label}",
+						],
+						[
+							'type' => 'mrkdwn',
+							'text' => "*To:*\n{$new_label}",
+						],
+					],
+				],
+				[
+					'type'     => 'context',
+					'elements' => [
+						[
+							'type' => 'mrkdwn',
+							'text' => "Post ID: {$post_id}",
+						],
+					],
+				],
+			],
+		];
+
+		return $this->apply_filter( $message, 'status_transition', $post_id );
+	}
+
+	/**
+	 * Build the Slack payload for an at-risk group.
+	 *
+	 * @param string $group_name    Group display name.
+	 * @param int    $days_inactive Days since last event.
+	 * @param int    $post_id       The wp_meetup post ID.
+	 * @return array Slack message payload.
+	 */
+	public function build_at_risk_message( string $group_name, int $days_inactive, int $post_id ): array {
+		$message = [
+			'blocks' => [
+				[
+					'type' => 'section',
+					'text' => [
+						'type' => 'mrkdwn',
+						'text' => ":warning: *Group At Risk*\n*{$group_name}*",
+					],
+				],
+				[
+					'type'   => 'section',
+					'fields' => [
+						[
+							'type' => 'mrkdwn',
+							'text' => "*Days Inactive:*\n{$days_inactive}",
+						],
+						[
+							'type' => 'mrkdwn',
+							'text' => "*Status:*\nAt Risk",
+						],
+					],
+				],
+				[
+					'type'     => 'context',
+					'elements' => [
+						[
+							'type' => 'mrkdwn',
+							'text' => "Post ID: {$post_id} | This group has had no events for {$days_inactive} days.",
+						],
+					],
+				],
+			],
+		];
+
+		return $this->apply_filter( $message, 'at_risk', $post_id );
+	}
+
+	/**
+	 * Build the Slack payload for a dormant group.
+	 *
+	 * @param string $group_name    Group display name.
+	 * @param int    $days_inactive Days since last event.
+	 * @param int    $post_id       The wp_meetup post ID.
+	 * @return array Slack message payload.
+	 */
+	public function build_dormant_message( string $group_name, int $days_inactive, int $post_id ): array {
+		$message = [
+			'blocks' => [
+				[
+					'type' => 'section',
+					'text' => [
+						'type' => 'mrkdwn',
+						'text' => ":red_circle: *Group Now Dormant*\n*{$group_name}*",
+					],
+				],
+				[
+					'type'   => 'section',
+					'fields' => [
+						[
+							'type' => 'mrkdwn',
+							'text' => "*Days Inactive:*\n{$days_inactive}",
+						],
+						[
+							'type' => 'mrkdwn',
+							'text' => "*Status:*\nDormant",
+						],
+					],
+				],
+				[
+					'type'     => 'context',
+					'elements' => [
+						[
+							'type' => 'mrkdwn',
+							'text' => "Post ID: {$post_id} | This group has been transitioned to dormant after {$days_inactive} days of inactivity.",
+						],
+					],
+				],
+			],
+		];
+
+		return $this->apply_filter( $message, 'dormant', $post_id );
+	}
+
+	/**
+	 * Apply the groups_slack_notification filter.
+	 *
+	 * @param array  $message Slack message payload.
+	 * @param string $type    Notification type (status_transition, at_risk, dormant).
+	 * @param int    $post_id The wp_meetup post ID.
+	 * @return array Filtered message payload.
+	 */
+	private function apply_filter( array $message, string $type, int $post_id ): array {
+		/**
+		 * Filters the Slack notification payload before sending.
+		 *
+		 * Returning a falsy value prevents the notification from being sent.
+		 *
+		 * @param array  $message The Slack message payload.
+		 * @param string $type    Notification type: 'status_transition', 'at_risk', or 'dormant'.
+		 * @param int    $post_id The wp_meetup post ID.
+		 */
+		return apply_filters( 'groups_slack_notification', $message, $type, $post_id );
+	}
+
+	/**
+	 * Send a message to the configured Slack webhook.
+	 *
+	 * Non-blocking: any failure is logged and silently swallowed so that
+	 * the calling code path is never affected.
+	 *
+	 * @param array|false $message Slack message payload, or false to skip.
+	 * @return bool True if the message was sent successfully, false otherwise.
+	 */
+	public function send( $message ): bool {
+		if ( empty( $message ) ) {
+			return false;
+		}
+
+		$webhook_url = $this->get_webhook_url();
+		if ( empty( $webhook_url ) ) {
+			return false;
+		}
+
+		try {
+			$response = wp_remote_post(
+				$webhook_url,
+				[
+					'headers'  => [ 'Content-Type' => 'application/json; charset=utf-8' ],
+					'body'     => wp_json_encode( $message ),
+					'timeout'  => 5,
+					'blocking' => true,
+				]
+			);
+
+			if ( is_wp_error( $response ) ) {
+				error_log( '[Groups Slack] Send failed: ' . $response->get_error_message() );
+				return false;
+			}
+
+			$code = wp_remote_retrieve_response_code( $response );
+			if ( $code < 200 || $code >= 300 ) {
+				error_log( "[Groups Slack] Unexpected response code: {$code}" );
+				return false;
+			}
+
+			return true;
+		} catch ( \Throwable $e ) {
+			error_log( '[Groups Slack] Exception: ' . $e->getMessage() );
+			return false;
+		}
+	}
+
+	/**
+	 * Get the configured Slack webhook URL.
+	 *
+	 * @return string Webhook URL or empty string if not configured.
+	 */
+	public function get_webhook_url(): string {
+		return (string) get_site_option( self::OPTION_WEBHOOK_URL, '' );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/integrations/Test_Slack_Notifier.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/integrations/Test_Slack_Notifier.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * Tests for the Slack webhook notifier.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Integrations\Slack_Notifier;
+
+/**
+ * @coversDefaultClass \Groups\Integrations\Slack_Notifier
+ */
+class Test_Slack_Notifier extends WP_UnitTestCase {
+
+	/**
+	 * Slack_Notifier instance under test.
+	 *
+	 * @var Slack_Notifier
+	 */
+	private Slack_Notifier $notifier;
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->notifier = new Slack_Notifier();
+	}
+
+	/**
+	 * Tear down each test.
+	 */
+	public function tear_down(): void {
+		delete_site_option( Slack_Notifier::OPTION_WEBHOOK_URL );
+		remove_all_filters( 'groups_slack_notification' );
+		remove_all_filters( 'pre_http_request' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @covers ::build_status_transition_message
+	 */
+	public function test_status_transition_message_contains_group_name_and_statuses(): void {
+		$message = $this->notifier->build_status_transition_message(
+			'Melbourne WordPress',
+			'Pending Review',
+			'Under Vetting',
+			42
+		);
+
+		$this->assertIsArray( $message );
+		$this->assertArrayHasKey( 'blocks', $message );
+
+		$json = wp_json_encode( $message );
+		$this->assertStringContainsString( 'Melbourne WordPress', $json );
+		$this->assertStringContainsString( 'Pending Review', $json );
+		$this->assertStringContainsString( 'Under Vetting', $json );
+		$this->assertStringContainsString( 'Status Changed', $json );
+	}
+
+	/**
+	 * @covers ::build_at_risk_message
+	 */
+	public function test_at_risk_message_contains_group_name_and_days(): void {
+		$message = $this->notifier->build_at_risk_message( 'Sydney WP', 65, 99 );
+
+		$this->assertIsArray( $message );
+		$json = wp_json_encode( $message );
+		$this->assertStringContainsString( 'Sydney WP', $json );
+		$this->assertStringContainsString( '65', $json );
+		$this->assertStringContainsString( 'At Risk', $json );
+	}
+
+	/**
+	 * @covers ::build_dormant_message
+	 */
+	public function test_dormant_message_contains_group_name_and_days(): void {
+		$message = $this->notifier->build_dormant_message( 'Berlin WP', 95, 100 );
+
+		$this->assertIsArray( $message );
+		$json = wp_json_encode( $message );
+		$this->assertStringContainsString( 'Berlin WP', $json );
+		$this->assertStringContainsString( '95', $json );
+		$this->assertStringContainsString( 'Dormant', $json );
+	}
+
+	/**
+	 * @covers ::build_status_transition_message
+	 */
+	public function test_message_has_sections_fields_and_context_blocks(): void {
+		$message = $this->notifier->build_status_transition_message(
+			'Test Group',
+			'Old',
+			'New',
+			1
+		);
+
+		$block_types = array_column( $message['blocks'], 'type' );
+		$this->assertContains( 'section', $block_types, 'Message should contain section blocks.' );
+		$this->assertContains( 'context', $block_types, 'Message should contain a context block.' );
+
+		// Verify fields exist in at least one section block.
+		$has_fields = false;
+		foreach ( $message['blocks'] as $block ) {
+			if ( ! empty( $block['fields'] ) ) {
+				$has_fields = true;
+				break;
+			}
+		}
+		$this->assertTrue( $has_fields, 'At least one section block should contain fields.' );
+	}
+
+	/**
+	 * @covers ::send
+	 */
+	public function test_send_returns_false_when_no_webhook_configured(): void {
+		delete_site_option( Slack_Notifier::OPTION_WEBHOOK_URL );
+
+		$result = $this->notifier->send( [ 'text' => 'hello' ] );
+
+		$this->assertFalse( $result, 'send() should return false when no webhook URL is configured.' );
+	}
+
+	/**
+	 * @covers ::send
+	 */
+	public function test_send_returns_false_for_empty_message(): void {
+		update_site_option( Slack_Notifier::OPTION_WEBHOOK_URL, 'https://hooks.slack.com/services/test' );
+
+		$this->assertFalse( $this->notifier->send( [] ), 'send() should return false for empty array.' );
+		$this->assertFalse( $this->notifier->send( false ), 'send() should return false for false.' );
+	}
+
+	/**
+	 * @covers ::send
+	 */
+	public function test_send_posts_to_webhook_and_returns_true_on_success(): void {
+		$webhook = 'https://hooks.slack.com/services/T00/B00/test';
+		update_site_option( Slack_Notifier::OPTION_WEBHOOK_URL, $webhook );
+
+		$captured_url  = null;
+		$captured_body = null;
+
+		add_filter( 'pre_http_request', function ( $preempt, $args, $url ) use ( &$captured_url, &$captured_body ) {
+			$captured_url  = $url;
+			$captured_body = $args['body'];
+
+			return [
+				'response' => [ 'code' => 200, 'message' => 'OK' ],
+				'body'     => 'ok',
+			];
+		}, 10, 3 );
+
+		$payload = [ 'text' => 'Test message' ];
+		$result  = $this->notifier->send( $payload );
+
+		$this->assertTrue( $result, 'send() should return true on successful webhook post.' );
+		$this->assertSame( $webhook, $captured_url, 'Should post to the configured webhook URL.' );
+		$this->assertSame( wp_json_encode( $payload ), $captured_body, 'Body should be JSON-encoded payload.' );
+	}
+
+	/**
+	 * @covers ::send
+	 */
+	public function test_send_returns_false_on_wp_error_without_throwing(): void {
+		update_site_option( Slack_Notifier::OPTION_WEBHOOK_URL, 'https://hooks.slack.com/services/T00/B00/test' );
+
+		add_filter( 'pre_http_request', function () {
+			return new WP_Error( 'http_request_failed', 'Connection timed out' );
+		} );
+
+		$result = $this->notifier->send( [ 'text' => 'hello' ] );
+
+		$this->assertFalse( $result, 'send() should return false on WP_Error without throwing.' );
+	}
+
+	/**
+	 * @covers ::send
+	 */
+	public function test_send_returns_false_on_non_200_response(): void {
+		update_site_option( Slack_Notifier::OPTION_WEBHOOK_URL, 'https://hooks.slack.com/services/T00/B00/test' );
+
+		add_filter( 'pre_http_request', function () {
+			return [
+				'response' => [ 'code' => 403, 'message' => 'Forbidden' ],
+				'body'     => 'invalid_token',
+			];
+		} );
+
+		$result = $this->notifier->send( [ 'text' => 'hello' ] );
+
+		$this->assertFalse( $result, 'send() should return false for non-2xx response code.' );
+	}
+
+	/**
+	 * @covers ::send
+	 * @covers ::on_status_transition
+	 */
+	public function test_filter_allows_modification_of_message(): void {
+		$webhook = 'https://hooks.slack.com/services/T00/B00/test';
+		update_site_option( Slack_Notifier::OPTION_WEBHOOK_URL, $webhook );
+
+		add_filter( 'groups_slack_notification', function ( $message, $type, $post_id ) {
+			$message['text'] = "Custom: {$type} for post {$post_id}";
+			return $message;
+		}, 10, 3 );
+
+		$captured_body = null;
+		add_filter( 'pre_http_request', function ( $preempt, $args ) use ( &$captured_body ) {
+			$captured_body = $args['body'];
+			return [
+				'response' => [ 'code' => 200, 'message' => 'OK' ],
+				'body'     => 'ok',
+			];
+		}, 10, 3 );
+
+		$message = $this->notifier->build_status_transition_message( 'Test', 'Old', 'New', 55 );
+		$this->notifier->send( $message );
+
+		$decoded = json_decode( $captured_body, true );
+		$this->assertSame( 'Custom: status_transition for post 55', $decoded['text'] );
+	}
+
+	/**
+	 * @covers ::send
+	 */
+	public function test_filter_returning_empty_array_prevents_send(): void {
+		$webhook = 'https://hooks.slack.com/services/T00/B00/test';
+		update_site_option( Slack_Notifier::OPTION_WEBHOOK_URL, $webhook );
+
+		add_filter( 'groups_slack_notification', '__return_empty_array' );
+
+		$http_called = false;
+		add_filter( 'pre_http_request', function () use ( &$http_called ) {
+			$http_called = true;
+			return [
+				'response' => [ 'code' => 200, 'message' => 'OK' ],
+				'body'     => 'ok',
+			];
+		} );
+
+		$message = $this->notifier->build_at_risk_message( 'Test', 60, 1 );
+		$result  = $this->notifier->send( $message );
+
+		$this->assertFalse( $result, 'send() should return false when filter empties the message.' );
+		$this->assertFalse( $http_called, 'HTTP request should not be made when message is empty.' );
+	}
+
+	/**
+	 * @covers ::on_status_transition
+	 */
+	public function test_on_status_transition_sends_for_valid_post(): void {
+		$webhook = 'https://hooks.slack.com/services/T00/B00/test';
+		update_site_option( Slack_Notifier::OPTION_WEBHOOK_URL, $webhook );
+
+		$post_id = self::factory()->post->create( [
+			'post_title' => 'Tokyo WordPress Meetup',
+			'post_type'  => 'post',
+		] );
+
+		$sent = false;
+		add_filter( 'pre_http_request', function ( $preempt, $args ) use ( &$sent ) {
+			$body = json_decode( $args['body'], true );
+			$json = wp_json_encode( $body );
+			if ( str_contains( $json, 'Tokyo WordPress Meetup' ) ) {
+				$sent = true;
+			}
+			return [
+				'response' => [ 'code' => 200, 'message' => 'OK' ],
+				'body'     => 'ok',
+			];
+		}, 10, 3 );
+
+		$this->notifier->on_status_transition( $post_id, 'meetup-pending', 'meetup-vetting' );
+
+		$this->assertTrue( $sent, 'on_status_transition should send a Slack message containing the group name.' );
+	}
+
+	/**
+	 * @covers ::on_status_transition
+	 */
+	public function test_on_status_transition_uses_human_readable_labels(): void {
+		$webhook = 'https://hooks.slack.com/services/T00/B00/test';
+		update_site_option( Slack_Notifier::OPTION_WEBHOOK_URL, $webhook );
+
+		$post_id = self::factory()->post->create( [ 'post_title' => 'Label Test Group' ] );
+
+		$captured_body = null;
+		add_filter( 'pre_http_request', function ( $preempt, $args ) use ( &$captured_body ) {
+			$captured_body = $args['body'];
+			return [
+				'response' => [ 'code' => 200, 'message' => 'OK' ],
+				'body'     => 'ok',
+			];
+		}, 10, 3 );
+
+		$this->notifier->on_status_transition( $post_id, 'meetup-pending', 'meetup-active' );
+
+		$this->assertStringContainsString( 'Pending Review', $captured_body );
+		$this->assertStringContainsString( 'Active', $captured_body );
+	}
+
+	/**
+	 * @covers ::get_webhook_url
+	 */
+	public function test_get_webhook_url_returns_empty_string_when_not_set(): void {
+		delete_site_option( Slack_Notifier::OPTION_WEBHOOK_URL );
+		$this->assertSame( '', $this->notifier->get_webhook_url() );
+	}
+
+	/**
+	 * @covers ::get_webhook_url
+	 */
+	public function test_get_webhook_url_returns_configured_value(): void {
+		$url = 'https://hooks.slack.com/services/T00/B00/xyz';
+		update_site_option( Slack_Notifier::OPTION_WEBHOOK_URL, $url );
+		$this->assertSame( $url, $this->notifier->get_webhook_url() );
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Slack_Notifier` class (`Groups\Integrations` namespace) that sends rich Block Kit messages to a configured Slack webhook URL (stored as network option `groups_slack_webhook_url`)
- Hook into `groups_meetup_status_transition`, `groups_group_at_risk`, and `groups_group_dormant` actions to send contextual notifications with sections, fields, and context blocks
- Non-blocking design: failures are logged via `error_log()` but never affect application flow
- Filterable via `groups_slack_notification` filter to allow customizing or suppressing messages
- Wire into Plugin class for automatic initialization
- Add comprehensive test suite covering message formatting, send success/failure paths, filter modification, and filter suppression

## Test plan
- [ ] Verify `Test_Slack_Notifier` passes in wp-env PHPUnit environment
- [ ] Confirm messages contain correct group names, status labels, and days-inactive counts
- [ ] Confirm `send()` returns false gracefully on WP_Error, non-2xx responses, and missing webhook URL
- [ ] Confirm `groups_slack_notification` filter can modify or suppress messages
- [ ] Verify no regressions in existing test suites

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)