### PR TITLE
Add official-wordpress-events feed endpoint

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -62,6 +62,7 @@ class Plugin {
 		new Models\Recurrence_Generator();
 		Models\Recurrence_Generator::schedule_cron();
 		new Integrations\Slack_Notifier();
+		new Integrations\Official_Events_API();
 
 		add_action( 'init', [ Models\Membership::class, 'register_roles' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );

--- a/wp-content/plugins/wordpress-groups/includes/integrations/class-official-events-api.php
+++ b/wp-content/plugins/wordpress-groups/includes/integrations/class-official-events-api.php
@@ -1,0 +1,374 @@
+<?php
+/**
+ * REST API feed endpoint for the official-wordpress-events plugin.
+ *
+ * Replaces Meetup.com as the data source by exposing a public, paginated,
+ * cacheable endpoint that returns events across all group sites in the
+ * network in the format the aggregation plugin expects.
+ *
+ * @package Groups
+ */
+
+namespace Groups\Integrations;
+
+use Groups\Post_Types\Event;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Official_Events_API — network-wide events feed for the
+ * official-wordpress-events aggregation plugin.
+ */
+class Official_Events_API extends WP_REST_Controller {
+
+	/**
+	 * REST namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'groups/v1';
+
+	/**
+	 * REST base path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'integration/events-feed';
+
+	/**
+	 * Default number of events per page.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_PER_PAGE = 20;
+
+	/**
+	 * Maximum number of events per page.
+	 *
+	 * @var int
+	 */
+	const MAX_PER_PAGE = 100;
+
+	/**
+	 * Cache max-age in seconds (5 minutes).
+	 *
+	 * @var int
+	 */
+	const CACHE_MAX_AGE = 300;
+
+	/**
+	 * Constructor — hooks into rest_api_init.
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+	}
+
+	/**
+	 * Register the events-feed route.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_items' ],
+					'permission_callback' => [ $this, 'get_items_permissions_check' ],
+					'args'                => $this->get_collection_params(),
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Public endpoint — no authentication required.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true
+	 */
+	public function get_items_permissions_check( $request ): true {
+		return true;
+	}
+
+	/**
+	 * Retrieve events across all group sites in the network.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ): WP_REST_Response {
+		$page     = max( 1, (int) $request->get_param( 'page' ) );
+		$per_page = min( self::MAX_PER_PAGE, max( 1, (int) ( $request->get_param( 'per_page' ) ?: self::DEFAULT_PER_PAGE ) ) );
+
+		$events      = [];
+		$total       = 0;
+		$site_events = $this->query_network_events( $page, $per_page, $total );
+
+		foreach ( $site_events as $item ) {
+			$events[] = $this->format_event( $item );
+		}
+
+		$total_pages = (int) ceil( $total / $per_page );
+
+		$response = new WP_REST_Response( $events, 200 );
+		$response->header( 'X-WP-Total', $total );
+		$response->header( 'X-WP-TotalPages', $total_pages );
+
+		// Cache-Control headers.
+		$response->header( 'Cache-Control', 'public, max-age=' . self::CACHE_MAX_AGE );
+
+		// ETag for conditional requests.
+		$etag = $this->generate_etag( $events );
+		$response->header( 'ETag', $etag );
+
+		// Handle If-None-Match for 304 responses.
+		$if_none_match = $request->get_header( 'If-None-Match' );
+		if ( $if_none_match && trim( $if_none_match, '" ' ) === trim( $etag, '"' ) ) {
+			return new WP_REST_Response( null, 304 );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Query events across all sites in the network.
+	 *
+	 * Iterates over group sites, collecting upcoming/active events,
+	 * then sorts by start date and applies pagination.
+	 *
+	 * @param int $page     Current page number.
+	 * @param int $per_page Events per page.
+	 * @param int $total    Total event count (passed by reference).
+	 * @return array Array of event data arrays.
+	 */
+	protected function query_network_events( int $page, int $per_page, int &$total ): array {
+		$all_events = [];
+
+		$sites = get_sites( [
+			'number'   => 0, // All sites.
+			'public'   => 1,
+			'archived' => 0,
+			'deleted'  => 0,
+			'spam'     => 0,
+			'fields'   => 'ids',
+		] );
+
+		foreach ( $sites as $site_id ) {
+			$site_id = (int) $site_id;
+
+			switch_to_blog( $site_id );
+
+			// Only query sites that have the event post type registered.
+			if ( ! post_type_exists( Event::POST_TYPE ) ) {
+				restore_current_blog();
+				continue;
+			}
+
+			$query = new \WP_Query( [
+				'post_type'      => Event::POST_TYPE,
+				'post_status'    => [ 'event-scheduled', 'event-active' ],
+				'posts_per_page' => -1,
+				'meta_key'       => '_event_start_date', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'orderby'        => 'meta_value',
+				'order'          => 'ASC',
+			] );
+
+			$blog_details = get_blog_details( $site_id );
+			$group_name   = $blog_details ? $blog_details->blogname : '';
+			$group_url    = $blog_details ? $blog_details->siteurl : '';
+
+			foreach ( $query->posts as $post ) {
+				$venue_id = (int) get_post_meta( $post->ID, '_event_venue_id', true );
+
+				$location = [
+					'latitude'  => '',
+					'longitude' => '',
+					'city'      => '',
+					'country'   => '',
+				];
+
+				if ( $venue_id ) {
+					$location = [
+						'latitude'  => (string) get_post_meta( $venue_id, '_venue_latitude', true ),
+						'longitude' => (string) get_post_meta( $venue_id, '_venue_longitude', true ),
+						'city'      => (string) get_post_meta( $venue_id, '_venue_city', true ),
+						'country'   => (string) get_post_meta( $venue_id, '_venue_country', true ),
+					];
+				}
+
+				$all_events[] = [
+					'post'       => $post,
+					'blog_id'    => $site_id,
+					'group_name' => $group_name,
+					'group_url'  => $group_url,
+					'location'   => $location,
+					'start_date' => (string) get_post_meta( $post->ID, '_event_start_date', true ),
+					'end_date'   => (string) get_post_meta( $post->ID, '_event_end_date', true ),
+					'permalink'  => get_permalink( $post ),
+				];
+			}
+
+			restore_current_blog();
+		}
+
+		// Sort by start date ascending.
+		usort( $all_events, function ( $a, $b ) {
+			return strcmp( $a['start_date'], $b['start_date'] );
+		} );
+
+		$total  = count( $all_events );
+		$offset = ( $page - 1 ) * $per_page;
+
+		return array_slice( $all_events, $offset, $per_page );
+	}
+
+	/**
+	 * Format an event data array into the structure expected by
+	 * the official-wordpress-events plugin.
+	 *
+	 * @param array $item Event data from query_network_events().
+	 * @return array Formatted event.
+	 */
+	protected function format_event( array $item ): array {
+		$post = $item['post'];
+
+		return [
+			'title'       => html_entity_decode( get_the_title( $post ), ENT_QUOTES, 'UTF-8' ),
+			'description' => wp_strip_all_tags( $post->post_content ),
+			'url'         => esc_url( $item['permalink'] ),
+			'date'        => $item['start_date'],
+			'end_date'    => $item['end_date'],
+			'location'    => [
+				'latitude'  => $item['location']['latitude'],
+				'longitude' => $item['location']['longitude'],
+				'city'      => $item['location']['city'],
+				'country'   => $item['location']['country'],
+			],
+			'group'       => [
+				'name' => $item['group_name'],
+				'url'  => esc_url( $item['group_url'] ),
+			],
+		];
+	}
+
+	/**
+	 * Generate an ETag from the response data.
+	 *
+	 * @param array $events Formatted events array.
+	 * @return string Quoted ETag value.
+	 */
+	protected function generate_etag( array $events ): string {
+		return '"' . md5( wp_json_encode( $events ) ) . '"';
+	}
+
+	/**
+	 * Get the query parameters for the collection.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_collection_params(): array {
+		return [
+			'page'     => [
+				'description'       => __( 'Current page of the collection.', 'wordpress-groups' ),
+				'type'              => 'integer',
+				'default'           => 1,
+				'minimum'           => 1,
+				'sanitize_callback' => 'absint',
+			],
+			'per_page' => [
+				'description'       => __( 'Maximum number of items to return per page.', 'wordpress-groups' ),
+				'type'              => 'integer',
+				'default'           => self::DEFAULT_PER_PAGE,
+				'minimum'           => 1,
+				'maximum'           => self::MAX_PER_PAGE,
+				'sanitize_callback' => 'absint',
+			],
+		];
+	}
+
+	/**
+	 * Get the schema for the events feed.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_item_schema(): array {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$this->schema = [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'events-feed',
+			'type'       => 'object',
+			'properties' => [
+				'title'       => [
+					'description' => __( 'Event title.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+				],
+				'description' => [
+					'description' => __( 'Plain text event description.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+				],
+				'url'         => [
+					'description' => __( 'Event URL.', 'wordpress-groups' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => [ 'view' ],
+				],
+				'date'        => [
+					'description' => __( 'Event start date/time in UTC (Y-m-d H:i:s).', 'wordpress-groups' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+				],
+				'end_date'    => [
+					'description' => __( 'Event end date/time in UTC (Y-m-d H:i:s).', 'wordpress-groups' ),
+					'type'        => 'string',
+					'context'     => [ 'view' ],
+				],
+				'location'    => [
+					'description' => __( 'Event location details.', 'wordpress-groups' ),
+					'type'        => 'object',
+					'context'     => [ 'view' ],
+					'properties'  => [
+						'latitude'  => [
+							'type' => 'string',
+						],
+						'longitude' => [
+							'type' => 'string',
+						],
+						'city'      => [
+							'type' => 'string',
+						],
+						'country'   => [
+							'type' => 'string',
+						],
+					],
+				],
+				'group'       => [
+					'description' => __( 'Group that hosts the event.', 'wordpress-groups' ),
+					'type'        => 'object',
+					'context'     => [ 'view' ],
+					'properties'  => [
+						'name' => [
+							'type' => 'string',
+						],
+						'url'  => [
+							'type'   => 'string',
+							'format' => 'uri',
+						],
+					],
+				],
+			],
+		];
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/bootstrap.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/bootstrap.php
@@ -90,6 +90,12 @@ tests_add_filter(
 	}
 );
 
+// Tell the WP test bootstrap exactly where the config file lives so that
+// symlinked includes directories do not break __DIR__ resolution.
+if ( ! defined( 'WP_TESTS_CONFIG_FILE_PATH' ) ) {
+	define( 'WP_TESTS_CONFIG_FILE_PATH', $_tests_dir . '/wp-tests-config.php' );
+}
+
 require $_tests_dir . '/includes/bootstrap.php';
 
 // Create custom tables for tests.

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/integrations/Test_Official_Events_API.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/integrations/Test_Official_Events_API.php
@@ -1,0 +1,358 @@
+<?php
+/**
+ * Tests for the Official Events API feed endpoint.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Integrations\Official_Events_API;
+use Groups\Post_Types\Event;
+use Groups\Post_Types\Venue;
+
+/**
+ * @coversDefaultClass \Groups\Integrations\Official_Events_API
+ * @group rest-api
+ */
+class Test_Official_Events_API extends WP_UnitTestCase {
+
+	/**
+	 * REST server instance.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private WP_REST_Server $server;
+
+	/**
+	 * Register CPTs once for the test suite.
+	 */
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+
+		$event_cpt = new Event();
+		$event_cpt->register_post_type();
+		$event_cpt->register_post_statuses();
+
+		$venue_cpt = new Venue();
+		$venue_cpt->register_post_type();
+		$venue_cpt->register_meta_fields();
+	}
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wp_rest_server;
+		$this->server = $wp_rest_server = new WP_REST_Server();
+
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Tear down each test.
+	 */
+	public function tear_down(): void {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper: create an event on the current site.
+	 *
+	 * @param array $args Override defaults.
+	 * @return int Post ID.
+	 */
+	private function create_event( array $args = [] ): int {
+		$defaults = [
+			'post_type'   => Event::POST_TYPE,
+			'post_status' => 'event-scheduled',
+			'post_title'  => 'Test Event',
+			'post_content' => 'A test event description.',
+		];
+
+		$post_id = self::factory()->post->create( array_merge( $defaults, $args ) );
+
+		$meta_defaults = [
+			'_event_start_date' => '2026-06-15 18:00:00',
+			'_event_end_date'   => '2026-06-15 20:00:00',
+		];
+
+		$meta = array_merge( $meta_defaults, $args['meta'] ?? [] );
+
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Helper: create a venue on the current site.
+	 *
+	 * @param array $meta Venue meta.
+	 * @return int Post ID.
+	 */
+	private function create_venue( array $meta = [] ): int {
+		$venue_id = self::factory()->post->create( [
+			'post_type'   => Venue::POST_TYPE,
+			'post_status' => 'publish',
+			'post_title'  => 'Test Venue',
+		] );
+
+		$defaults = [
+			'_venue_latitude'  => '-37.8136',
+			'_venue_longitude' => '144.9631',
+			'_venue_city'      => 'Melbourne',
+			'_venue_country'   => 'AU',
+		];
+
+		foreach ( array_merge( $defaults, $meta ) as $key => $value ) {
+			update_post_meta( $venue_id, $key, $value );
+		}
+
+		return $venue_id;
+	}
+
+	/**
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_endpoint_is_publicly_accessible(): void {
+		// Ensure no user is logged in.
+		wp_set_current_user( 0 );
+
+		$this->create_event();
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/integration/events-feed' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status(), 'Endpoint should be accessible without authentication.' );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_endpoint_returns_events_in_expected_format(): void {
+		$venue_id = $this->create_venue();
+		$this->create_event( [
+			'post_title'   => 'Melbourne WordPress Meetup',
+			'post_content' => 'Monthly WordPress meetup in Melbourne.',
+			'meta'         => [
+				'_event_start_date' => '2026-07-01 08:00:00',
+				'_event_end_date'   => '2026-07-01 10:00:00',
+				'_event_venue_id'   => $venue_id,
+			],
+		] );
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/integration/events-feed' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertIsArray( $data );
+		$this->assertNotEmpty( $data, 'Should return at least one event.' );
+
+		$event = $data[0];
+
+		// Top-level fields.
+		$this->assertArrayHasKey( 'title', $event );
+		$this->assertArrayHasKey( 'description', $event );
+		$this->assertArrayHasKey( 'url', $event );
+		$this->assertArrayHasKey( 'date', $event );
+		$this->assertArrayHasKey( 'end_date', $event );
+
+		$this->assertSame( 'Melbourne WordPress Meetup', $event['title'] );
+		$this->assertSame( 'Monthly WordPress meetup in Melbourne.', $event['description'] );
+		$this->assertSame( '2026-07-01 08:00:00', $event['date'] );
+		$this->assertSame( '2026-07-01 10:00:00', $event['end_date'] );
+
+		// Location.
+		$this->assertArrayHasKey( 'location', $event );
+		$this->assertArrayHasKey( 'latitude', $event['location'] );
+		$this->assertArrayHasKey( 'longitude', $event['location'] );
+		$this->assertArrayHasKey( 'city', $event['location'] );
+		$this->assertArrayHasKey( 'country', $event['location'] );
+		$this->assertSame( 'Melbourne', $event['location']['city'] );
+		$this->assertSame( 'AU', $event['location']['country'] );
+
+		// Group.
+		$this->assertArrayHasKey( 'group', $event );
+		$this->assertArrayHasKey( 'name', $event['group'] );
+		$this->assertArrayHasKey( 'url', $event['group'] );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_only_scheduled_and_active_events_are_returned(): void {
+		$this->create_event( [
+			'post_title'  => 'Scheduled Event',
+			'post_status' => 'event-scheduled',
+		] );
+		$this->create_event( [
+			'post_title'  => 'Active Event',
+			'post_status' => 'event-active',
+		] );
+		$this->create_event( [
+			'post_title'  => 'Past Event',
+			'post_status' => 'event-past',
+		] );
+		$this->create_event( [
+			'post_title'  => 'Draft Event',
+			'post_status' => 'event-draft',
+		] );
+		$this->create_event( [
+			'post_title'  => 'Cancelled Event',
+			'post_status' => 'event-cancelled',
+		] );
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/integration/events-feed' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$titles = array_column( $data, 'title' );
+
+		$this->assertContains( 'Scheduled Event', $titles );
+		$this->assertContains( 'Active Event', $titles );
+		$this->assertNotContains( 'Past Event', $titles );
+		$this->assertNotContains( 'Draft Event', $titles );
+		$this->assertNotContains( 'Cancelled Event', $titles );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_pagination_works(): void {
+		// Create 5 events with distinct start dates.
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$this->create_event( [
+				'post_title' => "Event {$i}",
+				'meta'       => [
+					'_event_start_date' => sprintf( '2026-08-%02d 18:00:00', $i ),
+					'_event_end_date'   => sprintf( '2026-08-%02d 20:00:00', $i ),
+				],
+			] );
+		}
+
+		// Page 1 with 2 per page.
+		$request = new WP_REST_Request( 'GET', '/groups/v1/integration/events-feed' );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'per_page', 2 );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 2, $response->get_data() );
+		$this->assertEquals( 5, $response->get_headers()['X-WP-Total'] );
+		$this->assertEquals( 3, $response->get_headers()['X-WP-TotalPages'] );
+
+		// Page 2.
+		$request->set_param( 'page', 2 );
+		$response2 = $this->server->dispatch( $request );
+		$this->assertCount( 2, $response2->get_data() );
+
+		// Page 3 (last page, should have 1 event).
+		$request->set_param( 'page', 3 );
+		$response3 = $this->server->dispatch( $request );
+		$this->assertCount( 1, $response3->get_data() );
+
+		// Ensure no overlap between pages.
+		$page1_titles = array_column( $response->get_data(), 'title' );
+		$page2_titles = array_column( $response2->get_data(), 'title' );
+		$page3_titles = array_column( $response3->get_data(), 'title' );
+
+		$all_titles = array_merge( $page1_titles, $page2_titles, $page3_titles );
+		$this->assertCount( 5, array_unique( $all_titles ), 'All pages combined should contain 5 unique events.' );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_events_sorted_by_start_date(): void {
+		$this->create_event( [
+			'post_title' => 'Later Event',
+			'meta'       => [ '_event_start_date' => '2026-12-01 18:00:00' ],
+		] );
+		$this->create_event( [
+			'post_title' => 'Earlier Event',
+			'meta'       => [ '_event_start_date' => '2026-06-01 18:00:00' ],
+		] );
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/integration/events-feed' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 'Earlier Event', $data[0]['title'] );
+		$this->assertSame( 'Later Event', $data[1]['title'] );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_cache_control_headers_are_set(): void {
+		$this->create_event();
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/integration/events-feed' );
+		$response = $this->server->dispatch( $request );
+		$headers  = $response->get_headers();
+
+		$this->assertArrayHasKey( 'Cache-Control', $headers );
+		$this->assertStringContainsString( 'public', $headers['Cache-Control'] );
+		$this->assertStringContainsString( 'max-age=', $headers['Cache-Control'] );
+
+		$this->assertArrayHasKey( 'ETag', $headers );
+		$this->assertNotEmpty( $headers['ETag'] );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_empty_response_when_no_events(): void {
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/integration/events-feed' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( [], $response->get_data() );
+		$this->assertEquals( 0, $response->get_headers()['X-WP-Total'] );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_event_without_venue_has_empty_location(): void {
+		$this->create_event( [
+			'post_title' => 'Online Only Event',
+		] );
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/integration/events-feed' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertNotEmpty( $data );
+		$event = $data[0];
+
+		$this->assertSame( '', $event['location']['latitude'] );
+		$this->assertSame( '', $event['location']['longitude'] );
+		$this->assertSame( '', $event['location']['city'] );
+		$this->assertSame( '', $event['location']['country'] );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_description_is_plain_text(): void {
+		$this->create_event( [
+			'post_title'   => 'HTML Event',
+			'post_content' => '<p>This is a <strong>bold</strong> description.</p>',
+		] );
+
+		$request  = new WP_REST_Request( 'GET', '/groups/v1/integration/events-feed' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertNotEmpty( $data );
+		$this->assertStringNotContainsString( '<', $data[0]['description'] );
+		$this->assertStringContainsString( 'bold', $data[0]['description'] );
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Official_Events_API` class (`Groups\Integrations`) that registers a public REST endpoint at `GET /groups/v1/integration/events-feed`
- Queries events across all group sites in the network and returns them in the format expected by the `official-wordpress-events` aggregation plugin (title, description, url, date/end_date in UTC, location with lat/lon/city/country, group name/url)
- Supports pagination (`page`, `per_page`) and caching (`Cache-Control`, `ETag`/`If-None-Match`)
- Wire into `Plugin` class for automatic initialization
- Fix test bootstrap `WP_TESTS_CONFIG_FILE_PATH` resolution for symlinked test directories

## Test plan
- [x] 9 PHPUnit tests covering:
  - Public access (no auth required)
  - Response format matches official-wordpress-events expectations
  - Only scheduled/active events returned (not draft/past/cancelled)
  - Pagination with correct headers (X-WP-Total, X-WP-TotalPages)
  - Events sorted by start date
  - Cache-Control and ETag headers present
  - Empty response for no events
  - Events without venue have empty location fields
  - HTML stripped from descriptions
- [x] Full test suite passes (300/301, 1 pre-existing failure in Test_Aggregator)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)