### PR TITLE
Add admin Application Tracker list table (#30)

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/admin/class-application-tracker.php
+++ b/wp-content/plugins/wordpress-groups/includes/admin/class-application-tracker.php
@@ -1,0 +1,458 @@
+<?php
+/**
+ * Application Tracker list table for managing wp_meetup applications.
+ *
+ * Provides a WP_List_Table-based admin UI on the network admin for
+ * deputies to review, filter, and act on group applications.
+ *
+ * @package Groups\Admin
+ */
+
+namespace Groups\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WP_List_Table' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+/**
+ * Application Tracker list table.
+ */
+class Application_Tracker extends \WP_List_Table {
+
+	/**
+	 * Valid meetup statuses for filtering.
+	 *
+	 * @var array<string, string>
+	 */
+	private const STATUSES = [
+		'meetup-pending'     => 'Pending',
+		'meetup-vetting'     => 'Vetting',
+		'meetup-feedback'    => 'Feedback',
+		'meetup-orientation' => 'Orientation',
+		'meetup-scheduling'  => 'Scheduling',
+		'meetup-active'      => 'Active',
+		'meetup-dormant'     => 'Dormant',
+	];
+
+	/**
+	 * Constructor. Registers the admin menu hook.
+	 */
+	public function __construct() {
+		add_action( 'network_admin_menu', [ $this, 'register_menu_page' ] );
+	}
+
+	/**
+	 * Register the network admin menu page.
+	 */
+	public function register_menu_page(): void {
+		add_menu_page(
+			__( 'Group Applications', 'wordpress-groups' ),
+			__( 'Group Applications', 'wordpress-groups' ),
+			'manage_options',
+			'group-applications',
+			[ $this, 'render_page' ],
+			'dashicons-groups',
+			30
+		);
+	}
+
+	/**
+	 * Check whether the current user has access.
+	 *
+	 * @return bool
+	 */
+	public static function current_user_can_access(): bool {
+		return is_super_admin() || current_user_can( 'administrator' );
+	}
+
+	/**
+	 * Render the admin page.
+	 */
+	public function render_page(): void {
+		if ( ! self::current_user_can_access() ) {
+			wp_die( esc_html__( 'You do not have permission to access this page.', 'wordpress-groups' ) );
+		}
+
+		$this->process_bulk_actions();
+
+		// Re-initialise list table internals for rendering.
+		$this->init_list_table();
+		$this->prepare_items();
+
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'Group Applications', 'wordpress-groups' ) . '</h1>';
+
+		echo '<form method="get">';
+		echo '<input type="hidden" name="page" value="group-applications" />';
+		$this->display_status_filter();
+		$this->display();
+		echo '</form>';
+
+		echo '</div>';
+	}
+
+	/**
+	 * Initialise WP_List_Table internals (called before prepare_items).
+	 */
+	private function init_list_table(): void {
+		parent::__construct( [
+			'singular' => 'application',
+			'plural'   => 'applications',
+			'ajax'     => false,
+			'screen'   => 'toplevel_page_group-applications-network',
+		] );
+	}
+
+	/**
+	 * Get the list of columns.
+	 *
+	 * @return array<string, string>
+	 */
+	public function get_columns(): array {
+		return [
+			'cb'           => '<input type="checkbox" />',
+			'group_name'   => __( 'Group Name', 'wordpress-groups' ),
+			'city_country' => __( 'City/Country', 'wordpress-groups' ),
+			'organizer'    => __( 'Organizer', 'wordpress-groups' ),
+			'status'       => __( 'Status', 'wordpress-groups' ),
+			'applied_date' => __( 'Applied Date', 'wordpress-groups' ),
+			'deputy'       => __( 'Deputy', 'wordpress-groups' ),
+		];
+	}
+
+	/**
+	 * Get sortable columns.
+	 *
+	 * @return array<string, array{0: string, 1: bool}>
+	 */
+	public function get_sortable_columns(): array {
+		return [
+			'group_name'   => [ 'title', false ],
+			'applied_date' => [ 'date', true ],
+			'status'       => [ 'status', false ],
+		];
+	}
+
+	/**
+	 * Get bulk actions.
+	 *
+	 * @return array<string, string>
+	 */
+	public function get_bulk_actions(): array {
+		return [
+			'approve'          => __( 'Approve (→ Vetting)', 'wordpress-groups' ),
+			'decline'          => __( 'Decline', 'wordpress-groups' ),
+			'request_feedback' => __( 'Request Feedback', 'wordpress-groups' ),
+		];
+	}
+
+	/**
+	 * Process bulk actions.
+	 */
+	public function process_bulk_actions(): void {
+		$action = $this->current_action();
+
+		if ( ! $action ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$nonce = isset( $_REQUEST['_wpnonce'] ) ? wp_unslash( $_REQUEST['_wpnonce'] ) : '';
+
+		if ( ! wp_verify_nonce( $nonce, 'bulk-applications' ) ) {
+			return;
+		}
+
+		$post_ids = isset( $_REQUEST['application'] ) ? array_map( 'intval', (array) $_REQUEST['application'] ) : [];
+
+		if ( empty( $post_ids ) ) {
+			return;
+		}
+
+		$status_map = [
+			'approve'          => 'meetup-vetting',
+			'decline'          => 'meetup-declined',
+			'request_feedback' => 'meetup-feedback',
+		];
+
+		if ( ! isset( $status_map[ $action ] ) ) {
+			return;
+		}
+
+		$new_status = $status_map[ $action ];
+
+		foreach ( $post_ids as $post_id ) {
+			$post = get_post( $post_id );
+
+			if ( ! $post || 'wp_meetup' !== $post->post_type ) {
+				continue;
+			}
+
+			wp_update_post( [
+				'ID'          => $post_id,
+				'post_status' => $new_status,
+			] );
+		}
+	}
+
+	/**
+	 * Prepare items for the table.
+	 */
+	public function prepare_items(): void {
+		$per_page = 20;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$current_page = isset( $_REQUEST['paged'] ) ? max( 1, (int) $_REQUEST['paged'] ) : 1;
+
+		$args = [
+			'post_type'      => 'wp_meetup',
+			'posts_per_page' => $per_page,
+			'paged'          => $current_page,
+			'post_status'    => 'any',
+		];
+
+		// Status filter.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$status_filter = isset( $_REQUEST['meetup_status'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['meetup_status'] ) ) : '';
+
+		if ( $status_filter && array_key_exists( $status_filter, self::STATUSES ) ) {
+			$args['post_status'] = $status_filter;
+		}
+
+		// Sorting.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$orderby = isset( $_REQUEST['orderby'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['orderby'] ) ) : 'date';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$order = isset( $_REQUEST['order'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['order'] ) ) : 'DESC';
+
+		$args['orderby'] = $orderby;
+		$args['order']   = in_array( strtoupper( $order ), [ 'ASC', 'DESC' ], true ) ? strtoupper( $order ) : 'DESC';
+
+		$query = new \WP_Query( $args );
+
+		$this->items = $query->posts;
+
+		$this->set_pagination_args( [
+			'total_items' => $query->found_posts,
+			'per_page'    => $per_page,
+			'total_pages' => $query->max_num_pages,
+		] );
+
+		$this->_column_headers = [
+			$this->get_columns(),
+			[],
+			$this->get_sortable_columns(),
+		];
+	}
+
+	/**
+	 * Render the checkbox column.
+	 *
+	 * @param \WP_Post $item Post object.
+	 * @return string
+	 */
+	public function column_cb( $item ): string {
+		return sprintf(
+			'<input type="checkbox" name="application[]" value="%d" />',
+			$item->ID
+		);
+	}
+
+	/**
+	 * Render the Group Name column with row actions.
+	 *
+	 * @param \WP_Post $item Post object.
+	 * @return string
+	 */
+	public function column_group_name( $item ): string {
+		$actions = [
+			'view'     => sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( get_permalink( $item->ID ) ),
+				__( 'View', 'wordpress-groups' )
+			),
+			'edit'     => sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( get_edit_post_link( $item->ID ) ),
+				__( 'Edit', 'wordpress-groups' )
+			),
+			'add_note' => sprintf(
+				'<a href="#" class="add-note" data-post-id="%d">%s</a>',
+				$item->ID,
+				__( 'Add Note', 'wordpress-groups' )
+			),
+		];
+
+		return sprintf(
+			'<strong>%s</strong>%s',
+			esc_html( $item->post_title ),
+			$this->row_actions( $actions )
+		);
+	}
+
+	/**
+	 * Render the City/Country column.
+	 *
+	 * @param \WP_Post $item Post object.
+	 * @return string
+	 */
+	public function column_city_country( $item ): string {
+		$city    = get_post_meta( $item->ID, '_meetup_city', true );
+		$country = get_post_meta( $item->ID, '_meetup_country', true );
+
+		if ( $city && $country ) {
+			return esc_html( $city . ', ' . $country );
+		}
+
+		return esc_html( $city ?: $country ?: '—' );
+	}
+
+	/**
+	 * Render the Organizer column.
+	 *
+	 * @param \WP_Post $item Post object.
+	 * @return string
+	 */
+	public function column_organizer( $item ): string {
+		$username = get_post_meta( $item->ID, '_meetup_organizer_username', true );
+
+		return $username ? esc_html( $username ) : '—';
+	}
+
+	/**
+	 * Render the Status column.
+	 *
+	 * @param \WP_Post $item Post object.
+	 * @return string
+	 */
+	public function column_status( $item ): string {
+		$status = $item->post_status;
+
+		return esc_html( self::STATUSES[ $status ] ?? $status );
+	}
+
+	/**
+	 * Render the Applied Date column.
+	 *
+	 * @param \WP_Post $item Post object.
+	 * @return string
+	 */
+	public function column_applied_date( $item ): string {
+		$date = get_post_meta( $item->ID, '_meetup_application_date', true );
+
+		if ( ! $date ) {
+			$date = $item->post_date;
+		}
+
+		return esc_html( mysql2date( 'Y-m-d', $date ) );
+	}
+
+	/**
+	 * Render the Deputy column.
+	 *
+	 * @param \WP_Post $item Post object.
+	 * @return string
+	 */
+	public function column_deputy( $item ): string {
+		$deputy = get_post_meta( $item->ID, '_meetup_deputy_assigned', true );
+
+		return $deputy ? esc_html( $deputy ) : '—';
+	}
+
+	/**
+	 * Default column renderer.
+	 *
+	 * @param \WP_Post $item        Post object.
+	 * @param string   $column_name Column name.
+	 * @return string
+	 */
+	public function column_default( $item, $column_name ): string {
+		return '—';
+	}
+
+	/**
+	 * Display the status filter dropdown above the table.
+	 */
+	private function display_status_filter(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$current = isset( $_REQUEST['meetup_status'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['meetup_status'] ) ) : '';
+
+		echo '<div class="tablenav top">';
+		echo '<div class="alignleft actions">';
+		echo '<select name="meetup_status">';
+		echo '<option value="">' . esc_html__( 'All Statuses', 'wordpress-groups' ) . '</option>';
+
+		foreach ( self::STATUSES as $slug => $label ) {
+			printf(
+				'<option value="%s"%s>%s</option>',
+				esc_attr( $slug ),
+				selected( $current, $slug, false ),
+				esc_html( $label )
+			);
+		}
+
+		echo '</select>';
+		submit_button( __( 'Filter', 'wordpress-groups' ), '', 'filter_action', false );
+		echo '</div>';
+		echo '</div>';
+	}
+
+	/**
+	 * Message displayed when no items are found.
+	 */
+	public function no_items(): void {
+		esc_html_e( 'No group applications found.', 'wordpress-groups' );
+	}
+
+	/**
+	 * Get the available statuses.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function get_statuses(): array {
+		return self::STATUSES;
+	}
+
+	/**
+	 * Add an internal note to a meetup post.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $note    Note text.
+	 * @param int    $user_id User ID who added the note.
+	 * @return bool True on success.
+	 */
+	public static function add_note( int $post_id, string $note, int $user_id = 0 ): bool {
+		$post = get_post( $post_id );
+
+		if ( ! $post || 'wp_meetup' !== $post->post_type ) {
+			return false;
+		}
+
+		$notes = get_post_meta( $post_id, '_meetup_notes', true );
+
+		if ( ! is_array( $notes ) ) {
+			$notes = [];
+		}
+
+		$notes[] = [
+			'note'    => sanitize_textarea_field( $note ),
+			'user_id' => $user_id ?: get_current_user_id(),
+			'date'    => current_time( 'mysql', true ),
+		];
+
+		return (bool) update_post_meta( $post_id, '_meetup_notes', $notes );
+	}
+
+	/**
+	 * Get internal notes for a meetup post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array
+	 */
+	public static function get_notes( int $post_id ): array {
+		$notes = get_post_meta( $post_id, '_meetup_notes', true );
+
+		return is_array( $notes ) ? $notes : [];
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -63,6 +63,7 @@ class Plugin {
 		Models\Recurrence_Generator::schedule_cron();
 		new Integrations\Slack_Notifier();
 		new Integrations\Official_Events_API();
+		new Admin\Application_Tracker();
 
 		add_action( 'init', [ Models\Membership::class, 'register_roles' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/admin/Test_Application_Tracker.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/admin/Test_Application_Tracker.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Tests for the Application_Tracker list table.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Admin\Application_Tracker;
+
+/**
+ * @coversDefaultClass \Groups\Admin\Application_Tracker
+ */
+class Test_Application_Tracker extends WP_UnitTestCase {
+
+	/**
+	 * Tracker instance.
+	 *
+	 * @var Application_Tracker
+	 */
+	private Application_Tracker $tracker;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// Register the wp_meetup post type for testing.
+		register_post_type( 'wp_meetup', [
+			'public' => false,
+		] );
+
+		// Register all meetup statuses.
+		$statuses = [
+			'meetup-pending',
+			'meetup-vetting',
+			'meetup-feedback',
+			'meetup-orientation',
+			'meetup-scheduling',
+			'meetup-active',
+			'meetup-dormant',
+			'meetup-suspended',
+			'meetup-removed',
+			'meetup-declined',
+		];
+
+		foreach ( $statuses as $status ) {
+			register_post_status( $status, [
+				'public' => true,
+			] );
+		}
+
+		$this->tracker = new Application_Tracker();
+	}
+
+	/**
+	 * Helper to create a wp_meetup post with a given status.
+	 *
+	 * @param string $status Initial post status.
+	 * @param array  $meta   Optional post meta.
+	 * @return int Post ID.
+	 */
+	private function create_meetup_post( string $status = 'meetup-pending', array $meta = [] ): int {
+		$post_id = wp_insert_post( [
+			'post_type'   => 'wp_meetup',
+			'post_title'  => 'Test Group',
+			'post_status' => $status,
+		] );
+
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * @covers ::register_menu_page
+	 */
+	public function test_menu_page_is_registered(): void {
+		// Use an existing super admin (user 1 is super admin in test suite).
+		wp_set_current_user( 1 );
+
+		// Fire the hook.
+		$this->tracker->register_menu_page();
+
+		global $menu;
+
+		$found = false;
+
+		if ( is_array( $menu ) ) {
+			foreach ( $menu as $item ) {
+				if ( isset( $item[2] ) && 'group-applications' === $item[2] ) {
+					$found = true;
+					break;
+				}
+			}
+		}
+
+		$this->assertTrue( $found, 'The group-applications menu page should be registered.' );
+	}
+
+	/**
+	 * @covers ::get_columns
+	 */
+	public function test_list_table_returns_correct_columns(): void {
+		$columns = $this->tracker->get_columns();
+
+		$this->assertArrayHasKey( 'cb', $columns );
+		$this->assertArrayHasKey( 'group_name', $columns );
+		$this->assertArrayHasKey( 'city_country', $columns );
+		$this->assertArrayHasKey( 'organizer', $columns );
+		$this->assertArrayHasKey( 'status', $columns );
+		$this->assertArrayHasKey( 'applied_date', $columns );
+		$this->assertArrayHasKey( 'deputy', $columns );
+		$this->assertCount( 7, $columns );
+	}
+
+	/**
+	 * @covers ::get_sortable_columns
+	 */
+	public function test_sortable_columns(): void {
+		$sortable = $this->tracker->get_sortable_columns();
+
+		$this->assertArrayHasKey( 'group_name', $sortable );
+		$this->assertArrayHasKey( 'applied_date', $sortable );
+		$this->assertArrayHasKey( 'status', $sortable );
+	}
+
+	/**
+	 * @covers ::get_bulk_actions
+	 */
+	public function test_bulk_actions(): void {
+		$actions = $this->tracker->get_bulk_actions();
+
+		$this->assertArrayHasKey( 'approve', $actions );
+		$this->assertArrayHasKey( 'decline', $actions );
+		$this->assertArrayHasKey( 'request_feedback', $actions );
+	}
+
+	/**
+	 * @covers ::prepare_items
+	 */
+	public function test_status_filter_works(): void {
+		$this->create_meetup_post( 'meetup-pending' );
+		$this->create_meetup_post( 'meetup-vetting' );
+		$this->create_meetup_post( 'meetup-vetting' );
+
+		// Simulate status filter via $_REQUEST.
+		$_REQUEST['meetup_status'] = 'meetup-vetting';
+
+		$this->tracker->prepare_items();
+
+		$this->assertCount( 2, $this->tracker->items, 'Status filter should return only vetting posts.' );
+
+		foreach ( $this->tracker->items as $item ) {
+			$this->assertSame( 'meetup-vetting', $item->post_status );
+		}
+
+		unset( $_REQUEST['meetup_status'] );
+	}
+
+	/**
+	 * @covers ::prepare_items
+	 */
+	public function test_prepare_items_returns_all_without_filter(): void {
+		$this->create_meetup_post( 'meetup-pending' );
+		$this->create_meetup_post( 'meetup-active' );
+
+		$this->tracker->prepare_items();
+
+		$this->assertCount( 2, $this->tracker->items );
+	}
+
+	/**
+	 * @covers ::add_note
+	 * @covers ::get_notes
+	 */
+	public function test_add_and_get_notes(): void {
+		$post_id = $this->create_meetup_post();
+
+		$result = Application_Tracker::add_note( $post_id, 'Test note content', 1 );
+
+		$this->assertTrue( $result );
+
+		$notes = Application_Tracker::get_notes( $post_id );
+
+		$this->assertCount( 1, $notes );
+		$this->assertSame( 'Test note content', $notes[0]['note'] );
+		$this->assertSame( 1, $notes[0]['user_id'] );
+		$this->assertArrayHasKey( 'date', $notes[0] );
+	}
+
+	/**
+	 * @covers ::add_note
+	 */
+	public function test_add_note_rejects_non_meetup_post(): void {
+		$post_id = self::factory()->post->create( [ 'post_type' => 'post' ] );
+
+		$result = Application_Tracker::add_note( $post_id, 'Should fail' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @covers ::get_notes
+	 */
+	public function test_get_notes_returns_empty_array_for_no_notes(): void {
+		$post_id = $this->create_meetup_post();
+
+		$notes = Application_Tracker::get_notes( $post_id );
+
+		$this->assertIsArray( $notes );
+		$this->assertEmpty( $notes );
+	}
+
+	/**
+	 * @covers ::get_statuses
+	 */
+	public function test_get_statuses_returns_all_filter_statuses(): void {
+		$statuses = Application_Tracker::get_statuses();
+
+		$this->assertArrayHasKey( 'meetup-pending', $statuses );
+		$this->assertArrayHasKey( 'meetup-vetting', $statuses );
+		$this->assertArrayHasKey( 'meetup-feedback', $statuses );
+		$this->assertArrayHasKey( 'meetup-orientation', $statuses );
+		$this->assertArrayHasKey( 'meetup-scheduling', $statuses );
+		$this->assertArrayHasKey( 'meetup-active', $statuses );
+		$this->assertArrayHasKey( 'meetup-dormant', $statuses );
+	}
+
+	/**
+	 * @covers ::current_user_can_access
+	 */
+	public function test_super_admin_can_access(): void {
+		// User 1 is super admin in multisite test suite.
+		wp_set_current_user( 1 );
+
+		$this->assertTrue( Application_Tracker::current_user_can_access() );
+	}
+
+	/**
+	 * @covers ::current_user_can_access
+	 */
+	public function test_subscriber_cannot_access(): void {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $user_id );
+
+		$this->assertFalse( Application_Tracker::current_user_can_access() );
+	}
+
+	/**
+	 * @covers ::column_status
+	 */
+	public function test_column_status_renders_label(): void {
+		$post_id = $this->create_meetup_post( 'meetup-pending' );
+		$post    = get_post( $post_id );
+
+		$output = $this->tracker->column_status( $post );
+
+		$this->assertSame( 'Pending', $output );
+	}
+
+	/**
+	 * @covers ::column_city_country
+	 */
+	public function test_column_city_country_renders_meta(): void {
+		$post_id = $this->create_meetup_post( 'meetup-pending', [
+			'_meetup_city'    => 'Melbourne',
+			'_meetup_country' => 'Australia',
+		] );
+		$post = get_post( $post_id );
+
+		$output = $this->tracker->column_city_country( $post );
+
+		$this->assertSame( 'Melbourne, Australia', $output );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/bootstrap.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/bootstrap.php
@@ -10,6 +10,13 @@ if ( ! getenv( 'WP_MULTISITE' ) ) {
 	putenv( 'WP_MULTISITE=1' );
 }
 
+// Load PHPUnit Polyfills if available via Composer.
+$_polyfills_path = dirname( __DIR__, 2 ) . '/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
+if ( file_exists( $_polyfills_path ) ) {
+	require_once $_polyfills_path;
+}
+unset( $_polyfills_path );
+
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( ! $_tests_dir ) {


### PR DESCRIPTION
## Summary
- Adds `Groups\Admin\Application_Tracker` extending `WP_List_Table` for managing `wp_meetup` group applications in the network admin
- Registers a "Group Applications" network admin menu page with deputy-only access (super admin or administrator)
- Displays sortable/filterable table with columns: Group Name, City/Country, Organizer, Status, Applied Date, Deputy
- Status filter dropdown for 7 workflow statuses (pending, vetting, feedback, orientation, scheduling, active, dormant)
- Bulk actions: Approve (to vetting), Decline, Request Feedback
- Row actions: View, Edit, Add Note
- Internal notes stored as `_meetup_notes` post meta array with user ID and timestamp
- Wired into Plugin class, PHPUnit polyfills loaded in bootstrap for test environment compatibility
- 14 tests covering menu registration, columns, status filtering, notes CRUD, access control, and column rendering

## Test plan
- [x] All 14 PHPUnit tests pass locally via wp-env
- [ ] Verify menu page appears in network admin when logged in as super admin
- [ ] Verify status filter correctly narrows results
- [ ] Verify bulk actions transition post statuses correctly

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)