### PR TITLE
Add group announcement system and notification preferences

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -56,6 +56,7 @@ class Plugin {
 		Analytics\Dormancy_Detector::schedule_cron();
 		new Calendar\ICal_Export();
 		new Notifications\Scheduler();
+		new Notifications\Announcements();
 		new Workflow\Application_Workflow();
 		new Workflow\Status_Transition();
 		new Workflow\Site_Provisioner();

--- a/wp-content/plugins/wordpress-groups/includes/notifications/class-announcements.php
+++ b/wp-content/plugins/wordpress-groups/includes/notifications/class-announcements.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Group announcement system.
+ *
+ * Sends branded HTML email announcements from organizers to all group members.
+ *
+ * @package Groups\Notifications
+ */
+
+namespace Groups\Notifications;
+
+use Groups\Database\Activity_Log_Table;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles sending group-wide announcements to all members of a group site.
+ *
+ * Uses the `group-announcement.html` email template and respects per-user
+ * notification preferences via User_Preferences.
+ */
+class Announcements {
+
+	/**
+	 * Email notifier instance.
+	 *
+	 * @var Email_Notifier
+	 */
+	private Email_Notifier $notifier;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Email_Notifier|null $notifier Optional. Email notifier instance.
+	 */
+	public function __construct( ?Email_Notifier $notifier = null ) {
+		$this->notifier = $notifier ?? new Email_Notifier();
+	}
+
+	/**
+	 * Send an announcement to all members of a group site.
+	 *
+	 * Retrieves all users on the specified blog, filters out those who have
+	 * opted out of announcements, sends each a branded HTML email using the
+	 * `group-announcement` template, and logs the action to the activity log.
+	 *
+	 * @param int    $blog_id   Blog ID of the group site.
+	 * @param int    $sender_id User ID of the announcement sender.
+	 * @param string $subject   Email subject line.
+	 * @param string $body      Announcement body content (may contain HTML).
+	 * @return int Number of emails sent successfully.
+	 */
+	public function send( int $blog_id, int $sender_id, string $subject, string $body ): int {
+		$sender = get_userdata( $sender_id );
+
+		if ( ! $sender ) {
+			return 0;
+		}
+
+		// Switch to the target blog to get its users and details.
+		switch_to_blog( $blog_id );
+
+		$group_name = get_bloginfo( 'name' );
+		$group_url  = home_url( '/' );
+		$users      = get_users( [ 'blog_id' => $blog_id ] );
+
+		restore_current_blog();
+
+		$sent_count = 0;
+
+		foreach ( $users as $user ) {
+			// Skip the sender — they already know what they wrote.
+			if ( $user->ID === $sender_id ) {
+				continue;
+			}
+
+			// Respect user notification preferences.
+			if ( ! User_Preferences::is_opted_in( $user->ID, 'announcements' ) ) {
+				continue;
+			}
+
+			$template_data = [
+				'announcement_title' => $subject,
+				'announcement_body'  => $body,
+				'user_name'          => $user->display_name,
+				'group_name'         => $group_name,
+				'group_url'          => $group_url,
+				'email_subject'      => $subject,
+				'preview_text'       => wp_strip_all_tags( $subject ),
+			];
+
+			$sent = $this->notifier->send(
+				$user->user_email,
+				$subject,
+				'group-announcement',
+				$template_data
+			);
+
+			if ( $sent ) {
+				$sent_count++;
+			}
+		}
+
+		// Log the announcement to the activity log.
+		Activity_Log_Table::insert(
+			$blog_id,
+			$sender_id,
+			'announcement_sent',
+			0,
+			[
+				'subject'    => $subject,
+				'recipients' => $sent_count,
+			]
+		);
+
+		/**
+		 * Fires after a group announcement has been sent.
+		 *
+		 * @param int    $blog_id    Blog ID of the group site.
+		 * @param int    $sender_id  User ID of the sender.
+		 * @param string $subject    Email subject.
+		 * @param int    $sent_count Number of emails sent.
+		 */
+		do_action( 'groups_announcement_sent', $blog_id, $sender_id, $subject, $sent_count );
+
+		return $sent_count;
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/notifications/class-user-preferences.php
+++ b/wp-content/plugins/wordpress-groups/includes/notifications/class-user-preferences.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * User notification preferences.
+ *
+ * Manages per-user opt-in/opt-out settings for each notification type.
+ *
+ * @package Groups\Notifications
+ */
+
+namespace Groups\Notifications;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stores and retrieves user notification preferences from user meta.
+ *
+ * Preferences are stored as a serialized associative array under the
+ * `_groups_notification_prefs` user meta key. All notification types
+ * default to opted-in.
+ */
+class User_Preferences {
+
+	/**
+	 * User meta key for notification preferences.
+	 *
+	 * @var string
+	 */
+	public const META_KEY = '_groups_notification_prefs';
+
+	/**
+	 * Valid notification types.
+	 *
+	 * @var array<string>
+	 */
+	public const TYPES = [
+		'event_reminders',
+		'announcements',
+		'rsvp_confirmations',
+	];
+
+	/**
+	 * Get the preference value for a specific notification type.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $type    Notification type (one of self::TYPES).
+	 * @return bool True if opted in, false if opted out.
+	 *
+	 * @throws \InvalidArgumentException If the notification type is not valid.
+	 */
+	public static function get_preference( int $user_id, string $type ): bool {
+		self::validate_type( $type );
+
+		$prefs = self::get_all_preferences( $user_id );
+
+		return $prefs[ $type ] ?? true;
+	}
+
+	/**
+	 * Set the preference for a specific notification type.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $type    Notification type (one of self::TYPES).
+	 * @param bool   $enabled Whether the notification type is enabled.
+	 * @return bool True on success, false on failure.
+	 *
+	 * @throws \InvalidArgumentException If the notification type is not valid.
+	 */
+	public static function set_preference( int $user_id, string $type, bool $enabled ): bool {
+		self::validate_type( $type );
+
+		$prefs          = self::get_all_preferences( $user_id );
+		$prefs[ $type ] = $enabled;
+
+		return (bool) update_user_meta( $user_id, self::META_KEY, $prefs );
+	}
+
+	/**
+	 * Check whether a user is opted in to a specific notification type.
+	 *
+	 * Alias for get_preference() for readability at call sites.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $type    Notification type (one of self::TYPES).
+	 * @return bool True if opted in, false if opted out.
+	 */
+	public static function is_opted_in( int $user_id, string $type ): bool {
+		return self::get_preference( $user_id, $type );
+	}
+
+	/**
+	 * Get all preferences for a user.
+	 *
+	 * @param int $user_id User ID.
+	 * @return array<string, bool> Associative array of type => enabled pairs.
+	 */
+	private static function get_all_preferences( int $user_id ): array {
+		$prefs = get_user_meta( $user_id, self::META_KEY, true );
+
+		if ( ! is_array( $prefs ) ) {
+			return [];
+		}
+
+		return $prefs;
+	}
+
+	/**
+	 * Validate that a notification type is recognised.
+	 *
+	 * @param string $type Notification type to validate.
+	 *
+	 * @throws \InvalidArgumentException If the type is not in self::TYPES.
+	 */
+	private static function validate_type( string $type ): void {
+		if ( ! in_array( $type, self::TYPES, true ) ) {
+			throw new \InvalidArgumentException(
+				sprintf(
+					'Invalid notification type "%s". Valid types: %s',
+					$type,
+					implode( ', ', self::TYPES )
+				)
+			);
+		}
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Announcements.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Announcements.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Tests for the Announcements class.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Database\Activity_Log_Table;
+use Groups\Notifications\Announcements;
+use Groups\Notifications\User_Preferences;
+
+/**
+ * @coversDefaultClass \Groups\Notifications\Announcements
+ */
+class Test_Announcements extends WP_UnitTestCase {
+
+	/**
+	 * Announcements instance under test.
+	 *
+	 * @var Announcements
+	 */
+	private Announcements $announcements;
+
+	/**
+	 * Blog ID of the test group site.
+	 *
+	 * @var int
+	 */
+	private int $blog_id;
+
+	/**
+	 * Sender user ID.
+	 *
+	 * @var int
+	 */
+	private int $sender_id;
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->announcements = new Announcements();
+		$this->blog_id       = get_current_blog_id();
+
+		// Use the default admin user (ID 1) as sender so it is skipped
+		// as a recipient and does not affect test counts.
+		$this->sender_id = 1;
+		wp_update_user( [
+			'ID'         => 1,
+			'user_email' => 'sender@example.org',
+		] );
+	}
+
+	/**
+	 * Helper: create a user and add them to the current blog.
+	 *
+	 * @param array $args User creation args.
+	 * @return int User ID.
+	 */
+	private function create_member( array $args = [] ): int {
+		$user_id = self::factory()->user->create( $args );
+		add_user_to_blog( $this->blog_id, $user_id, 'subscriber' );
+		return $user_id;
+	}
+
+	/**
+	 * @covers ::send
+	 */
+	public function test_send_delivers_to_all_opted_in_members(): void {
+		$member1 = $this->create_member( [ 'user_email' => 'member1@example.org' ] );
+		$member2 = $this->create_member( [ 'user_email' => 'member2@example.org' ] );
+
+		$recipients = [];
+		add_action(
+			'groups_before_email_send',
+			function ( $to ) use ( &$recipients ) {
+				$recipients[] = $to;
+			}
+		);
+
+		$count = $this->announcements->send( $this->blog_id, $this->sender_id, 'Test Subject', 'Test body content.' );
+
+		$this->assertSame( 2, $count );
+		$this->assertContains( 'member1@example.org', $recipients );
+		$this->assertContains( 'member2@example.org', $recipients );
+	}
+
+	/**
+	 * @covers ::send
+	 */
+	public function test_send_skips_opted_out_users(): void {
+		$member1 = $this->create_member( [ 'user_email' => 'opted-in@example.org' ] );
+		$member2 = $this->create_member( [ 'user_email' => 'opted-out@example.org' ] );
+
+		User_Preferences::set_preference( $member2, 'announcements', false );
+
+		$recipients = [];
+		add_action(
+			'groups_before_email_send',
+			function ( $to ) use ( &$recipients ) {
+				$recipients[] = $to;
+			}
+		);
+
+		$count = $this->announcements->send( $this->blog_id, $this->sender_id, 'Test', 'Body.' );
+
+		$this->assertSame( 1, $count );
+		$this->assertContains( 'opted-in@example.org', $recipients );
+		$this->assertNotContains( 'opted-out@example.org', $recipients );
+	}
+
+	/**
+	 * @covers ::send
+	 */
+	public function test_send_skips_the_sender(): void {
+		$member = $this->create_member( [ 'user_email' => 'member@example.org' ] );
+
+		$recipients = [];
+		add_action(
+			'groups_before_email_send',
+			function ( $to ) use ( &$recipients ) {
+				$recipients[] = $to;
+			}
+		);
+
+		$this->announcements->send( $this->blog_id, $this->sender_id, 'Test', 'Body.' );
+
+		$this->assertNotContains( 'sender@example.org', $recipients );
+		$this->assertContains( 'member@example.org', $recipients );
+	}
+
+	/**
+	 * @covers ::send
+	 */
+	public function test_send_returns_zero_for_invalid_sender(): void {
+		$count = $this->announcements->send( $this->blog_id, 999999, 'Test', 'Body.' );
+
+		$this->assertSame( 0, $count );
+	}
+
+	/**
+	 * @covers ::send
+	 */
+	public function test_send_logs_to_activity_log(): void {
+		$this->create_member( [ 'user_email' => 'member@example.org' ] );
+
+		$this->announcements->send( $this->blog_id, $this->sender_id, 'Important Update', 'Body.' );
+
+		$entries = Activity_Log_Table::query( [
+			'blog_id' => $this->blog_id,
+			'action'  => 'announcement_sent',
+		] );
+
+		$this->assertCount( 1, $entries );
+		$this->assertSame( $this->sender_id, (int) $entries[0]->user_id );
+		$this->assertSame( 'Important Update', $entries[0]->meta['subject'] );
+		$this->assertSame( 1, $entries[0]->meta['recipients'] );
+	}
+
+	/**
+	 * @covers ::send
+	 */
+	public function test_send_fires_action_hook(): void {
+		$this->create_member( [ 'user_email' => 'member@example.org' ] );
+
+		$fired = false;
+		add_action(
+			'groups_announcement_sent',
+			function ( $blog_id, $sender_id, $subject, $sent_count ) use ( &$fired ) {
+				$fired = [
+					'blog_id'    => $blog_id,
+					'sender_id'  => $sender_id,
+					'subject'    => $subject,
+					'sent_count' => $sent_count,
+				];
+			},
+			10,
+			4
+		);
+
+		$this->announcements->send( $this->blog_id, $this->sender_id, 'Hello', 'World.' );
+
+		$this->assertIsArray( $fired );
+		$this->assertSame( $this->blog_id, $fired['blog_id'] );
+		$this->assertSame( $this->sender_id, $fired['sender_id'] );
+		$this->assertSame( 'Hello', $fired['subject'] );
+		$this->assertSame( 1, $fired['sent_count'] );
+	}
+
+	/**
+	 * @covers ::send
+	 */
+	public function test_send_with_no_members_returns_zero(): void {
+		// Remove all other users from this blog — only the sender is present.
+		$count = $this->announcements->send( $this->blog_id, $this->sender_id, 'Test', 'Body.' );
+
+		// Sender is skipped, so even if they are on the blog, count should be 0.
+		$this->assertSame( 0, $count );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_User_Preferences.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_User_Preferences.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Tests for the User_Preferences class.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Notifications\User_Preferences;
+
+/**
+ * @coversDefaultClass \Groups\Notifications\User_Preferences
+ */
+class Test_User_Preferences extends WP_UnitTestCase {
+
+	/**
+	 * User ID for testing.
+	 *
+	 * @var int
+	 */
+	private int $user_id;
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->user_id = self::factory()->user->create();
+	}
+
+	/**
+	 * @covers ::get_preference
+	 */
+	public function test_defaults_to_opted_in(): void {
+		$this->assertTrue( User_Preferences::get_preference( $this->user_id, 'announcements' ) );
+		$this->assertTrue( User_Preferences::get_preference( $this->user_id, 'event_reminders' ) );
+		$this->assertTrue( User_Preferences::get_preference( $this->user_id, 'rsvp_confirmations' ) );
+	}
+
+	/**
+	 * @covers ::set_preference
+	 * @covers ::get_preference
+	 */
+	public function test_set_and_get_preference(): void {
+		User_Preferences::set_preference( $this->user_id, 'announcements', false );
+
+		$this->assertFalse( User_Preferences::get_preference( $this->user_id, 'announcements' ) );
+	}
+
+	/**
+	 * @covers ::set_preference
+	 */
+	public function test_set_preference_preserves_other_types(): void {
+		User_Preferences::set_preference( $this->user_id, 'announcements', false );
+		User_Preferences::set_preference( $this->user_id, 'event_reminders', false );
+
+		$this->assertFalse( User_Preferences::get_preference( $this->user_id, 'announcements' ) );
+		$this->assertFalse( User_Preferences::get_preference( $this->user_id, 'event_reminders' ) );
+		$this->assertTrue( User_Preferences::get_preference( $this->user_id, 'rsvp_confirmations' ) );
+	}
+
+	/**
+	 * @covers ::is_opted_in
+	 */
+	public function test_is_opted_in_returns_same_as_get_preference(): void {
+		$this->assertSame(
+			User_Preferences::get_preference( $this->user_id, 'announcements' ),
+			User_Preferences::is_opted_in( $this->user_id, 'announcements' )
+		);
+
+		User_Preferences::set_preference( $this->user_id, 'announcements', false );
+
+		$this->assertSame(
+			User_Preferences::get_preference( $this->user_id, 'announcements' ),
+			User_Preferences::is_opted_in( $this->user_id, 'announcements' )
+		);
+	}
+
+	/**
+	 * @covers ::set_preference
+	 */
+	public function test_re_enable_preference(): void {
+		User_Preferences::set_preference( $this->user_id, 'announcements', false );
+		$this->assertFalse( User_Preferences::is_opted_in( $this->user_id, 'announcements' ) );
+
+		User_Preferences::set_preference( $this->user_id, 'announcements', true );
+		$this->assertTrue( User_Preferences::is_opted_in( $this->user_id, 'announcements' ) );
+	}
+
+	/**
+	 * @covers ::get_preference
+	 */
+	public function test_invalid_type_throws_exception(): void {
+		$this->expectException( \InvalidArgumentException::class );
+
+		User_Preferences::get_preference( $this->user_id, 'invalid_type' );
+	}
+
+	/**
+	 * @covers ::set_preference
+	 */
+	public function test_set_invalid_type_throws_exception(): void {
+		$this->expectException( \InvalidArgumentException::class );
+
+		User_Preferences::set_preference( $this->user_id, 'invalid_type', true );
+	}
+
+	/**
+	 * @covers ::get_preference
+	 */
+	public function test_preferences_are_per_user(): void {
+		$other_user = self::factory()->user->create();
+
+		User_Preferences::set_preference( $this->user_id, 'announcements', false );
+
+		$this->assertFalse( User_Preferences::is_opted_in( $this->user_id, 'announcements' ) );
+		$this->assertTrue( User_Preferences::is_opted_in( $other_user, 'announcements' ) );
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Announcements` class (`Groups\Notifications`) that sends branded HTML emails to all group site members using the `group-announcement` template, skipping the sender and respecting user preferences
- Add `User_Preferences` class (`Groups\Notifications`) for managing per-user notification opt-in/opt-out settings (`event_reminders`, `announcements`, `rsvp_confirmations`) stored as serialized user meta under `_groups_notification_prefs`
- Wire `Announcements` into the Plugin class initialization
- Activity log integration: each announcement is logged with subject and recipient count

## Test plan
- [x] `Test_User_Preferences`: 8 tests covering defaults (opted-in), set/get round-trip, per-user isolation, re-enable, and invalid type validation
- [x] `Test_Announcements`: 7 tests covering delivery to all members, opt-out skipping, sender skipping, invalid sender handling, activity log insertion, action hook firing, and empty group handling
- [x] All 15 new tests pass locally

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)