### PR TITLE
Add application-form block (multi-step form)

### DIFF
--- a/wp-content/plugins/wordpress-groups/blocks/application-form/block.json
+++ b/wp-content/plugins/wordpress-groups/blocks/application-form/block.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "groups/application-form",
+	"version": "0.1.0",
+	"title": "Application Form",
+	"category": "widgets",
+	"description": "A multi-step form for applying to organize a WordPress community group.",
+	"textdomain": "wordpress-groups",
+	"attributes": {},
+	"supports": {
+		"html": false,
+		"align": [ "wide", "full" ],
+		"multiple": false
+	},
+	"editorScript": "file:./index.js",
+	"viewScript": "file:./view.js",
+	"style": "file:./style-index.css",
+	"render": "file:./render.php"
+}

--- a/wp-content/plugins/wordpress-groups/blocks/application-form/edit.js
+++ b/wp-content/plugins/wordpress-groups/blocks/application-form/edit.js
@@ -1,0 +1,30 @@
+/**
+ * Application Form — editor component.
+ *
+ * Shows a placeholder in the block editor since the form is client-rendered.
+ */
+
+import { createElement } from '@wordpress/element';
+import { useBlockProps } from '@wordpress/block-editor';
+import { Placeholder } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Edit component for the Application Form block.
+ */
+export default function Edit() {
+	const blockProps = useBlockProps();
+
+	return createElement(
+		'div',
+		blockProps,
+		createElement( Placeholder, {
+			icon: 'clipboard',
+			label: __( 'Application Form', 'wordpress-groups' ),
+			instructions: __(
+				'This block displays a multi-step application form for organizing a WordPress community group. The form is rendered on the frontend only.',
+				'wordpress-groups'
+			),
+		} )
+	);
+}

--- a/wp-content/plugins/wordpress-groups/blocks/application-form/index.js
+++ b/wp-content/plugins/wordpress-groups/blocks/application-form/index.js
@@ -1,0 +1,14 @@
+/**
+ * Application Form — block registration.
+ *
+ * @package Groups
+ */
+
+import { registerBlockType } from '@wordpress/blocks';
+import metadata from './block.json';
+import Edit from './edit';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+} );

--- a/wp-content/plugins/wordpress-groups/blocks/application-form/render.php
+++ b/wp-content/plugins/wordpress-groups/blocks/application-form/render.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Server-side render for the Application Form block.
+ *
+ * Renders a container for the React multi-step form.
+ * If the user is not logged in, shows a login prompt instead.
+ *
+ * @package Groups
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$is_logged_in = is_user_logged_in();
+$login_url    = wp_login_url( get_permalink() );
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	[
+		'class'          => 'wp-block-groups-application-form',
+		'data-logged-in' => $is_logged_in ? '1' : '0',
+		'data-login-url' => esc_url( $login_url ),
+		'data-nonce'     => wp_create_nonce( 'wp_rest' ),
+	]
+);
+
+?>
+<div <?php echo $wrapper_attributes; ?>>
+	<?php if ( ! $is_logged_in ) : ?>
+		<div class="wp-block-groups-application-form__login-prompt">
+			<h2><?php esc_html_e( 'Start a WordPress Community Group', 'wordpress-groups' ); ?></h2>
+			<p>
+				<?php esc_html_e( 'You need to be logged in with your WordPress.org account to submit a group application.', 'wordpress-groups' ); ?>
+			</p>
+			<a
+				class="wp-block-groups-application-form__login-btn"
+				href="<?php echo esc_url( $login_url ); ?>"
+			>
+				<?php esc_html_e( 'Log in to apply', 'wordpress-groups' ); ?>
+			</a>
+		</div>
+	<?php else : ?>
+		<div class="wp-block-groups-application-form__loading" aria-live="polite">
+			<p><?php esc_html_e( 'Loading application form\u2026', 'wordpress-groups' ); ?></p>
+		</div>
+	<?php endif; ?>
+</div>

--- a/wp-content/plugins/wordpress-groups/blocks/application-form/style.scss
+++ b/wp-content/plugins/wordpress-groups/blocks/application-form/style.scss
@@ -1,0 +1,440 @@
+/**
+ * Application Form block styles.
+ *
+ * Multi-step form with progress indicator, field validation, and responsive layout.
+ * Follows WordPress.org design language with accessible focus styles.
+ */
+
+.wp-block-groups-application-form {
+	max-width: 680px;
+	margin: 0 auto;
+
+	// Login prompt for logged-out users.
+	&__login-prompt {
+		text-align: center;
+		padding: 48px 24px;
+		background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+		border-radius: 8px;
+
+		h2 {
+			margin: 0 0 16px;
+			font-size: 24px;
+			font-weight: 600;
+			color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		}
+
+		p {
+			margin: 0 0 24px;
+			color: var(--wp--preset--color--charcoal-4, #50575e);
+			font-size: 16px;
+			line-height: 1.6;
+		}
+	}
+
+	&__login-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 12px 32px;
+		background-color: var(--wp--preset--color--blueberry-1, #3858e9);
+		color: var(--wp--preset--color--white, #fff);
+		border: 2px solid transparent;
+		border-radius: 4px;
+		font-size: 16px;
+		font-weight: 600;
+		text-decoration: none;
+		min-height: 44px;
+		cursor: pointer;
+		transition: background-color 0.15s ease;
+
+		&:hover {
+			background-color: var(--wp--preset--color--deep-blueberry, #2145e6);
+			color: var(--wp--preset--color--white, #fff);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp--preset--color--blueberry-1, #3858e9);
+			outline-offset: 2px;
+		}
+	}
+
+	// Loading state.
+	&__loading {
+		padding: 48px 24px;
+		text-align: center;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+	}
+
+	// Inner wrapper for the hydrated form.
+	&__inner {
+		padding: 0;
+	}
+
+	&__title {
+		margin: 0 0 24px;
+		font-size: 28px;
+		font-weight: 600;
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+	}
+
+	// Progress indicator.
+	&__progress {
+		margin-bottom: 32px;
+	}
+
+	&__steps {
+		display: flex;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		counter-reset: step;
+		gap: 4px;
+	}
+
+	&__step-item {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 8px;
+		position: relative;
+		text-align: center;
+
+		// Connector line between steps.
+		&::after {
+			content: "";
+			position: absolute;
+			top: 16px;
+			left: calc(50% + 18px);
+			width: calc(100% - 36px);
+			height: 2px;
+			background-color: var(--wp--preset--color--light-grey-1, #dcdcde);
+		}
+
+		&:last-child::after {
+			display: none;
+		}
+
+		&.is-complete::after {
+			background-color: var(--wp--preset--color--blueberry-1, #3858e9);
+		}
+	}
+
+	&__step-number {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: 50%;
+		font-size: 14px;
+		font-weight: 600;
+		background-color: var(--wp--preset--color--light-grey-1, #dcdcde);
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+		position: relative;
+		z-index: 1;
+		transition: background-color 0.2s ease, color 0.2s ease;
+
+		.is-current & {
+			background-color: var(--wp--preset--color--blueberry-1, #3858e9);
+			color: var(--wp--preset--color--white, #fff);
+		}
+
+		.is-complete & {
+			background-color: #00a32a;
+			color: var(--wp--preset--color--white, #fff);
+		}
+	}
+
+	&__step-label {
+		font-size: 12px;
+		font-weight: 500;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+		line-height: 1.3;
+
+		.is-current & {
+			color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+			font-weight: 600;
+		}
+
+		.is-complete & {
+			color: #00a32a;
+		}
+	}
+
+	// Fieldset and legend.
+	&__fieldset {
+		border: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	&__legend {
+		font-size: 20px;
+		font-weight: 600;
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		margin: 0 0 20px;
+		padding: 0;
+	}
+
+	// Form fields.
+	&__field {
+		margin-bottom: 20px;
+
+		&--checkbox {
+			margin-top: 24px;
+		}
+	}
+
+	&__label {
+		display: block;
+		font-size: 14px;
+		font-weight: 600;
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		margin-bottom: 6px;
+	}
+
+	&__required {
+		color: #cc1818;
+	}
+
+	&__input {
+		display: block;
+		width: 100%;
+		padding: 10px 12px;
+		border: 1px solid var(--wp--preset--color--light-grey-1, #dcdcde);
+		border-radius: 4px;
+		font-size: 16px;
+		line-height: 1.5;
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		background-color: var(--wp--preset--color--white, #fff);
+		transition: border-color 0.15s ease, box-shadow 0.15s ease;
+		box-sizing: border-box;
+
+		&:focus {
+			border-color: var(--wp--preset--color--blueberry-1, #3858e9);
+			box-shadow: 0 0 0 1px var(--wp--preset--color--blueberry-1, #3858e9);
+			outline: none;
+		}
+
+		&.has-error {
+			border-color: #cc1818;
+
+			&:focus {
+				box-shadow: 0 0 0 1px #cc1818;
+			}
+		}
+	}
+
+	textarea#{&}__input {
+		resize: vertical;
+		min-height: 100px;
+	}
+
+	&__help {
+		margin: 6px 0 0;
+		font-size: 13px;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+		line-height: 1.4;
+	}
+
+	&__error {
+		margin: 6px 0 0;
+		font-size: 13px;
+		color: #cc1818;
+		line-height: 1.4;
+	}
+
+	// Checkbox field.
+	&__checkbox-label {
+		display: flex;
+		align-items: flex-start;
+		gap: 10px;
+		cursor: pointer;
+		font-size: 14px;
+		line-height: 1.5;
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+	}
+
+	&__checkbox {
+		flex-shrink: 0;
+		width: 20px;
+		height: 20px;
+		margin-top: 2px;
+		accent-color: var(--wp--preset--color--blueberry-1, #3858e9);
+
+		&:focus-visible {
+			outline: 2px solid var(--wp--preset--color--blueberry-1, #3858e9);
+			outline-offset: 2px;
+		}
+	}
+
+	// Review step.
+	&__review-list {
+		margin: 0;
+		padding: 0;
+		display: grid;
+		gap: 8px;
+
+		dt {
+			font-size: 13px;
+			font-weight: 600;
+			color: var(--wp--preset--color--charcoal-4, #50575e);
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+			margin-top: 12px;
+
+			&:first-child {
+				margin-top: 0;
+			}
+		}
+
+		dd {
+			margin: 0;
+			font-size: 16px;
+			line-height: 1.6;
+			color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+			white-space: pre-wrap;
+			word-break: break-word;
+
+			a {
+				color: var(--wp--preset--color--blueberry-1, #3858e9);
+			}
+		}
+	}
+
+	// Submit error.
+	&__submit-error {
+		padding: 12px 16px;
+		margin-bottom: 16px;
+		background-color: #fcf0f1;
+		border: 1px solid #cc1818;
+		border-radius: 4px;
+		color: #cc1818;
+		font-size: 14px;
+		line-height: 1.5;
+	}
+
+	// Action buttons.
+	&__actions {
+		display: flex;
+		gap: 12px;
+		margin-top: 28px;
+		padding-top: 24px;
+		border-top: 1px solid var(--wp--preset--color--light-grey-1, #dcdcde);
+	}
+
+	&__btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 10px 24px;
+		border: 2px solid transparent;
+		border-radius: 4px;
+		font-size: 16px;
+		font-weight: 600;
+		line-height: 1.5;
+		cursor: pointer;
+		min-height: 44px;
+		transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+
+		&--primary {
+			background-color: var(--wp--preset--color--blueberry-1, #3858e9);
+			color: var(--wp--preset--color--white, #fff);
+			border-color: var(--wp--preset--color--blueberry-1, #3858e9);
+			margin-left: auto;
+
+			&:hover {
+				background-color: var(--wp--preset--color--deep-blueberry, #2145e6);
+				border-color: var(--wp--preset--color--deep-blueberry, #2145e6);
+			}
+
+			&:active {
+				background-color: var(--wp--preset--color--dark-blueberry, #183fc5);
+				border-color: var(--wp--preset--color--dark-blueberry, #183fc5);
+			}
+		}
+
+		&--secondary {
+			background-color: transparent;
+			color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+			border-color: var(--wp--preset--color--light-grey-1, #dcdcde);
+
+			&:hover {
+				border-color: var(--wp--preset--color--charcoal-4, #50575e);
+			}
+		}
+
+		&:disabled {
+			opacity: 0.7;
+			cursor: not-allowed;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp--preset--color--blueberry-1, #3858e9);
+			outline-offset: 2px;
+			box-shadow: 0 0 0 2px var(--wp--preset--color--white, #fff);
+		}
+	}
+
+	// Success message.
+	&__success {
+		text-align: center;
+		padding: 48px 24px;
+		background: #f0f6e8;
+		border-radius: 8px;
+		border: 1px solid #00a32a;
+
+		h2 {
+			margin: 0 0 16px;
+			font-size: 24px;
+			font-weight: 600;
+			color: #007017;
+		}
+
+		p {
+			margin: 0 0 12px;
+			font-size: 16px;
+			line-height: 1.6;
+			color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+	}
+}
+
+// Responsive: Stack step labels on small screens.
+@media (max-width: 600px) {
+	.wp-block-groups-application-form {
+		&__steps {
+			gap: 2px;
+		}
+
+		&__step-label {
+			font-size: 11px;
+		}
+
+		&__step-item::after {
+			left: calc(50% + 14px);
+			width: calc(100% - 28px);
+		}
+
+		&__title {
+			font-size: 22px;
+		}
+
+		&__actions {
+			flex-direction: column-reverse;
+		}
+
+		&__btn {
+			width: 100%;
+
+			&--primary {
+				margin-left: 0;
+			}
+		}
+	}
+}

--- a/wp-content/plugins/wordpress-groups/blocks/application-form/view.js
+++ b/wp-content/plugins/wordpress-groups/blocks/application-form/view.js
@@ -1,0 +1,613 @@
+/**
+ * Application Form — frontend multi-step form.
+ *
+ * Hydrates the server-rendered container with a React-based multi-step
+ * application form for starting a WordPress community group.
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, createRoot, useState, useCallback, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Total number of steps in the application form.
+ */
+const TOTAL_STEPS = 4;
+
+/**
+ * Step labels for the progress indicator.
+ */
+const STEP_LABELS = [
+	__( 'Group Details', 'wordpress-groups' ),
+	__( 'Your Background', 'wordpress-groups' ),
+	__( 'Profile & Agreement', 'wordpress-groups' ),
+	__( 'Review & Submit', 'wordpress-groups' ),
+];
+
+/**
+ * Validate a single field value.
+ *
+ * @param {string} name  Field name.
+ * @param {*}      value Field value.
+ * @return {string} Error message, or empty string if valid.
+ */
+function validateField( name, value ) {
+	switch ( name ) {
+		case 'city':
+			return value.trim()
+				? ''
+				: __( 'City is required.', 'wordpress-groups' );
+		case 'groupName':
+			return value.trim()
+				? ''
+				: __( 'Proposed group name is required.', 'wordpress-groups' );
+		case 'wpExperience':
+			return value.trim()
+				? ''
+				: __( 'Please describe your WordPress experience.', 'wordpress-groups' );
+		case 'whyOrganize':
+			return value.trim()
+				? ''
+				: __( 'Please explain why you want to organize a group.', 'wordpress-groups' );
+		case 'profileUrl':
+			if ( ! value.trim() ) {
+				return __( 'WordPress.org profile link is required.', 'wordpress-groups' );
+			}
+			if ( ! /^https?:\/\/(profiles\.)?wordpress\.org\/.+/i.test( value.trim() ) ) {
+				return __( 'Please enter a valid WordPress.org profile URL.', 'wordpress-groups' );
+			}
+			return '';
+		case 'cocAccepted':
+			return value
+				? ''
+				: __( 'You must accept the Code of Conduct to proceed.', 'wordpress-groups' );
+		default:
+			return '';
+	}
+}
+
+/**
+ * Fields required per step (0-indexed).
+ */
+const STEP_FIELDS = [
+	[ 'city', 'groupName' ],
+	[ 'wpExperience', 'whyOrganize' ],
+	[ 'profileUrl', 'cocAccepted' ],
+	[], // Review step has no new fields.
+];
+
+/**
+ * Validate all fields for a given step.
+ *
+ * @param {number} step     Current step (0-indexed).
+ * @param {Object} formData Form data object.
+ * @return {Object} Errors keyed by field name.
+ */
+function validateStep( step, formData ) {
+	const errors = {};
+	const fields = STEP_FIELDS[ step ] || [];
+
+	fields.forEach( ( field ) => {
+		const error = validateField( field, formData[ field ] );
+		if ( error ) {
+			errors[ field ] = error;
+		}
+	} );
+
+	return errors;
+}
+
+/**
+ * Progress Indicator component.
+ *
+ * @param {Object} props
+ * @param {number} props.currentStep Current step (0-indexed).
+ */
+function ProgressIndicator( { currentStep } ) {
+	return createElement(
+		'nav',
+		{
+			className: 'wp-block-groups-application-form__progress',
+			'aria-label': __( 'Application progress', 'wordpress-groups' ),
+		},
+		createElement(
+			'ol',
+			{ className: 'wp-block-groups-application-form__steps' },
+			STEP_LABELS.map( ( label, index ) =>
+				createElement(
+					'li',
+					{
+						key: index,
+						className: [
+							'wp-block-groups-application-form__step-item',
+							index === currentStep ? 'is-current' : '',
+							index < currentStep ? 'is-complete' : '',
+						]
+							.filter( Boolean )
+							.join( ' ' ),
+						'aria-current': index === currentStep ? 'step' : undefined,
+					},
+					createElement(
+						'span',
+						{ className: 'wp-block-groups-application-form__step-number', 'aria-hidden': 'true' },
+						index < currentStep ? '\u2713' : String( index + 1 )
+					),
+					createElement(
+						'span',
+						{ className: 'wp-block-groups-application-form__step-label' },
+						label
+					)
+				)
+			)
+		)
+	);
+}
+
+/**
+ * Form field with label and error display.
+ *
+ * @param {Object}  props
+ * @param {string}  props.id          Field ID.
+ * @param {string}  props.label       Field label.
+ * @param {string}  props.type        Input type (text, url, textarea).
+ * @param {string}  props.value       Current value.
+ * @param {string}  props.error       Error message.
+ * @param {string}  props.help        Help text.
+ * @param {boolean} props.required    Whether the field is required.
+ * @param {Function} props.onChange   Change handler.
+ */
+function FormField( { id, label, type = 'text', value, error, help, required = true, onChange } ) {
+	const errorId = `${ id }-error`;
+	const helpId = help ? `${ id }-help` : undefined;
+	const describedBy = [ error ? errorId : '', helpId || '' ].filter( Boolean ).join( ' ' ) || undefined;
+
+	const inputProps = {
+		id,
+		name: id,
+		value,
+		onChange: ( e ) => onChange( e.target.value ),
+		'aria-invalid': error ? 'true' : undefined,
+		'aria-describedby': describedBy,
+		'aria-required': required ? 'true' : undefined,
+		className: [
+			'wp-block-groups-application-form__input',
+			error ? 'has-error' : '',
+		]
+			.filter( Boolean )
+			.join( ' ' ),
+	};
+
+	const input =
+		type === 'textarea'
+			? createElement( 'textarea', { ...inputProps, rows: 4 } )
+			: createElement( 'input', { ...inputProps, type } );
+
+	return createElement(
+		'div',
+		{ className: 'wp-block-groups-application-form__field' },
+		createElement(
+			'label',
+			{
+				htmlFor: id,
+				className: 'wp-block-groups-application-form__label',
+			},
+			label,
+			required && createElement( 'span', { className: 'wp-block-groups-application-form__required', 'aria-hidden': 'true' }, ' *' )
+		),
+		input,
+		help &&
+			createElement(
+				'p',
+				{ id: helpId, className: 'wp-block-groups-application-form__help' },
+				help
+			),
+		error &&
+			createElement(
+				'p',
+				{
+					id: errorId,
+					className: 'wp-block-groups-application-form__error',
+					role: 'alert',
+				},
+				error
+			)
+	);
+}
+
+/**
+ * Step 1: Group Details.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.formData Form data.
+ * @param {Object}   props.errors   Validation errors.
+ * @param {Function} props.onChange  Field change handler.
+ */
+function StepGroupDetails( { formData, errors, onChange } ) {
+	return createElement(
+		'fieldset',
+		{ className: 'wp-block-groups-application-form__fieldset' },
+		createElement( 'legend', { className: 'wp-block-groups-application-form__legend' }, __( 'Group Details', 'wordpress-groups' ) ),
+		createElement( FormField, {
+			id: 'city',
+			label: __( 'City', 'wordpress-groups' ),
+			value: formData.city,
+			error: errors.city,
+			help: __( 'The city where your group will primarily meet.', 'wordpress-groups' ),
+			onChange: ( val ) => onChange( 'city', val ),
+		} ),
+		createElement( FormField, {
+			id: 'groupName',
+			label: __( 'Proposed Group Name', 'wordpress-groups' ),
+			value: formData.groupName,
+			error: errors.groupName,
+			help: __( 'For example: "Melbourne WordPress User Group" or "Paris WordPress Meetup".', 'wordpress-groups' ),
+			onChange: ( val ) => onChange( 'groupName', val ),
+		} )
+	);
+}
+
+/**
+ * Step 2: Organizer Background.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.formData Form data.
+ * @param {Object}   props.errors   Validation errors.
+ * @param {Function} props.onChange  Field change handler.
+ */
+function StepBackground( { formData, errors, onChange } ) {
+	return createElement(
+		'fieldset',
+		{ className: 'wp-block-groups-application-form__fieldset' },
+		createElement( 'legend', { className: 'wp-block-groups-application-form__legend' }, __( 'Your Background', 'wordpress-groups' ) ),
+		createElement( FormField, {
+			id: 'wpExperience',
+			label: __( 'WordPress Experience', 'wordpress-groups' ),
+			type: 'textarea',
+			value: formData.wpExperience,
+			error: errors.wpExperience,
+			help: __( 'Describe your experience with WordPress (using, developing, contributing, etc.).', 'wordpress-groups' ),
+			onChange: ( val ) => onChange( 'wpExperience', val ),
+		} ),
+		createElement( FormField, {
+			id: 'whyOrganize',
+			label: __( 'Why do you want to organize a group?', 'wordpress-groups' ),
+			type: 'textarea',
+			value: formData.whyOrganize,
+			error: errors.whyOrganize,
+			help: __( 'Tell us about your motivation and what you hope to achieve.', 'wordpress-groups' ),
+			onChange: ( val ) => onChange( 'whyOrganize', val ),
+		} )
+	);
+}
+
+/**
+ * Step 3: Profile & Code of Conduct.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.formData Form data.
+ * @param {Object}   props.errors   Validation errors.
+ * @param {Function} props.onChange  Field change handler.
+ */
+function StepProfile( { formData, errors, onChange } ) {
+	return createElement(
+		'fieldset',
+		{ className: 'wp-block-groups-application-form__fieldset' },
+		createElement( 'legend', { className: 'wp-block-groups-application-form__legend' }, __( 'Profile & Agreement', 'wordpress-groups' ) ),
+		createElement( FormField, {
+			id: 'profileUrl',
+			label: __( 'WordPress.org Profile URL', 'wordpress-groups' ),
+			type: 'url',
+			value: formData.profileUrl,
+			error: errors.profileUrl,
+			help: __( 'Your profile at profiles.wordpress.org (e.g., https://profiles.wordpress.org/yourname).', 'wordpress-groups' ),
+			onChange: ( val ) => onChange( 'profileUrl', val ),
+		} ),
+		createElement(
+			'div',
+			{
+				className: [
+					'wp-block-groups-application-form__field',
+					'wp-block-groups-application-form__field--checkbox',
+				].join( ' ' ),
+			},
+			createElement(
+				'label',
+				{
+					htmlFor: 'cocAccepted',
+					className: 'wp-block-groups-application-form__checkbox-label',
+				},
+				createElement( 'input', {
+					type: 'checkbox',
+					id: 'cocAccepted',
+					name: 'cocAccepted',
+					checked: formData.cocAccepted,
+					onChange: ( e ) => onChange( 'cocAccepted', e.target.checked ),
+					'aria-invalid': errors.cocAccepted ? 'true' : undefined,
+					'aria-describedby': errors.cocAccepted ? 'cocAccepted-error' : undefined,
+					'aria-required': 'true',
+					className: 'wp-block-groups-application-form__checkbox',
+				} ),
+				createElement(
+					'span',
+					null,
+					__( 'I agree to the ', 'wordpress-groups' ),
+					createElement(
+						'a',
+						{
+							href: 'https://make.wordpress.org/community/handbook/meetup-organizer/responding-to-code-of-conduct-violations/',
+							target: '_blank',
+							rel: 'noopener noreferrer',
+						},
+						__( 'WordPress Community Code of Conduct', 'wordpress-groups' )
+					)
+				)
+			),
+			errors.cocAccepted &&
+				createElement(
+					'p',
+					{
+						id: 'cocAccepted-error',
+						className: 'wp-block-groups-application-form__error',
+						role: 'alert',
+					},
+					errors.cocAccepted
+				)
+		)
+	);
+}
+
+/**
+ * Step 4: Review & Submit.
+ *
+ * @param {Object} props
+ * @param {Object} props.formData Form data.
+ */
+function StepReview( { formData } ) {
+	return createElement(
+		'fieldset',
+		{ className: 'wp-block-groups-application-form__fieldset' },
+		createElement( 'legend', { className: 'wp-block-groups-application-form__legend' }, __( 'Review Your Application', 'wordpress-groups' ) ),
+		createElement(
+			'div',
+			{ className: 'wp-block-groups-application-form__review' },
+			createElement(
+				'dl',
+				{ className: 'wp-block-groups-application-form__review-list' },
+				createElement( 'dt', null, __( 'City', 'wordpress-groups' ) ),
+				createElement( 'dd', null, formData.city ),
+				createElement( 'dt', null, __( 'Proposed Group Name', 'wordpress-groups' ) ),
+				createElement( 'dd', null, formData.groupName ),
+				createElement( 'dt', null, __( 'WordPress Experience', 'wordpress-groups' ) ),
+				createElement( 'dd', null, formData.wpExperience ),
+				createElement( 'dt', null, __( 'Why do you want to organize?', 'wordpress-groups' ) ),
+				createElement( 'dd', null, formData.whyOrganize ),
+				createElement( 'dt', null, __( 'WordPress.org Profile', 'wordpress-groups' ) ),
+				createElement(
+					'dd',
+					null,
+					createElement(
+						'a',
+						{ href: formData.profileUrl, target: '_blank', rel: 'noopener noreferrer' },
+						formData.profileUrl
+					)
+				),
+				createElement( 'dt', null, __( 'Code of Conduct', 'wordpress-groups' ) ),
+				createElement( 'dd', null, __( 'Accepted', 'wordpress-groups' ) )
+			)
+		)
+	);
+}
+
+/**
+ * Main Application Form component.
+ */
+function ApplicationForm() {
+	const [ step, setStep ] = useState( 0 );
+	const [ formData, setFormData ] = useState( {
+		city: '',
+		groupName: '',
+		wpExperience: '',
+		whyOrganize: '',
+		profileUrl: '',
+		cocAccepted: false,
+	} );
+	const [ errors, setErrors ] = useState( {} );
+	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const [ submitError, setSubmitError ] = useState( '' );
+	const [ isSubmitted, setIsSubmitted ] = useState( false );
+	const formRef = useRef( null );
+
+	/**
+	 * Update a single form field value and clear its error.
+	 */
+	const handleFieldChange = useCallback( ( name, value ) => {
+		setFormData( ( prev ) => ( { ...prev, [ name ]: value } ) );
+		setErrors( ( prev ) => {
+			const next = { ...prev };
+			delete next[ name ];
+			return next;
+		} );
+	}, [] );
+
+	/**
+	 * Advance to the next step after validation.
+	 */
+	const handleNext = useCallback( () => {
+		const stepErrors = validateStep( step, formData );
+
+		if ( Object.keys( stepErrors ).length > 0 ) {
+			setErrors( stepErrors );
+			// Focus the first field with an error.
+			if ( formRef.current ) {
+				const firstErrorField = formRef.current.querySelector( '[aria-invalid="true"]' );
+				if ( firstErrorField ) {
+					firstErrorField.focus();
+				}
+			}
+			return;
+		}
+
+		setErrors( {} );
+		setStep( ( prev ) => Math.min( prev + 1, TOTAL_STEPS - 1 ) );
+	}, [ step, formData ] );
+
+	/**
+	 * Go back to the previous step.
+	 */
+	const handlePrev = useCallback( () => {
+		setErrors( {} );
+		setStep( ( prev ) => Math.max( prev - 1, 0 ) );
+	}, [] );
+
+	/**
+	 * Submit the application via the REST API.
+	 */
+	const handleSubmit = useCallback( async () => {
+		setIsSubmitting( true );
+		setSubmitError( '' );
+
+		try {
+			await apiFetch( {
+				path: '/groups/v1/applications',
+				method: 'POST',
+				data: {
+					city: formData.city,
+					group_name: formData.groupName,
+					wp_experience: formData.wpExperience,
+					why_organize: formData.whyOrganize,
+					profile_url: formData.profileUrl,
+					coc_accepted: formData.cocAccepted,
+				},
+			} );
+
+			setIsSubmitted( true );
+		} catch ( err ) {
+			setSubmitError(
+				err.message ||
+					__( 'Something went wrong submitting your application. Please try again.', 'wordpress-groups' )
+			);
+		} finally {
+			setIsSubmitting( false );
+		}
+	}, [ formData ] );
+
+	// Success state.
+	if ( isSubmitted ) {
+		return createElement(
+			'div',
+			{ className: 'wp-block-groups-application-form__success', role: 'status' },
+			createElement( 'h2', null, __( 'Application Submitted!', 'wordpress-groups' ) ),
+			createElement(
+				'p',
+				null,
+				__( 'Thank you for your interest in organizing a WordPress community group. Your application has been received and will be reviewed by a community deputy.', 'wordpress-groups' )
+			),
+			createElement(
+				'p',
+				null,
+				__( 'You will receive an email notification when the status of your application changes.', 'wordpress-groups' )
+			)
+		);
+	}
+
+	// Render the current step component.
+	const stepComponents = [
+		createElement( StepGroupDetails, { formData, errors, onChange: handleFieldChange } ),
+		createElement( StepBackground, { formData, errors, onChange: handleFieldChange } ),
+		createElement( StepProfile, { formData, errors, onChange: handleFieldChange } ),
+		createElement( StepReview, { formData } ),
+	];
+
+	return createElement(
+		'div',
+		{ className: 'wp-block-groups-application-form__inner', ref: formRef },
+		createElement( 'h2', { className: 'wp-block-groups-application-form__title' }, __( 'Apply to Organize a WordPress Group', 'wordpress-groups' ) ),
+		createElement( ProgressIndicator, { currentStep: step } ),
+		createElement(
+			'form',
+			{
+				className: 'wp-block-groups-application-form__form',
+				onSubmit: ( e ) => {
+					e.preventDefault();
+					if ( step === TOTAL_STEPS - 1 ) {
+						handleSubmit();
+					} else {
+						handleNext();
+					}
+				},
+				noValidate: true,
+			},
+			stepComponents[ step ],
+			submitError &&
+				createElement(
+					'div',
+					{
+						className: 'wp-block-groups-application-form__submit-error',
+						role: 'alert',
+					},
+					submitError
+				),
+			createElement(
+				'div',
+				{ className: 'wp-block-groups-application-form__actions' },
+				step > 0 &&
+					createElement(
+						'button',
+						{
+							type: 'button',
+							className: 'wp-block-groups-application-form__btn wp-block-groups-application-form__btn--secondary',
+							onClick: handlePrev,
+							disabled: isSubmitting,
+						},
+						__( 'Previous', 'wordpress-groups' )
+					),
+				step < TOTAL_STEPS - 1 &&
+					createElement(
+						'button',
+						{
+							type: 'submit',
+							className: 'wp-block-groups-application-form__btn wp-block-groups-application-form__btn--primary',
+						},
+						__( 'Next', 'wordpress-groups' )
+					),
+				step === TOTAL_STEPS - 1 &&
+					createElement(
+						'button',
+						{
+							type: 'submit',
+							className: 'wp-block-groups-application-form__btn wp-block-groups-application-form__btn--primary',
+							disabled: isSubmitting,
+							'aria-busy': isSubmitting ? 'true' : undefined,
+						},
+						isSubmitting
+							? __( 'Submitting\u2026', 'wordpress-groups' )
+							: __( 'Submit Application', 'wordpress-groups' )
+					)
+			)
+		)
+	);
+}
+
+/**
+ * Hydrate all application form containers on the page.
+ */
+function init() {
+	const containers = document.querySelectorAll( '.wp-block-groups-application-form[data-logged-in="1"]' );
+
+	containers.forEach( ( container ) => {
+		const root = createRoot( container );
+		root.render( createElement( ApplicationForm ) );
+	} );
+}
+
+// Hydrate when the DOM is ready (skip during tests).
+if ( typeof document !== 'undefined' ) {
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+}
+
+// Export for testing.
+export { ApplicationForm, ProgressIndicator, FormField, validateField, validateStep };


### PR DESCRIPTION
## Summary

- Implements the `groups/application-form` block -- a four-step React form for applying to organize a WordPress community group
- Steps: Group Details (city, name) -> Organizer Background (experience, motivation) -> Profile & Agreement (WordPress.org URL, Code of Conduct) -> Review & Submit
- Server renders a login prompt for logged-out users; hydrates the React form for authenticated users
- Submits to `/groups/v1/applications` REST endpoint with graceful error/success handling
- Fully accessible: progress indicator, fieldset/legend, proper labels, ARIA attributes, validation messages, WCAG 2.1 AA focus styles and touch targets

## Test plan

- [ ] Build blocks with `npm run build:blocks` and verify `build/application-form/` output
- [ ] Place the block in the editor -- should show a placeholder with clipboard icon
- [ ] View the page logged out -- should show login prompt with link
- [ ] View the page logged in -- should show multi-step form starting at Step 1
- [ ] Verify field validation: leave fields empty and click Next, confirm error messages appear
- [ ] Verify WordPress.org profile URL validation rejects non-WordPress.org URLs
- [ ] Navigate forward and back through all 4 steps
- [ ] Verify the Review step displays all entered data correctly
- [ ] Submit the form -- should show error (endpoint not yet implemented) handled gracefully
- [ ] Test keyboard navigation and screen reader announcement of progress steps
- [ ] Test responsive layout on mobile viewport widths

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)