### PR TITLE
Add RSVP confirmation and promotion emails

### DIFF
--- a/wp-content/plugins/wordpress-groups/email-templates/rsvp-promotion.html
+++ b/wp-content/plugins/wordpress-groups/email-templates/rsvp-promotion.html
@@ -1,0 +1,68 @@
+<h1 style="margin: 0 0 24px 0; font-size: 24px; font-weight: 700; color: #1e1e1e; line-height: 1.3;">
+	You're In!
+</h1>
+
+<p style="margin: 0 0 20px 0;">
+	Hi {{user_name}},
+</p>
+
+<p style="margin: 0 0 20px 0;">
+	Great news — a spot has opened up for <strong>{{event_title}}</strong> and you've been moved from the waitlist to the attending list. You're all set!
+</p>
+
+<!-- Event Details Card -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 0 28px 0;">
+	<tr>
+		<td class="info-box" style="background-color: #f0f6fc; border-left: 4px solid #3858E9; border-radius: 0 8px 8px 0; padding: 20px 24px;">
+			<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+				<tr>
+					<td style="padding-bottom: 12px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;">
+						<span style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: #3858E9;">Event Details</span>
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 8px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 18px; font-weight: 600; color: #1e1e1e;">
+						{{event_title}}
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 4px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#128197;&nbsp; {{event_date}} at {{event_time}}
+					</td>
+				</tr>
+				<tr>
+					<td style="padding-bottom: 4px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#128205;&nbsp; {{venue_name}}
+					</td>
+				</tr>
+				<tr>
+					<td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 14px; color: #50575e;">
+						&#128101;&nbsp; {{group_name}}
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+
+<!-- Status Badge -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 28px 0;">
+	<tr>
+		<td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 13px; font-weight: 600; color: #ffffff; padding: 6px 16px; border-radius: 20px; background-color: #00a32a;">
+			Attending
+		</td>
+	</tr>
+</table>
+
+<!-- CTA Button -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 28px 0;">
+	<tr>
+		<td style="border-radius: 8px; background-color: #3858E9;" class="cta-button">
+			<a href="{{event_url}}" target="_blank" style="display: inline-block; padding: 14px 32px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none; border-radius: 8px;">View Event Details</a>
+		</td>
+	</tr>
+</table>
+
+<p style="margin: 0 0 8px 0; font-size: 14px; color: #646970;">
+	If your plans change, please update your RSVP so others on the waitlist can attend.
+</p>

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -65,6 +65,7 @@ class Plugin {
 		new Integrations\Slack_Notifier();
 		new Integrations\Official_Events_API();
 		new Admin\Application_Tracker();
+		new Notifications\Rsvp_Notifications();
 
 		add_action( 'init', [ Models\Membership::class, 'register_roles' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );

--- a/wp-content/plugins/wordpress-groups/includes/notifications/class-rsvp-notifications.php
+++ b/wp-content/plugins/wordpress-groups/includes/notifications/class-rsvp-notifications.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * RSVP confirmation and promotion email notifications.
+ *
+ * Sends confirmation emails when users RSVP to events and promotion
+ * notifications when waitlisted users are moved to the attending list.
+ *
+ * @package Groups\Notifications
+ */
+
+namespace Groups\Notifications;
+
+use Groups\Models\Event;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Hooks into RSVP lifecycle actions to send email notifications.
+ */
+class Rsvp_Notifications {
+
+	/**
+	 * Email notifier instance.
+	 *
+	 * @var Email_Notifier
+	 */
+	private Email_Notifier $notifier;
+
+	/**
+	 * Constructor — registers hooks.
+	 *
+	 * @param Email_Notifier|null $notifier Optional. Email notifier instance.
+	 */
+	public function __construct( ?Email_Notifier $notifier = null ) {
+		$this->notifier = $notifier ?? new Email_Notifier();
+
+		add_action( 'groups_rsvp_created', [ $this, 'on_rsvp_created' ], 10, 4 );
+		add_action( 'groups_rsvp_promoted', [ $this, 'on_rsvp_promoted' ], 10, 3 );
+	}
+
+	/**
+	 * Send a confirmation email when an RSVP is created.
+	 *
+	 * @param int    $comment_id The RSVP comment ID.
+	 * @param int    $event_id   The event post ID.
+	 * @param int    $user_id    The user ID.
+	 * @param string $status     The RSVP status (attending or waitlisted).
+	 */
+	public function on_rsvp_created( int $comment_id, int $event_id, int $user_id, string $status ): void {
+		/**
+		 * Filters whether to send an RSVP confirmation email.
+		 *
+		 * @param bool   $send       Whether to send the confirmation. Default true.
+		 * @param int    $comment_id The RSVP comment ID.
+		 * @param int    $event_id   The event post ID.
+		 * @param int    $user_id    The user ID.
+		 * @param string $status     The RSVP status.
+		 */
+		if ( ! apply_filters( 'groups_send_rsvp_confirmation', true, $comment_id, $event_id, $user_id, $status ) ) {
+			return;
+		}
+
+		$user = get_userdata( $user_id );
+
+		if ( ! $user ) {
+			return;
+		}
+
+		$template_data = $this->get_event_template_data( $event_id, $user, $status );
+
+		if ( null === $template_data ) {
+			return;
+		}
+
+		$subject = 'attending' === $status
+			? sprintf(
+				/* translators: %s: event title */
+				__( 'RSVP Confirmed: %s', 'wordpress-groups' ),
+				$template_data['event_title']
+			)
+			: sprintf(
+				/* translators: %s: event title */
+				__( 'Waitlisted: %s', 'wordpress-groups' ),
+				$template_data['event_title']
+			);
+
+		$this->notifier->send(
+			$user->user_email,
+			$subject,
+			'rsvp-confirmation',
+			$template_data
+		);
+	}
+
+	/**
+	 * Send a promotion notification when a waitlisted user is promoted to attending.
+	 *
+	 * @param int $comment_id The RSVP comment ID.
+	 * @param int $event_id   The event post ID.
+	 * @param int $user_id    The user ID.
+	 */
+	public function on_rsvp_promoted( int $comment_id, int $event_id, int $user_id ): void {
+		/**
+		 * Filters whether to send an RSVP promotion email.
+		 *
+		 * @param bool $send       Whether to send the promotion notification. Default true.
+		 * @param int  $comment_id The RSVP comment ID.
+		 * @param int  $event_id   The event post ID.
+		 * @param int  $user_id    The user ID.
+		 */
+		if ( ! apply_filters( 'groups_send_rsvp_promotion', true, $comment_id, $event_id, $user_id ) ) {
+			return;
+		}
+
+		$user = get_userdata( $user_id );
+
+		if ( ! $user ) {
+			return;
+		}
+
+		$template_data = $this->get_event_template_data( $event_id, $user, 'attending' );
+
+		if ( null === $template_data ) {
+			return;
+		}
+
+		$subject = sprintf(
+			/* translators: %s: event title */
+			__( "You're in! %s", 'wordpress-groups' ),
+			$template_data['event_title']
+		);
+
+		$this->notifier->send(
+			$user->user_email,
+			$subject,
+			'rsvp-promotion',
+			$template_data
+		);
+	}
+
+	/**
+	 * Build template data array for an event email.
+	 *
+	 * @param int      $event_id The event post ID.
+	 * @param \WP_User $user     The recipient user.
+	 * @param string   $status   The RSVP status.
+	 * @return array|null Template data array, or null if the event is invalid.
+	 */
+	private function get_event_template_data( int $event_id, \WP_User $user, string $status ): ?array {
+		$event_data = Event::get( $event_id );
+
+		if ( is_wp_error( $event_data ) ) {
+			return null;
+		}
+
+		$venue_name = '';
+		$venue_id   = (int) get_post_meta( $event_id, '_event_venue_id', true );
+
+		if ( $venue_id ) {
+			$venue = get_post( $venue_id );
+
+			if ( $venue ) {
+				$venue_name = $venue->post_title;
+			}
+		}
+
+		if ( empty( $venue_name ) ) {
+			$online_link = get_post_meta( $event_id, '_event_online_link', true );
+			$venue_name  = $online_link ? __( 'Online', 'wordpress-groups' ) : __( 'TBA', 'wordpress-groups' );
+		}
+
+		$start_utc  = $event_data['start_utc'] ?? '';
+		$event_date = '';
+		$event_time = '';
+
+		if ( $start_utc ) {
+			$timestamp  = strtotime( $start_utc );
+			$event_date = wp_date( 'F j, Y', $timestamp );
+			$event_time = wp_date( 'g:i A', $timestamp );
+		}
+
+		$status_label = 'attending' === $status
+			? __( 'Attending', 'wordpress-groups' )
+			: __( 'Waitlisted', 'wordpress-groups' );
+
+		return [
+			'user_name'   => $user->display_name,
+			'event_title' => $event_data['title'],
+			'event_date'  => $event_date,
+			'event_time'  => $event_time,
+			'event_url'   => get_permalink( $event_id ),
+			'venue_name'  => $venue_name,
+			'group_name'  => get_bloginfo( 'name' ),
+			'rsvp_status' => $status,
+			'status_label' => $status_label,
+		];
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Email_Templates.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Email_Templates.php
@@ -318,6 +318,7 @@ class Test_Email_Templates extends WP_UnitTestCase {
 			'event-reminder',
 			'group-announcement',
 			'rsvp-confirmation',
+			'rsvp-promotion',
 			'welcome-organizer',
 		];
 

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Rsvp_Notifications.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Rsvp_Notifications.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Tests for RSVP confirmation and promotion email notifications.
+ *
+ * @package Groups\Tests
+ */
+
+use Groups\Models\Event;
+use Groups\Models\Rsvp;
+use Groups\Notifications\Rsvp_Notifications;
+use Groups\Post_Types\Event as Event_Post_Type;
+
+/**
+ * @coversDefaultClass \Groups\Notifications\Rsvp_Notifications
+ */
+class Test_Rsvp_Notifications extends WP_UnitTestCase {
+
+	/**
+	 * Rsvp_Notifications instance under test.
+	 *
+	 * @var Rsvp_Notifications
+	 */
+	private Rsvp_Notifications $notifications;
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$event_cpt = new Event_Post_Type();
+		$event_cpt->register_post_type();
+		$event_cpt->register_post_statuses();
+
+		$this->notifications = new Rsvp_Notifications();
+	}
+
+	/**
+	 * Helper to create a scheduled event post.
+	 *
+	 * @param array $overrides Optional overrides for event args.
+	 * @return int Post ID.
+	 */
+	private function create_scheduled_event( array $overrides = [] ): int {
+		$args = array_merge(
+			[
+				'title'     => 'Test Meetup',
+				'content'   => 'A test event.',
+				'start_utc' => gmdate( 'Y-m-d H:i:s', time() + ( 2 * DAY_IN_SECONDS ) ),
+				'end_utc'   => gmdate( 'Y-m-d H:i:s', time() + ( 2 * DAY_IN_SECONDS ) + ( 2 * HOUR_IN_SECONDS ) ),
+				'timezone'  => 'UTC',
+				'status'    => 'event-scheduled',
+			],
+			$overrides
+		);
+
+		return Event::create( $args );
+	}
+
+	/**
+	 * @covers ::on_rsvp_created
+	 */
+	public function test_confirmation_email_sent_on_rsvp(): void {
+		$event_id = $this->create_scheduled_event();
+		$user_id  = self::factory()->user->create( [ 'user_email' => 'rsvp-user@example.org' ] );
+
+		$recipients = [];
+		$templates  = [];
+		add_action(
+			'groups_before_email_send',
+			function ( $to, $subject, $template ) use ( &$recipients, &$templates ) {
+				$recipients[] = $to;
+				$templates[]  = $template;
+			},
+			10,
+			3
+		);
+
+		Rsvp::create( $event_id, $user_id );
+
+		$this->assertContains( 'rsvp-user@example.org', $recipients, 'Confirmation email should be sent to the RSVP user.' );
+		$this->assertContains( 'rsvp-confirmation', $templates, 'Should use the rsvp-confirmation template.' );
+	}
+
+	/**
+	 * @covers ::on_rsvp_created
+	 */
+	public function test_confirmation_email_not_sent_when_filtered_out(): void {
+		$event_id = $this->create_scheduled_event();
+		$user_id  = self::factory()->user->create( [ 'user_email' => 'filtered@example.org' ] );
+
+		add_filter( 'groups_send_rsvp_confirmation', '__return_false' );
+
+		$emails_sent = 0;
+		add_action(
+			'groups_before_email_send',
+			function () use ( &$emails_sent ) {
+				$emails_sent++;
+			}
+		);
+
+		Rsvp::create( $event_id, $user_id );
+
+		$this->assertSame( 0, $emails_sent, 'No confirmation email should be sent when filtered out.' );
+
+		remove_filter( 'groups_send_rsvp_confirmation', '__return_false' );
+	}
+
+	/**
+	 * @covers ::on_rsvp_promoted
+	 */
+	public function test_promotion_email_sent_on_waitlist_promotion(): void {
+		$event_id = $this->create_scheduled_event( [ 'attendee_limit' => 1 ] );
+
+		// Enable waitlist.
+		update_post_meta( $event_id, '_event_waitlist_enabled', true );
+
+		$user1 = self::factory()->user->create( [ 'user_email' => 'first@example.org' ] );
+		$user2 = self::factory()->user->create( [ 'user_email' => 'waitlisted@example.org' ] );
+
+		// First user takes the only spot.
+		$rsvp1 = Rsvp::create( $event_id, $user1 );
+
+		// Second user should be waitlisted.
+		Rsvp::create( $event_id, $user2 );
+
+		// Track emails from this point forward.
+		$recipients = [];
+		$templates  = [];
+		add_action(
+			'groups_before_email_send',
+			function ( $to, $subject, $template ) use ( &$recipients, &$templates ) {
+				$recipients[] = $to;
+				$templates[]  = $template;
+			},
+			10,
+			3
+		);
+
+		// Cancel the first user's RSVP — should trigger promotion.
+		Rsvp::cancel( $rsvp1 );
+
+		$this->assertContains( 'waitlisted@example.org', $recipients, 'Promotion email should be sent to the promoted user.' );
+		$this->assertContains( 'rsvp-promotion', $templates, 'Should use the rsvp-promotion template.' );
+	}
+
+	/**
+	 * @covers ::on_rsvp_promoted
+	 */
+	public function test_promotion_email_not_sent_when_filtered_out(): void {
+		$event_id = $this->create_scheduled_event( [ 'attendee_limit' => 1 ] );
+
+		// Enable waitlist.
+		update_post_meta( $event_id, '_event_waitlist_enabled', true );
+
+		$user1 = self::factory()->user->create( [ 'user_email' => 'first2@example.org' ] );
+		$user2 = self::factory()->user->create( [ 'user_email' => 'waitlisted2@example.org' ] );
+
+		$rsvp1 = Rsvp::create( $event_id, $user1 );
+		Rsvp::create( $event_id, $user2 );
+
+		add_filter( 'groups_send_rsvp_promotion', '__return_false' );
+
+		$emails_sent = 0;
+		add_action(
+			'groups_before_email_send',
+			function () use ( &$emails_sent ) {
+				$emails_sent++;
+			}
+		);
+
+		Rsvp::cancel( $rsvp1 );
+
+		$this->assertSame( 0, $emails_sent, 'No promotion email should be sent when filtered out.' );
+
+		remove_filter( 'groups_send_rsvp_promotion', '__return_false' );
+	}
+
+	/**
+	 * @covers ::on_rsvp_created
+	 */
+	public function test_waitlisted_rsvp_gets_waitlist_confirmation(): void {
+		$event_id = $this->create_scheduled_event( [ 'attendee_limit' => 1 ] );
+
+		// Enable waitlist.
+		update_post_meta( $event_id, '_event_waitlist_enabled', true );
+
+		$user1 = self::factory()->user->create( [ 'user_email' => 'attendee@example.org' ] );
+		$user2 = self::factory()->user->create( [ 'user_email' => 'waiter@example.org' ] );
+
+		// First user takes the spot.
+		Rsvp::create( $event_id, $user1 );
+
+		// Track emails from here.
+		$subjects = [];
+		add_action(
+			'groups_before_email_send',
+			function ( $to, $subject ) use ( &$subjects ) {
+				$subjects[ $to ] = $subject;
+			},
+			10,
+			2
+		);
+
+		// Second user is waitlisted.
+		Rsvp::create( $event_id, $user2 );
+
+		$this->assertArrayHasKey( 'waiter@example.org', $subjects, 'Waitlisted user should receive a confirmation email.' );
+		$this->assertStringContainsString( 'Waitlisted', $subjects['waiter@example.org'], 'Subject should indicate waitlisted status.' );
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Rsvp_Notifications` class (`Groups\Notifications`) that hooks into `groups_rsvp_created` and `groups_rsvp_promoted` to send email notifications via `Email_Notifier`
- Create `rsvp-promotion.html` email template for waitlist-to-attending promotion ("You're in!")
- Wire `Rsvp_Notifications` into the Plugin orchestrator class
- Add PHPUnit tests covering confirmation on RSVP, promotion on waitlist promotion, filter suppression, and waitlisted subject line

## Test plan
- [x] `vendor/bin/phpunit --filter=Test_Rsvp_Notifications` passes (5 tests, 8 assertions)
- [ ] Verify confirmation email is sent when creating an RSVP via REST API
- [ ] Verify promotion email is sent when a waitlisted user is promoted after cancellation
- [ ] Verify `groups_send_rsvp_confirmation` filter can suppress confirmation emails
- [ ] Verify `groups_send_rsvp_promotion` filter can suppress promotion emails

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)