### PR TITLE
Add group-directory block

### DIFF
--- a/wp-content/plugins/wordpress-groups/blocks/group-directory/block.json
+++ b/wp-content/plugins/wordpress-groups/blocks/group-directory/block.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "groups/group-directory",
+	"version": "0.1.0",
+	"title": "Group Directory",
+	"category": "widgets",
+	"description": "A searchable directory of WordPress community groups with filtering and pagination.",
+	"textdomain": "wordpress-groups",
+	"attributes": {},
+	"supports": {
+		"html": false,
+		"align": [ "wide", "full" ],
+		"multiple": false
+	},
+	"editorScript": "file:./index.js",
+	"viewScript": "file:./view.js",
+	"style": "file:./style-index.css",
+	"render": "file:./render.php"
+}

--- a/wp-content/plugins/wordpress-groups/blocks/group-directory/edit.js
+++ b/wp-content/plugins/wordpress-groups/blocks/group-directory/edit.js
@@ -1,0 +1,30 @@
+/**
+ * Group Directory — editor component.
+ *
+ * Shows a placeholder in the block editor since the directory is client-rendered.
+ */
+
+import { createElement } from '@wordpress/element';
+import { useBlockProps } from '@wordpress/block-editor';
+import { Placeholder } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Edit component for the Group Directory block.
+ */
+export default function Edit() {
+	const blockProps = useBlockProps();
+
+	return createElement(
+		'div',
+		blockProps,
+		createElement( Placeholder, {
+			icon: 'groups',
+			label: __( 'Group Directory', 'wordpress-groups' ),
+			instructions: __(
+				'This block displays a searchable directory of WordPress community groups. The directory is rendered on the frontend only.',
+				'wordpress-groups'
+			),
+		} )
+	);
+}

--- a/wp-content/plugins/wordpress-groups/blocks/group-directory/index.js
+++ b/wp-content/plugins/wordpress-groups/blocks/group-directory/index.js
@@ -1,0 +1,14 @@
+/**
+ * Group Directory — block registration.
+ *
+ * @package Groups
+ */
+
+import { registerBlockType } from '@wordpress/blocks';
+import metadata from './block.json';
+import Edit from './edit';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+} );

--- a/wp-content/plugins/wordpress-groups/blocks/group-directory/render.php
+++ b/wp-content/plugins/wordpress-groups/blocks/group-directory/render.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Server-side render for the Group Directory block.
+ *
+ * Renders a container div for React hydration on the frontend.
+ *
+ * @package Groups
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	[
+		'class'      => 'wp-block-groups-group-directory',
+		'data-nonce' => wp_create_nonce( 'wp_rest' ),
+	]
+);
+
+?>
+<div <?php echo $wrapper_attributes; ?>>
+	<div class="wp-block-groups-group-directory__loading" aria-live="polite">
+		<p><?php esc_html_e( 'Loading group directory\u2026', 'wordpress-groups' ); ?></p>
+	</div>
+</div>

--- a/wp-content/plugins/wordpress-groups/blocks/group-directory/style.scss
+++ b/wp-content/plugins/wordpress-groups/blocks/group-directory/style.scss
@@ -1,0 +1,223 @@
+/**
+ * Group Directory block styles.
+ *
+ * Responsive grid layout for group cards with search and pagination.
+ * Uses WordPress theme design tokens where available.
+ */
+
+.wp-block-groups-group-directory {
+	max-width: 1200px;
+	margin: 0 auto;
+
+	// Loading state.
+	&__loading {
+		padding: 48px 24px;
+		text-align: center;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+	}
+
+	// Inner wrapper for the hydrated directory.
+	&__inner {
+		padding: 0;
+	}
+
+	// Header with title, search, and count.
+	&__header {
+		margin-bottom: 32px;
+	}
+
+	&__title {
+		margin: 0 0 16px;
+		font-size: 28px;
+		font-weight: 600;
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+	}
+
+	&__search {
+		margin-bottom: 12px;
+	}
+
+	&__search-input {
+		display: block;
+		width: 100%;
+		padding: 12px 16px;
+		border: 1px solid var(--wp--preset--color--light-grey-1, #dcdcde);
+		border-radius: 4px;
+		font-size: 16px;
+		line-height: 1.5;
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		background-color: var(--wp--preset--color--white, #fff);
+		box-sizing: border-box;
+		transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+		&::placeholder {
+			color: var(--wp--preset--color--charcoal-4, #50575e);
+		}
+
+		&:focus {
+			border-color: var(--wp--preset--color--blueberry-1, #3858e9);
+			box-shadow: 0 0 0 1px var(--wp--preset--color--blueberry-1, #3858e9);
+			outline: none;
+		}
+	}
+
+	&__count {
+		margin: 0;
+		font-size: 14px;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+	}
+
+	// Error state.
+	&__error {
+		padding: 12px 16px;
+		margin-bottom: 16px;
+		background-color: #fcf0f1;
+		border: 1px solid #cc1818;
+		border-radius: 4px;
+		color: #cc1818;
+		font-size: 14px;
+		line-height: 1.5;
+	}
+
+	// Empty state.
+	&__empty {
+		padding: 48px 24px;
+		text-align: center;
+		background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+		border-radius: 8px;
+
+		p {
+			margin: 0;
+			font-size: 16px;
+			color: var(--wp--preset--color--charcoal-4, #50575e);
+		}
+	}
+
+	// Group card grid.
+	&__grid {
+		display: grid;
+		grid-template-columns: repeat( 3, 1fr );
+		gap: 24px;
+		margin-bottom: 32px;
+	}
+
+	// Individual group card.
+	&__card {
+		padding: 24px;
+		background: var(--wp--preset--color--white, #fff);
+		border: 1px solid var(--wp--preset--color--light-grey-1, #dcdcde);
+		border-radius: 8px;
+		transition: box-shadow 0.15s ease, border-color 0.15s ease;
+
+		&:hover {
+			border-color: var(--wp--preset--color--blueberry-1, #3858e9);
+			box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+		}
+	}
+
+	&__card-name {
+		margin: 0 0 8px;
+		font-size: 18px;
+		font-weight: 600;
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		line-height: 1.3;
+
+		a {
+			color: var(--wp--preset--color--blueberry-1, #3858e9);
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	&__card-city {
+		margin: 0 0 4px;
+		font-size: 14px;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+		line-height: 1.4;
+	}
+
+	&__card-members {
+		margin: 0;
+		font-size: 13px;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+		font-weight: 500;
+	}
+
+	// Pagination.
+	&__pagination {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		gap: 4px;
+		margin-top: 32px;
+	}
+
+	&__page-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 40px;
+		height: 40px;
+		padding: 8px 12px;
+		border: 1px solid var(--wp--preset--color--light-grey-1, #dcdcde);
+		border-radius: 4px;
+		background: var(--wp--preset--color--white, #fff);
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		font-size: 14px;
+		font-weight: 500;
+		cursor: pointer;
+		transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+
+		&:hover:not(:disabled) {
+			border-color: var(--wp--preset--color--blueberry-1, #3858e9);
+			color: var(--wp--preset--color--blueberry-1, #3858e9);
+		}
+
+		&.is-active {
+			background-color: var(--wp--preset--color--blueberry-1, #3858e9);
+			border-color: var(--wp--preset--color--blueberry-1, #3858e9);
+			color: var(--wp--preset--color--white, #fff);
+		}
+
+		&:disabled {
+			opacity: 0.4;
+			cursor: not-allowed;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp--preset--color--blueberry-1, #3858e9);
+			outline-offset: 2px;
+		}
+	}
+}
+
+// Responsive: 2 columns on tablets.
+@media ( max-width: 960px ) {
+	.wp-block-groups-group-directory {
+		&__grid {
+			grid-template-columns: repeat( 2, 1fr );
+			gap: 16px;
+		}
+	}
+}
+
+// Responsive: single column on mobile.
+@media ( max-width: 600px ) {
+	.wp-block-groups-group-directory {
+		&__title {
+			font-size: 22px;
+		}
+
+		&__grid {
+			grid-template-columns: 1fr;
+			gap: 12px;
+		}
+
+		&__card {
+			padding: 16px;
+		}
+	}
+}

--- a/wp-content/plugins/wordpress-groups/blocks/group-directory/view.js
+++ b/wp-content/plugins/wordpress-groups/blocks/group-directory/view.js
@@ -1,0 +1,337 @@
+/**
+ * Group Directory — frontend interactive directory.
+ *
+ * Hydrates the server-rendered container with a React-based searchable
+ * directory of WordPress community groups.
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, createRoot, useState, useEffect, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Number of groups to display per page.
+ */
+const PER_PAGE = 12;
+
+/**
+ * Debounce delay in milliseconds for the search input.
+ */
+const DEBOUNCE_MS = 300;
+
+/**
+ * A single group card component.
+ *
+ * @param {Object} props
+ * @param {Object} props.group Group data from the REST API.
+ */
+function GroupCard( { group } ) {
+	const cardContent = [
+		createElement(
+			'h3',
+			{
+				key: 'name',
+				className: 'wp-block-groups-group-directory__card-name',
+			},
+			group.site_url
+				? createElement(
+					'a',
+					{ href: group.site_url, rel: 'noopener noreferrer' },
+					group.name
+				)
+				: group.name
+		),
+		createElement(
+			'p',
+			{
+				key: 'city',
+				className: 'wp-block-groups-group-directory__card-city',
+			},
+			[ group.city, group.country ].filter( Boolean ).join( ', ' )
+		),
+		createElement(
+			'p',
+			{
+				key: 'members',
+				className: 'wp-block-groups-group-directory__card-members',
+			},
+			group.member_count === 1
+				? __( '1 member', 'wordpress-groups' )
+				: String( group.member_count ) + ' ' + __( 'members', 'wordpress-groups' )
+		),
+	];
+
+	return createElement(
+		'div',
+		{ className: 'wp-block-groups-group-directory__card' },
+		cardContent
+	);
+}
+
+/**
+ * Pagination component.
+ *
+ * @param {Object}   props
+ * @param {number}   props.currentPage Current page number (1-indexed).
+ * @param {number}   props.totalPages  Total number of pages.
+ * @param {Function} props.onPageChange Callback when page changes.
+ */
+function Pagination( { currentPage, totalPages, onPageChange } ) {
+	if ( totalPages <= 1 ) {
+		return null;
+	}
+
+	const buttons = [];
+
+	buttons.push(
+		createElement(
+			'button',
+			{
+				key: 'prev',
+				className: 'wp-block-groups-group-directory__page-btn',
+				onClick: () => onPageChange( currentPage - 1 ),
+				disabled: currentPage <= 1,
+				'aria-label': __( 'Previous page', 'wordpress-groups' ),
+			},
+			'\u2190'
+		)
+	);
+
+	for ( let i = 1; i <= totalPages; i++ ) {
+		buttons.push(
+			createElement(
+				'button',
+				{
+					key: i,
+					className: [
+						'wp-block-groups-group-directory__page-btn',
+						i === currentPage ? 'is-active' : '',
+					]
+						.filter( Boolean )
+						.join( ' ' ),
+					onClick: () => onPageChange( i ),
+					'aria-current': i === currentPage ? 'page' : undefined,
+					'aria-label': i === currentPage
+						? __( 'Current page', 'wordpress-groups' ) + ', ' + i
+						: __( 'Page', 'wordpress-groups' ) + ' ' + i,
+				},
+				String( i )
+			)
+		);
+	}
+
+	buttons.push(
+		createElement(
+			'button',
+			{
+				key: 'next',
+				className: 'wp-block-groups-group-directory__page-btn',
+				onClick: () => onPageChange( currentPage + 1 ),
+				disabled: currentPage >= totalPages,
+				'aria-label': __( 'Next page', 'wordpress-groups' ),
+			},
+			'\u2192'
+		)
+	);
+
+	return createElement(
+		'nav',
+		{
+			className: 'wp-block-groups-group-directory__pagination',
+			'aria-label': __( 'Directory pagination', 'wordpress-groups' ),
+		},
+		buttons
+	);
+}
+
+/**
+ * Main Group Directory component.
+ */
+function GroupDirectory() {
+	const [ groups, setGroups ] = useState( [] );
+	const [ search, setSearch ] = useState( '' );
+	const [ debouncedSearch, setDebouncedSearch ] = useState( '' );
+	const [ page, setPage ] = useState( 1 );
+	const [ totalPages, setTotalPages ] = useState( 1 );
+	const [ totalGroups, setTotalGroups ] = useState( 0 );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ error, setError ] = useState( '' );
+
+	// Debounce the search input.
+	useEffect( () => {
+		const timer = setTimeout( () => {
+			setDebouncedSearch( search );
+			setPage( 1 );
+		}, DEBOUNCE_MS );
+
+		return () => clearTimeout( timer );
+	}, [ search ] );
+
+	// Fetch groups from the REST API.
+	useEffect( () => {
+		setIsLoading( true );
+		setError( '' );
+
+		const queryParams = new URLSearchParams( {
+			per_page: String( PER_PAGE ),
+			page: String( page ),
+		} );
+
+		if ( debouncedSearch.trim() ) {
+			queryParams.set( 'search', debouncedSearch.trim() );
+		}
+
+		apiFetch( {
+			path: '/groups/v1/groups?' + queryParams.toString(),
+			parse: false,
+		} )
+			.then( ( response ) => {
+				setTotalPages( parseInt( response.headers.get( 'X-WP-TotalPages' ) || '1', 10 ) );
+				setTotalGroups( parseInt( response.headers.get( 'X-WP-Total' ) || '0', 10 ) );
+				return response.json();
+			} )
+			.then( ( data ) => {
+				setGroups( data );
+				setIsLoading( false );
+			} )
+			.catch( ( err ) => {
+				setError(
+					err.message ||
+						__( 'Failed to load groups. Please try again.', 'wordpress-groups' )
+				);
+				setIsLoading( false );
+			} );
+	}, [ debouncedSearch, page ] );
+
+	/**
+	 * Handle search input changes.
+	 */
+	const handleSearchChange = useCallback( ( e ) => {
+		setSearch( e.target.value );
+	}, [] );
+
+	/**
+	 * Handle page changes from the Pagination component.
+	 */
+	const handlePageChange = useCallback( ( newPage ) => {
+		setPage( newPage );
+		// Scroll back to the top of the directory.
+		const el = document.querySelector( '.wp-block-groups-group-directory' );
+		if ( el ) {
+			el.scrollIntoView( { behavior: 'smooth', block: 'start' } );
+		}
+	}, [] );
+
+	return createElement(
+		'div',
+		{ className: 'wp-block-groups-group-directory__inner' },
+		createElement(
+			'div',
+			{ className: 'wp-block-groups-group-directory__header' },
+			createElement(
+				'h2',
+				{ className: 'wp-block-groups-group-directory__title' },
+				__( 'WordPress Community Groups', 'wordpress-groups' )
+			),
+			createElement(
+				'div',
+				{ className: 'wp-block-groups-group-directory__search' },
+				createElement( 'input', {
+					type: 'search',
+					className: 'wp-block-groups-group-directory__search-input',
+					placeholder: __( 'Search groups by name or city\u2026', 'wordpress-groups' ),
+					value: search,
+					onChange: handleSearchChange,
+					'aria-label': __( 'Search groups', 'wordpress-groups' ),
+				} )
+			),
+			! isLoading && createElement(
+				'p',
+				{ className: 'wp-block-groups-group-directory__count' },
+				totalGroups === 1
+					? __( '1 group found', 'wordpress-groups' )
+					: String( totalGroups ) + ' ' + __( 'groups found', 'wordpress-groups' )
+			)
+		),
+		error &&
+			createElement(
+				'div',
+				{
+					className: 'wp-block-groups-group-directory__error',
+					role: 'alert',
+				},
+				error
+			),
+		isLoading &&
+			createElement(
+				'div',
+				{
+					className: 'wp-block-groups-group-directory__loading',
+					'aria-live': 'polite',
+				},
+				createElement( 'p', null, __( 'Loading groups\u2026', 'wordpress-groups' ) )
+			),
+		! isLoading &&
+			! error &&
+			groups.length === 0 &&
+			createElement(
+				'div',
+				{ className: 'wp-block-groups-group-directory__empty' },
+				createElement(
+					'p',
+					null,
+					debouncedSearch
+						? __( 'No groups match your search. Try a different term.', 'wordpress-groups' )
+						: __( 'No groups are available at this time.', 'wordpress-groups' )
+				)
+			),
+		! isLoading &&
+			! error &&
+			groups.length > 0 &&
+			createElement(
+				'div',
+				{
+					className: 'wp-block-groups-group-directory__grid',
+					role: 'list',
+				},
+				groups.map( ( group, index ) =>
+					createElement(
+						'div',
+						{ key: group.site_id || index, role: 'listitem' },
+						createElement( GroupCard, { group } )
+					)
+				)
+			),
+		! isLoading &&
+			! error &&
+			createElement( Pagination, {
+				currentPage: page,
+				totalPages,
+				onPageChange: handlePageChange,
+			} )
+	);
+}
+
+/**
+ * Hydrate all group directory containers on the page.
+ */
+function init() {
+	const containers = document.querySelectorAll( '.wp-block-groups-group-directory' );
+
+	containers.forEach( ( container ) => {
+		const root = createRoot( container );
+		root.render( createElement( GroupDirectory ) );
+	} );
+}
+
+// Hydrate when the DOM is ready (skip during tests).
+if ( typeof document !== 'undefined' ) {
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+}
+
+// Export for testing.
+export { GroupDirectory, GroupCard, Pagination };


### PR DESCRIPTION
## Summary
- Adds the `groups/group-directory` block with all required files: `block.json`, `render.php`, `edit.js`, `index.js`, `view.js`, and `style.scss`
- Frontend React view fetches from `/groups/v1/groups` via `apiFetch`, rendering a search input, responsive card grid (name, city, member count), and pagination
- Editor shows a placeholder since the directory is fully client-rendered

## Test plan
- [ ] Insert the Group Directory block in the editor and verify the placeholder renders
- [ ] View the page on the frontend and confirm groups load from the REST API
- [ ] Type in the search input and verify debounced filtering works
- [ ] Confirm pagination buttons appear when there are more than 12 groups
- [ ] Verify responsive layout: 3 columns on desktop, 2 on tablet, 1 on mobile

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)