### PR TITLE
Add event-directory block

### DIFF
--- a/wp-content/plugins/wordpress-groups/blocks/event-directory/block.json
+++ b/wp-content/plugins/wordpress-groups/blocks/event-directory/block.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "groups/event-directory",
+	"version": "0.1.0",
+	"title": "Event Directory",
+	"category": "widgets",
+	"icon": "calendar",
+	"description": "A browsable directory of events with list/calendar views and date filtering.",
+	"textdomain": "wordpress-groups",
+	"attributes": {},
+	"supports": {
+		"html": false,
+		"align": [ "wide", "full" ],
+		"multiple": false
+	},
+	"editorScript": "file:./index.js",
+	"viewScript": "file:./view.js",
+	"style": "file:./style-index.css",
+	"render": "file:./render.php"
+}

--- a/wp-content/plugins/wordpress-groups/blocks/event-directory/edit.js
+++ b/wp-content/plugins/wordpress-groups/blocks/event-directory/edit.js
@@ -1,0 +1,30 @@
+/**
+ * Event Directory — editor component.
+ *
+ * Shows a placeholder in the block editor since the directory is client-rendered.
+ */
+
+import { createElement } from '@wordpress/element';
+import { useBlockProps } from '@wordpress/block-editor';
+import { Placeholder } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Edit component for the Event Directory block.
+ */
+export default function Edit() {
+	const blockProps = useBlockProps();
+
+	return createElement(
+		'div',
+		blockProps,
+		createElement( Placeholder, {
+			icon: 'calendar',
+			label: __( 'Event Directory', 'wordpress-groups' ),
+			instructions: __(
+				'This block displays a browsable directory of events with list and calendar views. The directory is rendered on the frontend only.',
+				'wordpress-groups'
+			),
+		} )
+	);
+}

--- a/wp-content/plugins/wordpress-groups/blocks/event-directory/index.js
+++ b/wp-content/plugins/wordpress-groups/blocks/event-directory/index.js
@@ -1,0 +1,14 @@
+/**
+ * Event Directory — block registration.
+ *
+ * @package Groups
+ */
+
+import { registerBlockType } from '@wordpress/blocks';
+import metadata from './block.json';
+import Edit from './edit';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+} );

--- a/wp-content/plugins/wordpress-groups/blocks/event-directory/render.php
+++ b/wp-content/plugins/wordpress-groups/blocks/event-directory/render.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Server-side render for the Event Directory block.
+ *
+ * Renders a container for the React-powered event directory.
+ *
+ * @package Groups
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	[
+		'class'      => 'wp-block-groups-event-directory',
+		'data-nonce' => wp_create_nonce( 'wp_rest' ),
+	]
+);
+
+?>
+<div <?php echo $wrapper_attributes; ?>>
+	<div class="wp-block-groups-event-directory__loading" aria-live="polite">
+		<p><?php esc_html_e( 'Loading events\u2026', 'wordpress-groups' ); ?></p>
+	</div>
+</div>

--- a/wp-content/plugins/wordpress-groups/blocks/event-directory/style.scss
+++ b/wp-content/plugins/wordpress-groups/blocks/event-directory/style.scss
@@ -1,0 +1,439 @@
+/**
+ * Event Directory block styles.
+ *
+ * List and calendar views with date filtering toolbar.
+ * Follows WordPress.org design language with accessible focus styles.
+ */
+
+.wp-block-groups-event-directory {
+	max-width: 960px;
+	margin: 0 auto;
+
+	// Loading state.
+	&__loading {
+		padding: 48px 24px;
+		text-align: center;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+	}
+
+	// Error state.
+	&__error {
+		padding: 12px 16px;
+		margin-bottom: 16px;
+		background-color: #fcf0f1;
+		border: 1px solid #cc1818;
+		border-radius: 4px;
+		color: #cc1818;
+		font-size: 14px;
+		line-height: 1.5;
+	}
+
+	// Empty state.
+	&__empty {
+		padding: 48px 24px;
+		text-align: center;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+		background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+		border-radius: 8px;
+
+		p {
+			margin: 0;
+			font-size: 16px;
+		}
+	}
+
+	// Toolbar: view toggle + date filter.
+	&__toolbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+		margin-bottom: 24px;
+		flex-wrap: wrap;
+	}
+
+	// View toggle tabs.
+	&__view-toggle {
+		display: flex;
+		background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+		border-radius: 6px;
+		padding: 4px;
+		gap: 2px;
+	}
+
+	&__view-btn {
+		padding: 8px 20px;
+		border: none;
+		border-radius: 4px;
+		background: transparent;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+		font-size: 14px;
+		font-weight: 500;
+		cursor: pointer;
+		transition: background-color 0.15s ease, color 0.15s ease;
+		min-height: 36px;
+
+		&:hover {
+			color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+			background: var(--wp--preset--color--light-grey-1, #dcdcde);
+		}
+
+		&.is-active {
+			background: var(--wp--preset--color--white, #fff);
+			color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+			font-weight: 600;
+			box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp--preset--color--blueberry-1, #3858e9);
+			outline-offset: -2px;
+		}
+	}
+
+	// Date filter / month navigation.
+	&__date-filter {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	&__nav-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 36px;
+		height: 36px;
+		border: 1px solid var(--wp--preset--color--light-grey-1, #dcdcde);
+		border-radius: 4px;
+		background: var(--wp--preset--color--white, #fff);
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		font-size: 20px;
+		cursor: pointer;
+		transition: border-color 0.15s ease, background-color 0.15s ease;
+
+		&:hover {
+			border-color: var(--wp--preset--color--charcoal-4, #50575e);
+			background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp--preset--color--blueberry-1, #3858e9);
+			outline-offset: 2px;
+		}
+	}
+
+	&__month-label {
+		font-size: 16px;
+		font-weight: 600;
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		min-width: 160px;
+		text-align: center;
+	}
+
+	&__today-btn {
+		padding: 6px 16px;
+		border: 1px solid var(--wp--preset--color--light-grey-1, #dcdcde);
+		border-radius: 4px;
+		background: var(--wp--preset--color--white, #fff);
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		font-size: 13px;
+		font-weight: 500;
+		cursor: pointer;
+		min-height: 36px;
+		transition: border-color 0.15s ease, background-color 0.15s ease;
+
+		&:hover {
+			border-color: var(--wp--preset--color--charcoal-4, #50575e);
+			background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp--preset--color--blueberry-1, #3858e9);
+			outline-offset: 2px;
+		}
+	}
+
+	// ----- List View -----
+
+	&__list {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	// Event card (used in list view).
+	&__event-card {
+		display: flex;
+		gap: 16px;
+		padding: 20px;
+		background: var(--wp--preset--color--white, #fff);
+		border: 1px solid var(--wp--preset--color--light-grey-1, #dcdcde);
+		border-radius: 8px;
+		transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+		&:hover {
+			border-color: var(--wp--preset--color--blueberry-1, #3858e9);
+			box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+		}
+	}
+
+	&__event-date-badge {
+		flex-shrink: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		width: 56px;
+		height: 56px;
+		background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+		border-radius: 8px;
+	}
+
+	&__event-month {
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		color: var(--wp--preset--color--blueberry-1, #3858e9);
+		line-height: 1;
+	}
+
+	&__event-day {
+		font-size: 22px;
+		font-weight: 700;
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		line-height: 1.2;
+	}
+
+	&__event-details {
+		flex: 1;
+		min-width: 0;
+	}
+
+	&__event-title {
+		margin: 0 0 6px;
+		font-size: 18px;
+		font-weight: 600;
+		line-height: 1.3;
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+
+		a {
+			color: inherit;
+			text-decoration: none;
+
+			&:hover {
+				color: var(--wp--preset--color--blueberry-1, #3858e9);
+				text-decoration: underline;
+			}
+
+			&:focus-visible {
+				outline: 2px solid var(--wp--preset--color--blueberry-1, #3858e9);
+				outline-offset: 2px;
+			}
+		}
+	}
+
+	&__event-meta {
+		font-size: 14px;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+		line-height: 1.5;
+		margin-bottom: 6px;
+	}
+
+	&__event-excerpt {
+		margin: 0 0 8px;
+		font-size: 14px;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+		line-height: 1.5;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	&__event-status {
+		display: flex;
+		gap: 8px;
+	}
+
+	&__status-badge {
+		display: inline-block;
+		padding: 2px 10px;
+		border-radius: 12px;
+		font-size: 12px;
+		font-weight: 600;
+		text-transform: capitalize;
+		line-height: 1.5;
+		background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+
+		&--event-scheduled {
+			background: #e7f5fe;
+			color: #0a4b78;
+		}
+
+		&--event-active {
+			background: #f0f6e8;
+			color: #007017;
+		}
+
+		&--event-past {
+			background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+			color: var(--wp--preset--color--charcoal-4, #50575e);
+		}
+
+		&--event-cancelled {
+			background: #fcf0f1;
+			color: #cc1818;
+		}
+	}
+
+	// ----- Calendar View -----
+
+	&__calendar {
+		background: var(--wp--preset--color--white, #fff);
+		border: 1px solid var(--wp--preset--color--light-grey-1, #dcdcde);
+		border-radius: 8px;
+		overflow: hidden;
+	}
+
+	&__cal-header {
+		display: grid;
+		grid-template-columns: repeat(7, 1fr);
+		background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+		border-bottom: 1px solid var(--wp--preset--color--light-grey-1, #dcdcde);
+	}
+
+	&__cal-weekday {
+		padding: 10px 4px;
+		text-align: center;
+		font-size: 12px;
+		font-weight: 600;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	&__cal-grid {
+		display: grid;
+		grid-template-columns: repeat(7, 1fr);
+	}
+
+	&__cal-cell {
+		min-height: 90px;
+		padding: 6px;
+		border-right: 1px solid var(--wp--preset--color--light-grey-1, #dcdcde);
+		border-bottom: 1px solid var(--wp--preset--color--light-grey-1, #dcdcde);
+		position: relative;
+
+		&:nth-child(7n) {
+			border-right: none;
+		}
+
+		&--empty {
+			background: var(--wp--preset--color--light-grey-2, #f6f7f7);
+		}
+
+		&.is-today {
+			background: #f0f6ff;
+		}
+
+		&.has-events {
+			cursor: default;
+		}
+	}
+
+	&__cal-day-number {
+		display: block;
+		font-size: 13px;
+		font-weight: 500;
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+		margin-bottom: 4px;
+
+		.is-today & {
+			font-weight: 700;
+			color: var(--wp--preset--color--blueberry-1, #3858e9);
+		}
+	}
+
+	&__cal-events {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	&__cal-event-dot {
+		display: block;
+		padding: 2px 4px;
+		background: var(--wp--preset--color--blueberry-1, #3858e9);
+		border-radius: 3px;
+		text-decoration: none;
+		overflow: hidden;
+
+		&:hover {
+			opacity: 0.85;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp--preset--color--blueberry-1, #3858e9);
+			outline-offset: 1px;
+		}
+	}
+
+	&__cal-event-label {
+		display: block;
+		font-size: 11px;
+		font-weight: 500;
+		color: var(--wp--preset--color--white, #fff);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		line-height: 1.3;
+	}
+}
+
+// Responsive: stack toolbar on small screens.
+@media (max-width: 600px) {
+	.wp-block-groups-event-directory {
+		&__toolbar {
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		&__view-toggle {
+			justify-content: center;
+		}
+
+		&__date-filter {
+			justify-content: center;
+		}
+
+		&__month-label {
+			min-width: 120px;
+			font-size: 14px;
+		}
+
+		&__event-card {
+			flex-direction: column;
+			gap: 12px;
+		}
+
+		&__event-date-badge {
+			flex-direction: row;
+			width: auto;
+			height: auto;
+			gap: 6px;
+			padding: 6px 12px;
+		}
+
+		// Calendar: smaller cells on mobile.
+		&__cal-cell {
+			min-height: 60px;
+			padding: 4px;
+		}
+
+		&__cal-event-label {
+			font-size: 10px;
+		}
+	}
+}

--- a/wp-content/plugins/wordpress-groups/blocks/event-directory/view.js
+++ b/wp-content/plugins/wordpress-groups/blocks/event-directory/view.js
@@ -1,0 +1,592 @@
+/**
+ * Event Directory — frontend interactive directory.
+ *
+ * Hydrates the server-rendered container with a React-based event directory
+ * supporting list/calendar toggle, date filtering, and event cards.
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, createRoot, useState, useEffect, useCallback, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * View mode constants.
+ */
+const VIEW_LIST = 'list';
+const VIEW_CALENDAR = 'calendar';
+
+/**
+ * Days of the week for the calendar header.
+ */
+const WEEKDAYS = [
+	__( 'Sun', 'wordpress-groups' ),
+	__( 'Mon', 'wordpress-groups' ),
+	__( 'Tue', 'wordpress-groups' ),
+	__( 'Wed', 'wordpress-groups' ),
+	__( 'Thu', 'wordpress-groups' ),
+	__( 'Fri', 'wordpress-groups' ),
+	__( 'Sat', 'wordpress-groups' ),
+];
+
+/**
+ * Format a date string for display.
+ *
+ * @param {string} dateStr Date string in Y-m-d H:i:s format.
+ * @param {string} timezone Timezone identifier.
+ * @return {string} Formatted date string.
+ */
+function formatEventDate( dateStr, timezone ) {
+	if ( ! dateStr ) {
+		return '';
+	}
+
+	try {
+		// The API returns dates in Y-m-d H:i:s (UTC). Build a proper UTC date.
+		const utcDate = dateStr.includes( 'T' ) ? new Date( dateStr ) : new Date( dateStr.replace( ' ', 'T' ) + 'Z' );
+
+		return utcDate.toLocaleDateString( undefined, {
+			weekday: 'short',
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: '2-digit',
+			timeZone: timezone || undefined,
+		} );
+	} catch {
+		return dateStr;
+	}
+}
+
+/**
+ * Format a date string as YYYY-MM-DD for API queries.
+ *
+ * @param {Date} date Date object.
+ * @return {string} Formatted date string.
+ */
+function toApiDate( date ) {
+	const year = date.getFullYear();
+	const month = String( date.getMonth() + 1 ).padStart( 2, '0' );
+	const day = String( date.getDate() ).padStart( 2, '0' );
+	return `${ year }-${ month }-${ day }`;
+}
+
+/**
+ * Get the first and last days of a month.
+ *
+ * @param {number} year  Full year.
+ * @param {number} month Month (0-indexed).
+ * @return {Object} Object with `start` and `end` Date objects.
+ */
+function getMonthRange( year, month ) {
+	return {
+		start: new Date( year, month, 1 ),
+		end: new Date( year, month + 1, 0 ),
+	};
+}
+
+/**
+ * Parse a date string into a YYYY-MM-DD key for calendar grouping.
+ *
+ * @param {string} dateStr Date string.
+ * @return {string} Date key.
+ */
+function toDateKey( dateStr ) {
+	if ( ! dateStr ) {
+		return '';
+	}
+	return dateStr.substring( 0, 10 );
+}
+
+/**
+ * View toggle component.
+ *
+ * @param {Object}   props
+ * @param {string}   props.view     Current view mode.
+ * @param {Function} props.onChange  View change handler.
+ */
+function ViewToggle( { view, onChange } ) {
+	return createElement(
+		'div',
+		{
+			className: 'wp-block-groups-event-directory__view-toggle',
+			role: 'tablist',
+			'aria-label': __( 'Directory view', 'wordpress-groups' ),
+		},
+		createElement(
+			'button',
+			{
+				type: 'button',
+				role: 'tab',
+				'aria-selected': view === VIEW_LIST ? 'true' : 'false',
+				className: [
+					'wp-block-groups-event-directory__view-btn',
+					view === VIEW_LIST ? 'is-active' : '',
+				]
+					.filter( Boolean )
+					.join( ' ' ),
+				onClick: () => onChange( VIEW_LIST ),
+			},
+			__( 'List', 'wordpress-groups' )
+		),
+		createElement(
+			'button',
+			{
+				type: 'button',
+				role: 'tab',
+				'aria-selected': view === VIEW_CALENDAR ? 'true' : 'false',
+				className: [
+					'wp-block-groups-event-directory__view-btn',
+					view === VIEW_CALENDAR ? 'is-active' : '',
+				]
+					.filter( Boolean )
+					.join( ' ' ),
+				onClick: () => onChange( VIEW_CALENDAR ),
+			},
+			__( 'Calendar', 'wordpress-groups' )
+		)
+	);
+}
+
+/**
+ * Date filter component with month/year navigation.
+ *
+ * @param {Object}   props
+ * @param {number}   props.year     Current year.
+ * @param {number}   props.month    Current month (0-indexed).
+ * @param {Function} props.onPrev   Previous month handler.
+ * @param {Function} props.onNext   Next month handler.
+ * @param {Function} props.onToday  Today handler.
+ */
+function DateFilter( { year, month, onPrev, onNext, onToday } ) {
+	const monthLabel = new Date( year, month ).toLocaleDateString( undefined, {
+		year: 'numeric',
+		month: 'long',
+	} );
+
+	return createElement(
+		'div',
+		{ className: 'wp-block-groups-event-directory__date-filter' },
+		createElement(
+			'button',
+			{
+				type: 'button',
+				className: 'wp-block-groups-event-directory__nav-btn',
+				onClick: onPrev,
+				'aria-label': __( 'Previous month', 'wordpress-groups' ),
+			},
+			'\u2039'
+		),
+		createElement(
+			'span',
+			{
+				className: 'wp-block-groups-event-directory__month-label',
+				'aria-live': 'polite',
+			},
+			monthLabel
+		),
+		createElement(
+			'button',
+			{
+				type: 'button',
+				className: 'wp-block-groups-event-directory__nav-btn',
+				onClick: onNext,
+				'aria-label': __( 'Next month', 'wordpress-groups' ),
+			},
+			'\u203A'
+		),
+		createElement(
+			'button',
+			{
+				type: 'button',
+				className: 'wp-block-groups-event-directory__today-btn',
+				onClick: onToday,
+			},
+			__( 'Today', 'wordpress-groups' )
+		)
+	);
+}
+
+/**
+ * Single event card component.
+ *
+ * @param {Object} props
+ * @param {Object} props.event Event data object.
+ */
+function EventCard( { event } ) {
+	const startDate = formatEventDate( event.meta.start_date, event.meta.timezone );
+	const endDate = formatEventDate( event.meta.end_date, event.meta.timezone );
+
+	return createElement(
+		'article',
+		{ className: 'wp-block-groups-event-directory__event-card' },
+		createElement(
+			'div',
+			{ className: 'wp-block-groups-event-directory__event-date-badge' },
+			createElement(
+				'span',
+				{ className: 'wp-block-groups-event-directory__event-month' },
+				event.meta.start_date
+					? new Date( event.meta.start_date.replace( ' ', 'T' ) + 'Z' ).toLocaleDateString( undefined, { month: 'short' } )
+					: ''
+			),
+			createElement(
+				'span',
+				{ className: 'wp-block-groups-event-directory__event-day' },
+				event.meta.start_date
+					? new Date( event.meta.start_date.replace( ' ', 'T' ) + 'Z' ).getUTCDate()
+					: ''
+			)
+		),
+		createElement(
+			'div',
+			{ className: 'wp-block-groups-event-directory__event-details' },
+			createElement(
+				'h3',
+				{ className: 'wp-block-groups-event-directory__event-title' },
+				event.link
+					? createElement( 'a', { href: event.link }, event.title )
+					: event.title
+			),
+			createElement(
+				'div',
+				{ className: 'wp-block-groups-event-directory__event-meta' },
+				startDate && createElement(
+					'span',
+					{ className: 'wp-block-groups-event-directory__event-time' },
+					startDate
+				),
+				endDate && createElement(
+					'span',
+					{ className: 'wp-block-groups-event-directory__event-end-time' },
+					' \u2013 ',
+					endDate
+				)
+			),
+			event.excerpt && createElement(
+				'p',
+				{ className: 'wp-block-groups-event-directory__event-excerpt' },
+				event.excerpt
+			),
+			createElement(
+				'div',
+				{ className: 'wp-block-groups-event-directory__event-status' },
+				createElement(
+					'span',
+					{
+						className: [
+							'wp-block-groups-event-directory__status-badge',
+							`wp-block-groups-event-directory__status-badge--${ event.status }`,
+						].join( ' ' ),
+					},
+					event.status.replace( 'event-', '' )
+				)
+			)
+		)
+	);
+}
+
+/**
+ * List view component.
+ *
+ * @param {Object}  props
+ * @param {Array}   props.events  Array of event objects.
+ * @param {boolean} props.loading Whether events are loading.
+ */
+function ListView( { events, loading } ) {
+	if ( loading ) {
+		return createElement(
+			'div',
+			{ className: 'wp-block-groups-event-directory__loading', 'aria-live': 'polite' },
+			createElement( 'p', null, __( 'Loading events\u2026', 'wordpress-groups' ) )
+		);
+	}
+
+	if ( events.length === 0 ) {
+		return createElement(
+			'div',
+			{ className: 'wp-block-groups-event-directory__empty' },
+			createElement( 'p', null, __( 'No events found for this period.', 'wordpress-groups' ) )
+		);
+	}
+
+	return createElement(
+		'div',
+		{ className: 'wp-block-groups-event-directory__list' },
+		events.map( ( event ) =>
+			createElement( EventCard, { key: event.id, event } )
+		)
+	);
+}
+
+/**
+ * Calendar view component.
+ *
+ * @param {Object}  props
+ * @param {Array}   props.events  Array of event objects.
+ * @param {number}  props.year    Current year.
+ * @param {number}  props.month   Current month (0-indexed).
+ * @param {boolean} props.loading Whether events are loading.
+ */
+function CalendarView( { events, year, month, loading } ) {
+	// Group events by date key.
+	const eventsByDate = useMemo( () => {
+		const grouped = {};
+		events.forEach( ( event ) => {
+			const key = toDateKey( event.meta.start_date );
+			if ( ! key ) {
+				return;
+			}
+			if ( ! grouped[ key ] ) {
+				grouped[ key ] = [];
+			}
+			grouped[ key ].push( event );
+		} );
+		return grouped;
+	}, [ events ] );
+
+	// Build the calendar grid.
+	const firstDay = new Date( year, month, 1 ).getDay();
+	const daysInMonth = new Date( year, month + 1, 0 ).getDate();
+	const today = toApiDate( new Date() );
+
+	const cells = [];
+
+	// Empty cells before the first day.
+	for ( let i = 0; i < firstDay; i++ ) {
+		cells.push(
+			createElement( 'div', {
+				key: `empty-${ i }`,
+				className: 'wp-block-groups-event-directory__cal-cell wp-block-groups-event-directory__cal-cell--empty',
+			} )
+		);
+	}
+
+	// Day cells.
+	for ( let day = 1; day <= daysInMonth; day++ ) {
+		const dateKey = `${ year }-${ String( month + 1 ).padStart( 2, '0' ) }-${ String( day ).padStart( 2, '0' ) }`;
+		const dayEvents = eventsByDate[ dateKey ] || [];
+		const isToday = dateKey === today;
+
+		cells.push(
+			createElement(
+				'div',
+				{
+					key: dateKey,
+					className: [
+						'wp-block-groups-event-directory__cal-cell',
+						dayEvents.length > 0 ? 'has-events' : '',
+						isToday ? 'is-today' : '',
+					]
+						.filter( Boolean )
+						.join( ' ' ),
+				},
+				createElement(
+					'span',
+					{ className: 'wp-block-groups-event-directory__cal-day-number' },
+					day
+				),
+				dayEvents.length > 0 &&
+					createElement(
+						'div',
+						{ className: 'wp-block-groups-event-directory__cal-events' },
+						dayEvents.map( ( event ) =>
+							createElement(
+								'a',
+								{
+									key: event.id,
+									href: event.link,
+									className: 'wp-block-groups-event-directory__cal-event-dot',
+									title: event.title,
+								},
+								createElement(
+									'span',
+									{ className: 'wp-block-groups-event-directory__cal-event-label' },
+									event.title
+								)
+							)
+						)
+					)
+			)
+		);
+	}
+
+	if ( loading ) {
+		return createElement(
+			'div',
+			{ className: 'wp-block-groups-event-directory__loading', 'aria-live': 'polite' },
+			createElement( 'p', null, __( 'Loading events\u2026', 'wordpress-groups' ) )
+		);
+	}
+
+	return createElement(
+		'div',
+		{
+			className: 'wp-block-groups-event-directory__calendar',
+			role: 'grid',
+			'aria-label': __( 'Event calendar', 'wordpress-groups' ),
+		},
+		createElement(
+			'div',
+			{
+				className: 'wp-block-groups-event-directory__cal-header',
+				role: 'row',
+			},
+			WEEKDAYS.map( ( dayName ) =>
+				createElement(
+					'div',
+					{
+						key: dayName,
+						className: 'wp-block-groups-event-directory__cal-weekday',
+						role: 'columnheader',
+					},
+					dayName
+				)
+			)
+		),
+		createElement(
+			'div',
+			{ className: 'wp-block-groups-event-directory__cal-grid' },
+			cells
+		)
+	);
+}
+
+/**
+ * Main Event Directory component.
+ */
+function EventDirectory() {
+	const now = new Date();
+	const [ view, setView ] = useState( VIEW_LIST );
+	const [ year, setYear ] = useState( now.getFullYear() );
+	const [ month, setMonth ] = useState( now.getMonth() );
+	const [ events, setEvents ] = useState( [] );
+	const [ loading, setLoading ] = useState( true );
+	const [ error, setError ] = useState( '' );
+
+	/**
+	 * Fetch events for the current month.
+	 */
+	const fetchEvents = useCallback( async () => {
+		setLoading( true );
+		setError( '' );
+
+		const { start, end } = getMonthRange( year, month );
+
+		try {
+			const result = await apiFetch( {
+				path: `/groups/v1/events?after=${ toApiDate( start ) }&before=${ toApiDate( end ) }&per_page=100`,
+			} );
+
+			setEvents( result );
+		} catch ( err ) {
+			setError(
+				err.message ||
+					__( 'Failed to load events. Please try again.', 'wordpress-groups' )
+			);
+			setEvents( [] );
+		} finally {
+			setLoading( false );
+		}
+	}, [ year, month ] );
+
+	useEffect( () => {
+		fetchEvents();
+	}, [ fetchEvents ] );
+
+	/**
+	 * Navigate to the previous month.
+	 */
+	const handlePrev = useCallback( () => {
+		if ( month === 0 ) {
+			setMonth( 11 );
+			setYear( ( prev ) => prev - 1 );
+		} else {
+			setMonth( ( prev ) => prev - 1 );
+		}
+	}, [ month ] );
+
+	/**
+	 * Navigate to the next month.
+	 */
+	const handleNext = useCallback( () => {
+		if ( month === 11 ) {
+			setMonth( 0 );
+			setYear( ( prev ) => prev + 1 );
+		} else {
+			setMonth( ( prev ) => prev + 1 );
+		}
+	}, [ month ] );
+
+	/**
+	 * Navigate to today.
+	 */
+	const handleToday = useCallback( () => {
+		const today = new Date();
+		setYear( today.getFullYear() );
+		setMonth( today.getMonth() );
+	}, [] );
+
+	return createElement(
+		'div',
+		{ className: 'wp-block-groups-event-directory__inner' },
+		createElement(
+			'div',
+			{ className: 'wp-block-groups-event-directory__toolbar' },
+			createElement( ViewToggle, { view, onChange: setView } ),
+			createElement( DateFilter, {
+				year,
+				month,
+				onPrev: handlePrev,
+				onNext: handleNext,
+				onToday: handleToday,
+			} )
+		),
+		error &&
+			createElement(
+				'div',
+				{
+					className: 'wp-block-groups-event-directory__error',
+					role: 'alert',
+				},
+				error
+			),
+		view === VIEW_LIST
+			? createElement( ListView, { events, loading } )
+			: createElement( CalendarView, { events, year, month, loading } )
+	);
+}
+
+/**
+ * Hydrate all event directory containers on the page.
+ */
+function init() {
+	const containers = document.querySelectorAll( '.wp-block-groups-event-directory' );
+
+	containers.forEach( ( container ) => {
+		const root = createRoot( container );
+		root.render( createElement( EventDirectory ) );
+	} );
+}
+
+// Hydrate when the DOM is ready (skip during tests).
+if ( typeof document !== 'undefined' ) {
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+}
+
+// Export for testing.
+export {
+	EventDirectory,
+	ViewToggle,
+	DateFilter,
+	EventCard,
+	ListView,
+	CalendarView,
+	formatEventDate,
+	toApiDate,
+	toDateKey,
+};


### PR DESCRIPTION
## Summary
- Implements `groups/event-directory` block with list and calendar view toggle, month-based date navigation, and event cards
- Frontend React app fetches events from `/groups/v1/events` REST endpoint via `apiFetch` with `after`/`before` date filtering
- Follows existing block patterns (application-form) with server-rendered container, React hydration, editor placeholder, and SCSS styles

## Test plan
- [ ] Insert the Event Directory block in the editor and verify the placeholder renders
- [ ] View the block on the frontend and confirm the list view loads events for the current month
- [ ] Toggle between list and calendar views
- [ ] Navigate between months using the arrow buttons and "Today" button
- [ ] Verify event cards display title, date badge, time range, excerpt, and status badge
- [ ] Verify calendar view shows event dots on the correct dates
- [ ] Test responsive layout on mobile viewports

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)