### PR TITLE
Add email notifications for all transitions and recurrence sidebar

### DIFF
--- a/wp-content/plugins/wordpress-groups/assets/js/recurrence-panel.js
+++ b/wp-content/plugins/wordpress-groups/assets/js/recurrence-panel.js
@@ -1,0 +1,269 @@
+/**
+ * Recurrence Panel — PluginDocumentSettingPanel for event recurrence.
+ *
+ * Adds a sidebar panel to the event editor that allows organizers to
+ * set a recurrence rule (None, Weekly, Biweekly, Monthly) and see a
+ * preview of the next 3 occurrences.
+ *
+ * @package Groups
+ */
+( function () {
+	const { registerPlugin } = wp.plugins;
+	const { PluginDocumentSettingPanel } = wp.editPost;
+	const { SelectControl, Spinner, Notice } = wp.components;
+	const { useSelect, useDispatch } = wp.data;
+	const { useState, useEffect } = wp.element;
+	const { __ } = wp.i18n;
+	const apiFetch = wp.apiFetch;
+
+	const FREQUENCY_OPTIONS = [
+		{ label: __( 'None', 'wordpress-groups' ), value: 'none' },
+		{ label: __( 'Weekly', 'wordpress-groups' ), value: 'weekly' },
+		{ label: __( 'Biweekly', 'wordpress-groups' ), value: 'biweekly' },
+		{ label: __( 'Monthly', 'wordpress-groups' ), value: 'monthly-date' },
+	];
+
+	/**
+	 * Format a Y-m-d date string into a human-readable form.
+	 *
+	 * @param {string} dateStr Date in Y-m-d format.
+	 * @return {string} Formatted date string.
+	 */
+	function formatDate( dateStr ) {
+		const date = new Date( dateStr + 'T00:00:00' );
+		return date.toLocaleDateString( undefined, {
+			weekday: 'short',
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+		} );
+	}
+
+	/**
+	 * Parse a stored recurrence rule JSON string into a frequency value.
+	 *
+	 * @param {string} metaValue The raw meta value (JSON string or empty).
+	 * @return {string} The frequency string, or 'none'.
+	 */
+	function parseFrequency( metaValue ) {
+		if ( ! metaValue ) {
+			return 'none';
+		}
+
+		try {
+			const parsed = JSON.parse( metaValue );
+			return parsed.frequency || 'none';
+		} catch ( e ) {
+			return 'none';
+		}
+	}
+
+	/**
+	 * Build a recurrence rule JSON string from a frequency and start date.
+	 *
+	 * @param {string} frequency The selected frequency.
+	 * @param {string} startDate The event start date (Y-m-d or ISO).
+	 * @return {string} JSON string for the rule, or empty string for 'none'.
+	 */
+	function buildRuleJSON( frequency, startDate ) {
+		if ( frequency === 'none' || ! startDate ) {
+			return '';
+		}
+
+		const date = new Date( startDate );
+		const rule = { frequency: frequency };
+
+		if ( [ 'weekly', 'biweekly', 'monthly-day' ].includes( frequency ) ) {
+			rule.day_of_week = date.getUTCDay();
+		}
+
+		if ( frequency === 'monthly-date' ) {
+			rule.day_of_month = date.getUTCDate();
+		}
+
+		return JSON.stringify( rule );
+	}
+
+	/**
+	 * The Recurrence Panel component.
+	 */
+	function RecurrencePanel() {
+		const { postType, meta, startDate } = useSelect( function ( select ) {
+			const editor = select( 'core/editor' );
+			const currentPostType = editor.getCurrentPostType();
+			const postMeta = editor.getEditedPostAttribute( 'meta' ) || {};
+			const allMeta = postMeta || {};
+
+			// Try to get start date from meta.
+			let eventStartDate = allMeta._event_start_date || '';
+
+			// Fall back to post date if no event start date is set.
+			if ( ! eventStartDate ) {
+				eventStartDate = editor.getEditedPostAttribute( 'date' ) || '';
+			}
+
+			return {
+				postType: currentPostType,
+				meta: allMeta,
+				startDate: eventStartDate,
+			};
+		}, [] );
+
+		const { editPost } = useDispatch( 'core/editor' );
+
+		const metaKey = window.groupsRecurrence?.metaKey || '_event_recurrence_rule';
+		const expectedPostType = window.groupsRecurrence?.postType || 'event';
+
+		const currentMetaValue = meta[ metaKey ] || '';
+		const [ frequency, setFrequency ] = useState( parseFrequency( currentMetaValue ) );
+		const [ occurrences, setOccurrences ] = useState( [] );
+		const [ loading, setLoading ] = useState( false );
+		const [ error, setError ] = useState( '' );
+
+		// Don't render for non-event post types.
+		if ( postType !== expectedPostType ) {
+			return null;
+		}
+
+		/**
+		 * When frequency changes, update the post meta and fetch preview.
+		 */
+		function onFrequencyChange( newFrequency ) {
+			setFrequency( newFrequency );
+			setError( '' );
+
+			const ruleJSON = buildRuleJSON( newFrequency, startDate );
+
+			editPost( {
+				meta: {
+					[ metaKey ]: ruleJSON,
+				},
+			} );
+
+			// Fetch occurrence preview.
+			if ( newFrequency === 'none' ) {
+				setOccurrences( [] );
+				return;
+			}
+
+			if ( ! startDate ) {
+				setError( __( 'Set an event start date first.', 'wordpress-groups' ) );
+				return;
+			}
+
+			fetchPreview( newFrequency, startDate );
+		}
+
+		/**
+		 * Fetch occurrence preview from the REST endpoint.
+		 */
+		function fetchPreview( freq, date ) {
+			setLoading( true );
+			setOccurrences( [] );
+
+			// Normalize date to Y-m-d.
+			const dateStr = date.substring( 0, 10 );
+
+			apiFetch( {
+				path: '/groups/v1/recurrence-preview',
+				method: 'POST',
+				data: {
+					frequency: freq,
+					start_date: dateStr,
+				},
+			} )
+				.then( function ( response ) {
+					setOccurrences( response.occurrences || [] );
+					setLoading( false );
+				} )
+				.catch( function () {
+					setError( __( 'Could not load occurrence preview.', 'wordpress-groups' ) );
+					setLoading( false );
+				} );
+		}
+
+		// Fetch preview on mount if there is already a rule set.
+		useEffect( function () {
+			if ( frequency !== 'none' && startDate ) {
+				fetchPreview( frequency, startDate );
+			}
+		}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+		return wp.element.createElement(
+			PluginDocumentSettingPanel,
+			{
+				name: 'groups-recurrence-panel',
+				title: __( 'Recurrence', 'wordpress-groups' ),
+				className: 'groups-recurrence-panel',
+			},
+			wp.element.createElement( SelectControl, {
+				label: __( 'Repeat', 'wordpress-groups' ),
+				value: frequency,
+				options: FREQUENCY_OPTIONS,
+				onChange: onFrequencyChange,
+			} ),
+			error &&
+				wp.element.createElement(
+					Notice,
+					{
+						status: 'warning',
+						isDismissible: false,
+						className: 'groups-recurrence-notice',
+					},
+					error
+				),
+			loading && wp.element.createElement( Spinner, null ),
+			! loading &&
+				occurrences.length > 0 &&
+				wp.element.createElement(
+					'div',
+					{ className: 'groups-recurrence-preview' },
+					wp.element.createElement(
+						'p',
+						{
+							style: {
+								fontWeight: 600,
+								marginBottom: '8px',
+								fontSize: '11px',
+								textTransform: 'uppercase',
+								letterSpacing: '0.5px',
+							},
+						},
+						__( 'Next occurrences', 'wordpress-groups' )
+					),
+					wp.element.createElement(
+						'ul',
+						{
+							style: {
+								margin: 0,
+								padding: 0,
+								listStyle: 'none',
+							},
+						},
+						occurrences.map( function ( dateStr, index ) {
+							return wp.element.createElement(
+								'li',
+								{
+									key: index,
+									style: {
+										padding: '6px 0',
+										borderBottom:
+											index < occurrences.length - 1
+												? '1px solid #e0e0e0'
+												: 'none',
+										fontSize: '13px',
+									},
+								},
+								formatDate( dateStr )
+							);
+						} )
+					)
+				)
+		);
+	}
+
+	registerPlugin( 'groups-recurrence-panel', {
+		render: RecurrencePanel,
+		icon: 'calendar-alt',
+	} );
+} )();

--- a/wp-content/plugins/wordpress-groups/includes/blocks/class-recurrence-panel.php
+++ b/wp-content/plugins/wordpress-groups/includes/blocks/class-recurrence-panel.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Recurrence Panel — registers editor sidebar panel for event recurrence.
+ *
+ * Enqueues the React-based PluginDocumentSettingPanel that allows
+ * organizers to set recurrence rules on event posts. Also exposes
+ * a lightweight REST endpoint for previewing occurrences.
+ *
+ * @package Groups\Blocks
+ */
+
+namespace Groups\Blocks;
+
+use Groups\Models\Recurrence;
+use Groups\Post_Types\Event;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers the editor sidebar panel and supporting REST route
+ * for event recurrence management.
+ */
+class Recurrence_Panel {
+
+	/**
+	 * Constructor. Registers hooks.
+	 */
+	public function __construct() {
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_editor_assets' ] );
+		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
+		add_action( 'init', [ $this, 'register_post_meta' ] );
+	}
+
+	/**
+	 * Register the _event_recurrence_rule meta field for the REST API.
+	 *
+	 * This allows the Gutenberg editor to read and write the meta value
+	 * via the standard post meta mechanism.
+	 */
+	public function register_post_meta(): void {
+		register_post_meta(
+			Event::POST_TYPE,
+			Recurrence::META_KEY,
+			[
+				'show_in_rest'  => true,
+				'single'        => true,
+				'type'          => 'string',
+				'auth_callback' => function () {
+					return current_user_can( 'edit_posts' );
+				},
+			]
+		);
+	}
+
+	/**
+	 * Enqueue the sidebar panel script when editing an event.
+	 */
+	public function enqueue_editor_assets(): void {
+		$screen = get_current_screen();
+
+		if ( ! $screen || Event::POST_TYPE !== $screen->post_type ) {
+			return;
+		}
+
+		$asset_path = GROUPS_PLUGIN_DIR . '/assets/js/recurrence-panel.js';
+
+		wp_enqueue_script(
+			'groups-recurrence-panel',
+			GROUPS_PLUGIN_URL . 'assets/js/recurrence-panel.js',
+			[
+				'wp-plugins',
+				'wp-edit-post',
+				'wp-components',
+				'wp-data',
+				'wp-element',
+				'wp-api-fetch',
+				'wp-i18n',
+			],
+			file_exists( $asset_path ) ? filemtime( $asset_path ) : GROUPS_PLUGIN_VERSION,
+			true
+		);
+
+		wp_localize_script(
+			'groups-recurrence-panel',
+			'groupsRecurrence',
+			[
+				'restUrl'  => rest_url( 'groups/v1/recurrence-preview' ),
+				'nonce'    => wp_create_nonce( 'wp_rest' ),
+				'metaKey'  => Recurrence::META_KEY,
+				'postType' => Event::POST_TYPE,
+			]
+		);
+	}
+
+	/**
+	 * Register the REST route for previewing recurrence occurrences.
+	 */
+	public function register_rest_routes(): void {
+		register_rest_route(
+			'groups/v1',
+			'/recurrence-preview',
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'preview_occurrences' ],
+				'permission_callback' => function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'args'                => [
+					'frequency'  => [
+						'required'          => true,
+						'type'              => 'string',
+						'enum'              => array_merge( [ 'none' ], Recurrence::VALID_FREQUENCIES ),
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'start_date' => [
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * REST callback: return the next 3 occurrences for a given rule.
+	 *
+	 * @param \WP_REST_Request $request Full request object.
+	 * @return \WP_REST_Response
+	 */
+	public function preview_occurrences( \WP_REST_Request $request ): \WP_REST_Response {
+		$frequency  = $request->get_param( 'frequency' );
+		$start_date = $request->get_param( 'start_date' );
+
+		if ( 'none' === $frequency ) {
+			return new \WP_REST_Response( [ 'occurrences' => [] ], 200 );
+		}
+
+		// Parse start_date — accept both Y-m-d and full ISO datetime.
+		$date = \DateTime::createFromFormat( 'Y-m-d', substr( $start_date, 0, 10 ) );
+
+		if ( ! $date ) {
+			return new \WP_REST_Response(
+				[ 'message' => __( 'Invalid start date.', 'wordpress-groups' ) ],
+				400
+			);
+		}
+
+		// Build a minimal rule for the preview.
+		$rule = [ 'frequency' => $frequency ];
+
+		// For weekly/biweekly, use the day of week from the start date.
+		if ( in_array( $frequency, [ 'weekly', 'biweekly', 'monthly-day' ], true ) ) {
+			$rule['day_of_week'] = (int) $date->format( 'w' );
+		}
+
+		if ( 'monthly-date' === $frequency ) {
+			$rule['day_of_month'] = (int) $date->format( 'j' );
+		}
+
+		// Skip the first occurrence (the start date itself) by generating 4
+		// and dropping the first, so the preview shows the *next* 3 dates.
+		$occurrences = Recurrence::calculate_occurrences( $rule, $date->format( 'Y-m-d' ), 4 );
+		array_shift( $occurrences );
+
+		$formatted = array_map(
+			static function ( \DateTime $dt ): string {
+				return $dt->format( 'Y-m-d' );
+			},
+			$occurrences
+		);
+
+		return new \WP_REST_Response( [ 'occurrences' => array_values( $formatted ) ], 200 );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -68,6 +68,7 @@ class Plugin {
 		new Admin\Reports();
 		new Workflow\Organizer_Onboarding();
 		new Notifications\Rsvp_Notifications();
+		new Blocks\Recurrence_Panel();
 
 		add_action( 'init', [ Models\Membership::class, 'register_roles' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );

--- a/wp-content/plugins/wordpress-groups/includes/workflow/class-status-transition.php
+++ b/wp-content/plugins/wordpress-groups/includes/workflow/class-status-transition.php
@@ -3,7 +3,9 @@
  * Status transition side effects handler.
  *
  * Handles logging and email notifications when wp_meetup posts
- * transition between statuses.
+ * transition between statuses. Ensures every valid transition
+ * produces a context-specific HTML email to the organizer and,
+ * where appropriate, to the site administrators.
  *
  * @package Groups\Workflow
  */
@@ -47,6 +49,38 @@ class Status_Transition {
 	];
 
 	/**
+	 * Status-specific messages shown to the organizer in the email body.
+	 *
+	 * Each key is the *new* status. The value is an HTML-safe message
+	 * displayed inside the status card of the `application-status` template.
+	 *
+	 * @var array<string, string>
+	 */
+	private const STATUS_MESSAGES = [
+		'meetup-vetting'     => 'Your application has been received and is now being reviewed by the Community Team. We will be in touch soon.',
+		'meetup-feedback'    => 'The Community Team has reviewed your application and has a few questions. Please check your dashboard for details and respond at your earliest convenience.',
+		'meetup-orientation' => 'Great news! Your application has been approved. You are now entering the orientation phase. A mentor will be assigned to help you get started.',
+		'meetup-scheduling'  => 'Orientation is complete! Your group site has been created and you can now schedule your first event. Visit your dashboard to get started.',
+		'meetup-active'      => 'Congratulations! Your group is now fully active. Keep up the great work organizing events for the WordPress community!',
+		'meetup-dormant'     => 'Your group has been marked as dormant due to inactivity. If you would like to reactivate it, please reach out to the Community Team through your dashboard.',
+		'meetup-suspended'   => 'Your group has been suspended. Please contact the Community Team for more information about the next steps.',
+		'meetup-removed'     => 'Your group has been removed from the WordPress Community program. If you believe this is an error, please contact the Community Team.',
+		'meetup-declined'    => 'Unfortunately your application has not been approved at this time. You can find more details and contact the Community Team through your dashboard.',
+	];
+
+	/**
+	 * Transitions that should also notify site administrators.
+	 *
+	 * These are statuses where an admin review or action is typically needed.
+	 *
+	 * @var string[]
+	 */
+	private const ADMIN_NOTIFY_STATUSES = [
+		'meetup-pending',
+		'meetup-feedback',
+	];
+
+	/**
 	 * Constructor.
 	 *
 	 * @param Email_Notifier|null $email_notifier Optional. Email notifier instance.
@@ -82,9 +116,11 @@ class Status_Transition {
 	}
 
 	/**
-	 * Send email notification for the status transition.
+	 * Send email notifications for the status transition.
 	 *
-	 * Notifies the organizer (post author) about the status change.
+	 * Sends a context-specific email to the organizer (post author) for every
+	 * transition. For transitions that require admin attention, a separate
+	 * notification is also sent to site administrators.
 	 *
 	 * @param int    $post_id    Post ID.
 	 * @param string $old_status Previous status.
@@ -97,6 +133,30 @@ class Status_Transition {
 			return;
 		}
 
+		/**
+		 * Filters whether to send a status transition email notification.
+		 *
+		 * @param bool   $send       Whether to send the email. Default true.
+		 * @param int    $post_id    The post ID.
+		 * @param string $old_status Previous status.
+		 * @param string $new_status New status.
+		 */
+		if ( ! apply_filters( 'groups_send_transition_email', true, $post_id, $old_status, $new_status ) ) {
+			return;
+		}
+
+		$this->notify_organizer( $post, $old_status, $new_status );
+		$this->notify_admins( $post, $old_status, $new_status );
+	}
+
+	/**
+	 * Send a status-change email to the organizer (post author).
+	 *
+	 * @param \WP_Post $post       The meetup post.
+	 * @param string   $old_status Previous status.
+	 * @param string   $new_status New status.
+	 */
+	private function notify_organizer( \WP_Post $post, string $old_status, string $new_status ): void {
 		$author = get_user_by( 'id', $post->post_author );
 
 		if ( ! $author || ! $author->user_email ) {
@@ -112,30 +172,94 @@ class Status_Transition {
 			$new_label
 		);
 
-		/**
-		 * Filters whether to send a status transition email notification.
-		 *
-		 * @param bool   $send       Whether to send the email. Default true.
-		 * @param int    $post_id    The post ID.
-		 * @param string $old_status Previous status.
-		 * @param string $new_status New status.
-		 */
-		if ( ! apply_filters( 'groups_send_transition_email', true, $post_id, $old_status, $new_status ) ) {
-			return;
-		}
-
 		$this->email_notifier->send(
 			$author->user_email,
 			$subject,
 			'application-status',
 			[
+				'user_name'        => $author->display_name,
 				'group_name'       => $post->post_title,
 				'organizer_name'   => $author->display_name,
 				'old_status'       => $old_status,
 				'new_status'       => $new_status,
 				'old_status_label' => $old_label,
 				'new_status_label' => $new_label,
-				'dashboard_url'    => admin_url( 'post.php?post=' . $post_id . '&action=edit' ),
+				'status'           => $new_label,
+				'status_message'   => self::STATUS_MESSAGES[ $new_status ] ?? '',
+				'dashboard_url'    => admin_url( 'post.php?post=' . $post->ID . '&action=edit' ),
+			]
+		);
+	}
+
+	/**
+	 * Send an admin notification when the new status requires reviewer attention.
+	 *
+	 * @param \WP_Post $post       The meetup post.
+	 * @param string   $old_status Previous status.
+	 * @param string   $new_status New status.
+	 */
+	private function notify_admins( \WP_Post $post, string $old_status, string $new_status ): void {
+		if ( ! in_array( $new_status, self::ADMIN_NOTIFY_STATUSES, true ) ) {
+			return;
+		}
+
+		/**
+		 * Filters the email address that receives admin-level transition notifications.
+		 *
+		 * Defaults to the site admin email. Can be changed to a mailing list or
+		 * distribution address.
+		 *
+		 * @param string $admin_email Admin email address.
+		 * @param int    $post_id     The meetup post ID.
+		 * @param string $new_status  The new status.
+		 */
+		$admin_email = apply_filters(
+			'groups_transition_admin_email',
+			get_option( 'admin_email' ),
+			$post->ID,
+			$new_status
+		);
+
+		if ( ! $admin_email ) {
+			return;
+		}
+
+		$old_label = self::STATUS_LABELS[ $old_status ] ?? $old_status;
+		$new_label = self::STATUS_LABELS[ $new_status ] ?? $new_status;
+
+		$admin_message = match ( $new_status ) {
+			'meetup-pending'  => sprintf(
+				'A new meetup application for <strong>%s</strong> has been submitted and is awaiting review.',
+				esc_html( $post->post_title )
+			),
+			'meetup-feedback' => sprintf(
+				'The organizer of <strong>%s</strong> has responded to feedback. Please review the updated application.',
+				esc_html( $post->post_title )
+			),
+			default           => '',
+		};
+
+		$subject = sprintf(
+			/* translators: 1: group name, 2: new status label */
+			__( 'Admin Notice: %1$s moved to %2$s', 'wordpress-groups' ),
+			$post->post_title,
+			$new_label
+		);
+
+		$this->email_notifier->send(
+			$admin_email,
+			$subject,
+			'application-status',
+			[
+				'user_name'        => 'Community Team',
+				'group_name'       => $post->post_title,
+				'old_status'       => $old_status,
+				'new_status'       => $new_status,
+				'old_status_label' => $old_label,
+				'new_status_label' => $new_label,
+				'status'           => $new_label,
+				'status_message'   => $admin_message,
+				'dashboard_url'    => admin_url( 'post.php?post=' . $post->ID . '&action=edit' ),
 			]
 		);
 	}
@@ -148,5 +272,15 @@ class Status_Transition {
 	 */
 	public static function get_status_label( string $status ): string {
 		return self::STATUS_LABELS[ $status ] ?? $status;
+	}
+
+	/**
+	 * Get the status-specific message for a given status.
+	 *
+	 * @param string $status Status slug.
+	 * @return string The message, or an empty string if none is defined.
+	 */
+	public static function get_status_message( string $status ): string {
+		return self::STATUS_MESSAGES[ $status ] ?? '';
 	}
 }


### PR DESCRIPTION
## Summary

- **Issue #31 — Status transition emails:** Enhanced `Status_Transition` to send context-specific HTML email notifications for every workflow transition. Each status now has a descriptive `status_message` that populates the existing `application-status` template. Admins are also notified when applications arrive (`meetup-pending`) or when organizers respond to feedback (`meetup-feedback`), with a filterable admin email address via `groups_transition_admin_email`.
- **Issue #35 — Recurrence sidebar panel:** Added a `PluginDocumentSettingPanel` to the event block editor that lets organizers set recurrence (None, Weekly, Biweekly, Monthly). The panel previews the next 3 occurrences by calling a new `groups/v1/recurrence-preview` REST endpoint backed by `Recurrence::calculate_occurrences`. The selected rule is persisted to `_event_recurrence_rule` post meta via the REST API.

Closes #31, Closes #35

## Test plan

- [ ] Trigger each meetup status transition and verify the organizer receives an email with the correct status-specific message
- [ ] Transition to `meetup-pending` or `meetup-feedback` and verify the admin email receives a notification
- [ ] Use the `groups_send_transition_email` filter to suppress a notification and confirm no email is sent
- [ ] Open the event editor, verify the "Recurrence" panel appears in the sidebar
- [ ] Select each frequency option and confirm the next 3 occurrences preview updates
- [ ] Save the event and verify `_event_recurrence_rule` meta is persisted correctly
- [ ] Set recurrence back to "None" and confirm the meta is cleared
- [ ] Verify the panel does not appear when editing non-event post types

🤖 Generated with [Claude Code](https://claude.com/claude-code)