### PR TITLE
Fix broken nav links, RSVP block build, and dev setup

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -16,7 +16,7 @@
 	},
 	"testsEnvironment": false,
 	"lifecycleScripts": {
-		"afterStart": "npx wp-env run cli wp plugin activate wordpress-groups && npx wp-env run cli wp theme activate groups-site && npx wp-env run cli wp eval-file wp-content/plugins/wordpress-groups/seed-data.php"
+		"afterStart": "npm run build:blocks && npx wp-env run cli wp plugin activate wordpress-groups && npx wp-env run cli wp theme activate groups-site && npx wp-env run cli wp eval-file wp-content/plugins/wordpress-groups/seed-data.php"
 	},
 	"config": {
 		"WP_DEBUG": true,

--- a/wp-content/plugins/wordpress-groups/blocks/rsvp-button/block.json
+++ b/wp-content/plugins/wordpress-groups/blocks/rsvp-button/block.json
@@ -17,8 +17,8 @@
 		"html": false,
 		"align": false
 	},
-	"editorScript": "file:./edit.js",
+	"editorScript": "file:./index.js",
 	"viewScript": "file:./view.js",
-	"style": "file:./style.css",
+	"style": "file:./style-index.css",
 	"render": "file:./render.php"
 }

--- a/wp-content/plugins/wordpress-groups/blocks/rsvp-button/index.js
+++ b/wp-content/plugins/wordpress-groups/blocks/rsvp-button/index.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies.
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import metadata from './block.json';
+import Edit from './edit';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+} );

--- a/wp-content/themes/groups-site/parts/group-navigation.html
+++ b/wp-content/themes/groups-site/parts/group-navigation.html
@@ -1,9 +1,9 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 	<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"fontSize":"small"} -->
-		<!-- wp:navigation-link {"label":"Events","url":"events/","kind":"custom"} /-->
-		<!-- wp:navigation-link {"label":"Members","url":"members/","kind":"custom"} /-->
-		<!-- wp:navigation-link {"label":"About","url":"about/","kind":"custom"} /-->
+		<!-- wp:navigation-link {"label":"Events","type":"custom","url":"/events/","kind":"custom"} /-->
+		<!-- wp:navigation-link {"label":"Members","type":"custom","url":"/members/","kind":"custom"} /-->
+		<!-- wp:navigation-link {"label":"About","type":"custom","url":"/about/","kind":"custom"} /-->
 	<!-- /wp:navigation -->
 </div>
 <!-- /wp:group -->

--- a/wp-content/themes/groups-site/parts/header.html
+++ b/wp-content/themes/groups-site/parts/header.html
@@ -9,9 +9,9 @@
 		<!-- wp:site-title /-->
 
 		<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right"}} -->
-			<!-- wp:navigation-link {"label":"Events","url":"events/","kind":"custom"} /-->
-			<!-- wp:navigation-link {"label":"Members","url":"members/","kind":"custom"} /-->
-			<!-- wp:navigation-link {"label":"About","url":"about/","kind":"custom"} /-->
+			<!-- wp:navigation-link {"label":"Events","type":"custom","url":"/events/","kind":"custom"} /-->
+			<!-- wp:navigation-link {"label":"Members","type":"custom","url":"/members/","kind":"custom"} /-->
+			<!-- wp:navigation-link {"label":"About","type":"custom","url":"/about/","kind":"custom"} /-->
 		<!-- /wp:navigation -->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
## Summary
- **Header menu links broken**: Navigation links in `header.html` and `group-navigation.html` used relative paths like `events/` which WordPress resolved to `http://events/`. Changed to absolute paths `/events/`, `/members/`, `/about/`.
- **RSVP button block not building**: The `rsvp-button` block was missing an `index.js` entry point, so webpack never compiled its SCSS into CSS. Added `index.js` (following the pattern of all other blocks) and updated `block.json` to reference `style-index.css` instead of the non-existent `style.css`.
- **Blocks not auto-built on env start**: Added `npm run build:blocks` to the wp-env `afterStart` lifecycle script so blocks are compiled automatically when running `wp-env start`.

## Test plan
- [ ] Run `npm run build:blocks` — should compile all 12 blocks successfully, including `rsvp-button/style-index.css`
- [ ] Run `wp-env start` — blocks should auto-build during startup
- [ ] Visit the homepage — nav links should point to `/events/`, `/members/`, `/about/` (not `http://events/` etc.)
- [ ] Visit a single event page — RSVP button should render with full styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)