### PR TITLE
Fix navigation links and page 404s in multisite

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -50,6 +50,7 @@ npx wp-env run cli wp option update blogdescription "Melbourne WordPress Communi
 echo ""
 echo "🌱 Seeding Melbourne with sample data..."
 npx wp-env run cli wp eval-file wp-content/plugins/wordpress-groups/seed-data.php --url="$MELBOURNE_URL" 2>/dev/null || true
+npx wp-env run cli wp rewrite flush --url="$MELBOURNE_URL" 2>/dev/null || true
 
 echo ""
 echo "🌏 Creating Tokyo sub-site..."
@@ -67,6 +68,11 @@ npx wp-env run cli wp option update blogdescription "Tokyo WordPress Community G
 echo ""
 echo "🌱 Seeding Tokyo with sample data..."
 npx wp-env run cli wp eval-file wp-content/plugins/wordpress-groups/seed-data-tokyo.php --url="$TOKYO_URL" 2>/dev/null || true
+npx wp-env run cli wp rewrite flush --url="$TOKYO_URL" 2>/dev/null || true
+
+echo ""
+echo "🔄 Flushing rewrite rules..."
+npx wp-env run cli wp rewrite flush 2>/dev/null || true
 
 echo ""
 echo "✅ Setup complete!"

--- a/wp-content/themes/groups-site/parts/group-navigation.html
+++ b/wp-content/themes/groups-site/parts/group-navigation.html
@@ -1,9 +1,9 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 	<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"left"},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"fontSize":"small"} -->
-		<!-- wp:navigation-link {"label":"Events","type":"custom","url":"/events/","kind":"custom"} /-->
-		<!-- wp:navigation-link {"label":"Members","type":"custom","url":"/members/","kind":"custom"} /-->
-		<!-- wp:navigation-link {"label":"About","type":"custom","url":"/about/","kind":"custom"} /-->
+		<!-- wp:navigation-link {"label":"Events","type":"custom","url":"events/","kind":"custom"} /-->
+		<!-- wp:navigation-link {"label":"Members","type":"custom","url":"members/","kind":"custom"} /-->
+		<!-- wp:navigation-link {"label":"About","type":"custom","url":"about/","kind":"custom"} /-->
 	<!-- /wp:navigation -->
 </div>
 <!-- /wp:group -->

--- a/wp-content/themes/groups-site/parts/header.html
+++ b/wp-content/themes/groups-site/parts/header.html
@@ -9,9 +9,9 @@
 		<!-- wp:site-title /-->
 
 		<!-- wp:navigation {"overlayMenu":"mobile","layout":{"type":"flex","justifyContent":"right"}} -->
-			<!-- wp:navigation-link {"label":"Events","type":"custom","url":"/events/","kind":"custom"} /-->
-			<!-- wp:navigation-link {"label":"Members","type":"custom","url":"/members/","kind":"custom"} /-->
-			<!-- wp:navigation-link {"label":"About","type":"custom","url":"/about/","kind":"custom"} /-->
+			<!-- wp:navigation-link {"label":"Events","type":"custom","url":"events/","kind":"custom"} /-->
+			<!-- wp:navigation-link {"label":"Members","type":"custom","url":"members/","kind":"custom"} /-->
+			<!-- wp:navigation-link {"label":"About","type":"custom","url":"about/","kind":"custom"} /-->
 		<!-- /wp:navigation -->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
## Summary
- **Navigation links**: Changed from absolute paths (`/events/`, `/members/`, `/about/`) to relative paths (`events/`, `members/`, `about/`) in both `header.html` and `group-navigation.html`. Absolute paths resolve from the root site (`/events/`) instead of the sub-site (`/melbourne/events/`), breaking navigation in sub-directory multisite installs.
- **Page 404s**: Added `wp rewrite flush` calls for Melbourne, Tokyo, and the main site in `bin/setup.sh` after seeding, so that pages created by the seed script are immediately reachable.
- **Members block**: Verified that `blocks/group-members/render.php` already correctly queries users with roles `organizer`, `co_organizer`, and `member` via `role__in`. No code change needed there.

## Test plan
- [ ] Run `bin/setup.sh` and visit `/melbourne/` — nav links should point to `/melbourne/events/`, `/melbourne/members/`, `/melbourne/about/`
- [ ] Visit `/melbourne/events/` — should render the events page (not 404)
- [ ] Visit `/melbourne/members/` — should show seeded users grouped by role
- [ ] Repeat for `/tokyo/` sub-site

🤖 Generated with [Claude Code](https://claude.com/claude-code)