### PR TITLE
Fix navigation links for multisite (use page-list)

### DIFF
--- a/wp-content/themes/groups-site/parts/group-navigation.html
+++ b/wp-content/themes/groups-site/parts/group-navigation.html
@@ -1,9 +1,7 @@
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"backgroundColor":"light-grey-2","layout":{"type":"constrained","wideSize":"1600px"},"className":"groups-site-subnav"} -->
 <div class="wp-block-group groups-site-subnav has-light-grey-2-background-color has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
 	<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"blockGap":"0"},"typography":{"fontWeight":"500"}},"fontSize":"small","className":"groups-site-subnav__nav"} -->
-		<!-- wp:navigation-link {"label":"Events","type":"custom","url":"/events/","kind":"custom"} /-->
-		<!-- wp:navigation-link {"label":"Members","type":"custom","url":"/members/","kind":"custom"} /-->
-		<!-- wp:navigation-link {"label":"About","type":"custom","url":"/about/","kind":"custom"} /-->
+		<!-- wp:page-list /-->
 	<!-- /wp:navigation -->
 </div>
 <!-- /wp:group -->

--- a/wp-content/themes/groups-site/parts/header.html
+++ b/wp-content/themes/groups-site/parts/header.html
@@ -45,9 +45,7 @@
 		<!-- wp:site-title {"level":0,"fontSize":"small","style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-0"},"typography":{"textDecoration":"none"},":hover":{"color":{"text":"var:preset|color|blueberry-1"}}}},"typography":{"fontWeight":"600"}}} /-->
 
 		<!-- wp:navigation {"overlayMenu":"mobile","overlayBackgroundColor":"white","overlayTextColor":"charcoal-1","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","style":{"typography":{"fontWeight":"500"}}} -->
-			<!-- wp:navigation-link {"label":"Events","type":"custom","url":"/events/","kind":"custom"} /-->
-			<!-- wp:navigation-link {"label":"Members","type":"custom","url":"/members/","kind":"custom"} /-->
-			<!-- wp:navigation-link {"label":"About","type":"custom","url":"/about/","kind":"custom"} /-->
+			<!-- wp:page-list /-->
 		<!-- /wp:navigation -->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
The design PR (#156) overwrote the page-list fix with hardcoded absolute URLs. This re-applies wp:page-list to both header.html and group-navigation.html.