### PR TITLE
Add event search and social sharing buttons

### DIFF
--- a/wp-content/plugins/wordpress-groups/blocks/social-share/block.json
+++ b/wp-content/plugins/wordpress-groups/blocks/social-share/block.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "groups/social-share",
+	"version": "0.1.0",
+	"title": "Social Share",
+	"category": "widgets",
+	"icon": "share",
+	"description": "Displays social sharing buttons for event pages.",
+	"textdomain": "wordpress-groups",
+	"supports": {
+		"html": false,
+		"align": false
+	},
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css",
+	"render": "file:./render.php"
+}

--- a/wp-content/plugins/wordpress-groups/blocks/social-share/index.js
+++ b/wp-content/plugins/wordpress-groups/blocks/social-share/index.js
@@ -1,0 +1,20 @@
+/**
+ * Social Share block — editor registration.
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	edit() {
+		const blockProps = useBlockProps();
+		return (
+			<div { ...blockProps }>
+				<p style={ { color: '#757575', fontStyle: 'italic' } }>
+					Social Share — rendered on the front end.
+				</p>
+			</div>
+		);
+	},
+} );

--- a/wp-content/plugins/wordpress-groups/blocks/social-share/render.php
+++ b/wp-content/plugins/wordpress-groups/blocks/social-share/render.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Server-side render for the Social Share block.
+ *
+ * Outputs share links for Twitter/X, Facebook, LinkedIn, and a copy-link button.
+ * Uses the current event's title and permalink. No external JS required.
+ *
+ * @package Groups\Blocks
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$share_url   = esc_url( get_the_permalink() );
+$share_title = rawurlencode( get_the_title() );
+$share_text  = rawurlencode( get_the_title() . ' — ' . get_the_permalink() );
+
+$wrapper_attributes = get_block_wrapper_attributes( [
+	'class' => 'wp-block-groups-social-share',
+] );
+
+// Inline SVG icons (16x16).
+$icon_x = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>';
+
+$icon_facebook = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>';
+
+$icon_linkedin = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>';
+
+$icon_link = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>';
+
+$links = [
+	[
+		'label' => __( 'Share on X', 'wordpress-groups' ),
+		'url'   => 'https://x.com/intent/tweet?text=' . $share_text,
+		'icon'  => $icon_x,
+		'class' => 'wp-block-groups-social-share__link--x',
+	],
+	[
+		'label' => __( 'Share on Facebook', 'wordpress-groups' ),
+		'url'   => 'https://www.facebook.com/sharer/sharer.php?u=' . $share_url,
+		'icon'  => $icon_facebook,
+		'class' => 'wp-block-groups-social-share__link--facebook',
+	],
+	[
+		'label' => __( 'Share on LinkedIn', 'wordpress-groups' ),
+		'url'   => 'https://www.linkedin.com/sharing/share-offsite/?url=' . $share_url,
+		'icon'  => $icon_linkedin,
+		'class' => 'wp-block-groups-social-share__link--linkedin',
+	],
+	[
+		'label' => __( 'Copy link', 'wordpress-groups' ),
+		'url'   => $share_url,
+		'icon'  => $icon_link,
+		'class' => 'wp-block-groups-social-share__link--copy',
+		'extra' => ' data-share-url="' . esc_attr( get_the_permalink() ) . '" onclick="navigator.clipboard.writeText(this.dataset.shareUrl);this.querySelector(\'span\').textContent=\'' . esc_js( __( 'Copied!', 'wordpress-groups' ) ) . '\';return false;"',
+	],
+];
+?>
+
+<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+	<?php foreach ( $links as $link ) : ?>
+		<a
+			href="<?php echo esc_url( $link['url'] ); ?>"
+			class="wp-block-groups-social-share__link <?php echo esc_attr( $link['class'] ); ?>"
+			aria-label="<?php echo esc_attr( $link['label'] ); ?>"
+			target="_blank"
+			rel="noopener noreferrer"
+			<?php echo isset( $link['extra'] ) ? $link['extra'] : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		>
+			<?php echo $link['icon']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			<span><?php echo esc_html( $link['label'] ); ?></span>
+		</a>
+	<?php endforeach; ?>
+</div>

--- a/wp-content/plugins/wordpress-groups/blocks/social-share/style.scss
+++ b/wp-content/plugins/wordpress-groups/blocks/social-share/style.scss
@@ -1,0 +1,63 @@
+/**
+ * Social Share block styles.
+ *
+ * Horizontal row of icon buttons with accessible focus styles.
+ */
+
+.wp-block-groups-social-share {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	align-items: center;
+
+	&__link {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 8px 14px;
+		border: 1px solid var(--wp--preset--color--light-grey-1, #dcdcde);
+		border-radius: 4px;
+		background: var(--wp--preset--color--white, #fff);
+		color: var(--wp--preset--color--charcoal-4, #50575e);
+		font-size: 14px;
+		font-weight: 500;
+		line-height: 1.4;
+		text-decoration: none;
+		transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+		min-height: 40px;
+		cursor: pointer;
+
+		svg {
+			flex-shrink: 0;
+		}
+
+		&:hover {
+			background-color: var(--wp--preset--color--light-grey-2, #f0f0f1);
+			border-color: var(--wp--preset--color--charcoal-4, #50575e);
+			color: var(--wp--preset--color--charcoal-1, #1d2327);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--wp--preset--color--blueberry-1, #3858e9);
+			outline-offset: 2px;
+			box-shadow: 0 0 0 2px var(--wp--preset--color--white, #fff);
+		}
+
+		// Platform-specific hover colours.
+		&--x:hover {
+			color: #000;
+		}
+
+		&--facebook:hover {
+			color: #1877f2;
+		}
+
+		&--linkedin:hover {
+			color: #0a66c2;
+		}
+
+		&--copy:hover {
+			color: var(--wp--preset--color--blueberry-1, #3858e9);
+		}
+	}
+}

--- a/wp-content/themes/groups-site/templates/archive-event.html
+++ b/wp-content/themes/groups-site/templates/archive-event.html
@@ -7,6 +7,8 @@
 	<h1 class="wp-block-heading has-heading-1-font-size">Events</h1>
 	<!-- /wp:heading -->
 
+	<!-- wp:search {"label":"Search events","placeholder":"Search events\u2026","query":{"post_type":"event"},"buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"className":"wp-block-groups-event-search"} /-->
+
 	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained","wideSize":"1600px","justifyContent":"left"}} -->
 	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--60)">
 		<!-- wp:heading {"level":2,"fontSize":"heading-2"} -->

--- a/wp-content/themes/groups-site/templates/single-event.html
+++ b/wp-content/themes/groups-site/templates/single-event.html
@@ -58,6 +58,16 @@
 				<!-- /wp:separator -->
 
 				<!-- wp:groups/rsvp-button /-->
+
+				<!-- wp:separator {"className":"is-style-wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"color":"light-grey-1"} -->
+				<hr class="wp-block-separator has-text-color has-light-grey-1-color has-alpha-channel-opacity has-light-grey-1-background-color has-background is-style-wide" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)"/>
+				<!-- /wp:separator -->
+
+				<!-- wp:heading {"level":3,"fontSize":"heading-5","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}}} -->
+				<h3 class="wp-block-heading has-heading-5-font-size" style="margin-bottom:var(--wp--preset--spacing--10)">Share</h3>
+				<!-- /wp:heading -->
+
+				<!-- wp:groups/social-share /-->
 			</div>
 			<!-- /wp:group -->
 		</div>


### PR DESCRIPTION
## Summary
- **Issue #128**: Added a WordPress `wp:search` block to the `archive-event.html` template with `post_type=event` filtering, allowing users to search events by title/content.
- **Issue #127**: Created a new `groups/social-share` server-rendered block (`blocks/social-share/`) with share links for X, Facebook, LinkedIn, and a copy-link button. Uses inline SVG icons, plain `<a>` tags with share URLs, and no external JS. Added to the single-event sidebar.

Closes #127, Closes #128

## Test plan
- [ ] Visit the event archive page and verify the search form appears between the heading and upcoming events
- [ ] Enter a search term and confirm results are filtered to events only
- [ ] Visit a single event page and verify share buttons appear in the sidebar below the RSVP button
- [ ] Click each share link (X, Facebook, LinkedIn) and verify the correct share dialog opens with the event URL/title
- [ ] Click the "Copy link" button and verify the event URL is copied to clipboard
- [ ] Run `npm run build:blocks` and verify the social-share block compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)