### PR TITLE
Add notification preferences UI block

### DIFF
--- a/wp-content/plugins/wordpress-groups/blocks/notification-preferences/block.json
+++ b/wp-content/plugins/wordpress-groups/blocks/notification-preferences/block.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "groups/notification-preferences",
+	"version": "0.1.0",
+	"title": "Notification Preferences",
+	"category": "widgets",
+	"description": "Displays toggle switches for managing user notification preferences (event reminders, announcements, RSVP confirmations).",
+	"textdomain": "wordpress-groups",
+	"supports": {
+		"html": false,
+		"align": false
+	},
+	"editorScript": "file:./index.js",
+	"viewScript": "file:./view.js",
+	"style": "file:./style-index.css",
+	"render": "file:./render.php"
+}

--- a/wp-content/plugins/wordpress-groups/blocks/notification-preferences/edit.js
+++ b/wp-content/plugins/wordpress-groups/blocks/notification-preferences/edit.js
@@ -1,0 +1,67 @@
+/**
+ * Notification Preferences — editor component.
+ *
+ * Shows a placeholder preview in the block editor.
+ */
+
+import { createElement } from '@wordpress/element';
+import { useBlockProps } from '@wordpress/block-editor';
+import { Placeholder } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Edit component for the Notification Preferences block.
+ */
+export default function Edit() {
+	const blockProps = useBlockProps();
+
+	return createElement(
+		'div',
+		blockProps,
+		createElement(
+			Placeholder,
+			{
+				icon: 'bell',
+				label: __( 'Notification Preferences', 'wordpress-groups' ),
+				instructions: __(
+					'This block displays notification preference toggles for logged-in users on the frontend.',
+					'wordpress-groups'
+				),
+			},
+			createElement(
+				'div',
+				{ className: 'wp-block-groups-notification-preferences__preview' },
+				createElement(
+					'div',
+					{ className: 'wp-block-groups-notification-preferences__item' },
+					createElement( 'span', null, __( 'Event Reminders', 'wordpress-groups' ) ),
+					createElement(
+						'span',
+						{ className: 'wp-block-groups-notification-preferences__toggle-preview' },
+						__( 'On', 'wordpress-groups' )
+					)
+				),
+				createElement(
+					'div',
+					{ className: 'wp-block-groups-notification-preferences__item' },
+					createElement( 'span', null, __( 'Announcements', 'wordpress-groups' ) ),
+					createElement(
+						'span',
+						{ className: 'wp-block-groups-notification-preferences__toggle-preview' },
+						__( 'On', 'wordpress-groups' )
+					)
+				),
+				createElement(
+					'div',
+					{ className: 'wp-block-groups-notification-preferences__item' },
+					createElement( 'span', null, __( 'RSVP Confirmations', 'wordpress-groups' ) ),
+					createElement(
+						'span',
+						{ className: 'wp-block-groups-notification-preferences__toggle-preview' },
+						__( 'On', 'wordpress-groups' )
+					)
+				)
+			)
+		)
+	);
+}

--- a/wp-content/plugins/wordpress-groups/blocks/notification-preferences/index.js
+++ b/wp-content/plugins/wordpress-groups/blocks/notification-preferences/index.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies.
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies.
+ */
+import metadata from './block.json';
+import Edit from './edit';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+} );

--- a/wp-content/plugins/wordpress-groups/blocks/notification-preferences/render.php
+++ b/wp-content/plugins/wordpress-groups/blocks/notification-preferences/render.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Server-side render for the Notification Preferences block.
+ *
+ * Provides initial preference state so the view script can hydrate.
+ * Only renders for logged-in users.
+ *
+ * @package Groups
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! is_user_logged_in() ) {
+	return;
+}
+
+$user_id = get_current_user_id();
+
+$notification_types = [
+	'event_reminders'    => __( 'Event Reminders', 'wordpress-groups' ),
+	'announcements'      => __( 'Announcements', 'wordpress-groups' ),
+	'rsvp_confirmations' => __( 'RSVP Confirmations', 'wordpress-groups' ),
+];
+
+$descriptions = [
+	'event_reminders'    => __( 'Get notified before events you have RSVP\'d to.', 'wordpress-groups' ),
+	'announcements'      => __( 'Receive group announcements and updates.', 'wordpress-groups' ),
+	'rsvp_confirmations' => __( 'Get confirmation emails when you RSVP to events.', 'wordpress-groups' ),
+];
+
+$preferences = [];
+foreach ( array_keys( $notification_types ) as $type ) {
+	$preferences[ $type ] = \Groups\Notifications\User_Preferences::is_opted_in( $user_id, $type );
+}
+
+$wrapper_attributes = get_block_wrapper_attributes( [
+	'class'            => 'wp-block-groups-notification-preferences',
+	'data-preferences' => wp_json_encode( $preferences ),
+	'data-nonce'       => wp_create_nonce( 'wp_rest' ),
+] );
+
+?>
+<div <?php echo $wrapper_attributes; ?>>
+	<h3 class="wp-block-groups-notification-preferences__heading">
+		<?php esc_html_e( 'Notification Preferences', 'wordpress-groups' ); ?>
+	</h3>
+	<p class="wp-block-groups-notification-preferences__description">
+		<?php esc_html_e( 'Choose which notifications you would like to receive.', 'wordpress-groups' ); ?>
+	</p>
+	<div class="wp-block-groups-notification-preferences__list">
+		<?php foreach ( $notification_types as $type => $label ) : ?>
+			<div
+				class="wp-block-groups-notification-preferences__item"
+				data-type="<?php echo esc_attr( $type ); ?>"
+			>
+				<div class="wp-block-groups-notification-preferences__item-info">
+					<label
+						class="wp-block-groups-notification-preferences__label"
+						for="notification-pref-<?php echo esc_attr( $type ); ?>"
+					>
+						<?php echo esc_html( $label ); ?>
+					</label>
+					<span class="wp-block-groups-notification-preferences__item-description">
+						<?php echo esc_html( $descriptions[ $type ] ); ?>
+					</span>
+				</div>
+				<button
+					type="button"
+					role="switch"
+					id="notification-pref-<?php echo esc_attr( $type ); ?>"
+					class="wp-block-groups-notification-preferences__toggle <?php echo $preferences[ $type ] ? 'is-checked' : ''; ?>"
+					aria-checked="<?php echo $preferences[ $type ] ? 'true' : 'false'; ?>"
+				>
+					<span class="wp-block-groups-notification-preferences__toggle-track">
+						<span class="wp-block-groups-notification-preferences__toggle-thumb"></span>
+					</span>
+					<span class="screen-reader-text">
+						<?php
+						printf(
+							/* translators: %s: notification type label */
+							esc_html__( 'Toggle %s', 'wordpress-groups' ),
+							esc_html( $label )
+						);
+						?>
+					</span>
+				</button>
+			</div>
+		<?php endforeach; ?>
+	</div>
+	<div class="wp-block-groups-notification-preferences__status" aria-live="polite"></div>
+</div>

--- a/wp-content/plugins/wordpress-groups/blocks/notification-preferences/style.scss
+++ b/wp-content/plugins/wordpress-groups/blocks/notification-preferences/style.scss
@@ -1,0 +1,175 @@
+/**
+ * Notification Preferences block styles.
+ *
+ * Clean toggle/switch UI following WordPress.org design language.
+ */
+
+.wp-block-groups-notification-preferences {
+	max-width: 600px;
+
+	&__heading {
+		margin: 0 0 8px;
+		font-size: 20px;
+		font-weight: 600;
+		line-height: 1.4;
+	}
+
+	&__description {
+		margin: 0 0 24px;
+		font-size: 14px;
+		color: var(--wp--preset--color--charcoal-4, #656a71);
+		line-height: 1.5;
+	}
+
+	// List of preference items.
+	&__list {
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+	}
+
+	// Single preference row.
+	&__item {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+		padding: 16px 0;
+		border-bottom: 1px solid var(--wp--preset--color--light-grey-1, #e0e0e0);
+
+		&:first-child {
+			border-top: 1px solid var(--wp--preset--color--light-grey-1, #e0e0e0);
+		}
+	}
+
+	&__item-info {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		flex: 1;
+		min-width: 0;
+	}
+
+	&__label {
+		font-size: 16px;
+		font-weight: 500;
+		line-height: 1.4;
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		cursor: pointer;
+	}
+
+	&__item-description {
+		font-size: 13px;
+		color: var(--wp--preset--color--charcoal-4, #656a71);
+		line-height: 1.4;
+	}
+
+	// Toggle switch.
+	&__toggle {
+		appearance: none;
+		position: relative;
+		flex-shrink: 0;
+		width: 44px;
+		height: 24px;
+		padding: 0;
+		border: 2px solid var(--wp--preset--color--charcoal-4, #656a71);
+		border-radius: 12px;
+		background: var(--wp--preset--color--white, #fff);
+		cursor: pointer;
+		transition: background-color 0.15s ease, border-color 0.15s ease;
+
+		&:hover {
+			border-color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		}
+
+		// Accessible focus styles.
+		&:focus-visible {
+			outline: 2px solid var(--wp--preset--color--blueberry-1, #3858e9);
+			outline-offset: 2px;
+			box-shadow: 0 0 0 2px var(--wp--preset--color--white, #fff);
+		}
+
+		// Checked state.
+		&.is-checked {
+			background-color: var(--wp--preset--color--blueberry-1, #3858e9);
+			border-color: var(--wp--preset--color--blueberry-1, #3858e9);
+
+			&:hover {
+				background-color: var(--wp--preset--color--deep-blueberry, #2145e6);
+				border-color: var(--wp--preset--color--deep-blueberry, #2145e6);
+			}
+
+			.wp-block-groups-notification-preferences__toggle-thumb {
+				transform: translateX(20px);
+				background-color: var(--wp--preset--color--white, #fff);
+			}
+		}
+	}
+
+	&__toggle-track {
+		display: flex;
+		align-items: center;
+		width: 100%;
+		height: 100%;
+		pointer-events: none;
+	}
+
+	&__toggle-thumb {
+		display: block;
+		width: 16px;
+		height: 16px;
+		border-radius: 50%;
+		background-color: var(--wp--preset--color--charcoal-4, #656a71);
+		transform: translateX(2px);
+		transition: transform 0.15s ease, background-color 0.15s ease;
+		pointer-events: none;
+	}
+
+	// Status message area.
+	&__status {
+		min-height: 24px;
+		margin-top: 16px;
+		font-size: 14px;
+		line-height: 1.5;
+		transition: opacity 0.2s ease;
+
+		&--success {
+			color: #00a32a;
+		}
+
+		&--error {
+			color: #cc1818;
+		}
+
+		&:empty {
+			margin-top: 0;
+		}
+	}
+
+	// Editor preview.
+	&__preview {
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+		padding: 12px 0;
+
+		.wp-block-groups-notification-preferences__item {
+			display: flex;
+			justify-content: space-between;
+			padding: 8px 0;
+			border-bottom: 1px solid #e0e0e0;
+			font-size: 14px;
+
+			&:first-child {
+				border-top: 1px solid #e0e0e0;
+			}
+		}
+	}
+
+	&__toggle-preview {
+		font-size: 13px;
+		color: #00a32a;
+		font-weight: 500;
+	}
+}

--- a/wp-content/plugins/wordpress-groups/blocks/notification-preferences/view.js
+++ b/wp-content/plugins/wordpress-groups/blocks/notification-preferences/view.js
@@ -1,0 +1,137 @@
+/**
+ * Notification Preferences — frontend interactive script.
+ *
+ * Hydrates the server-rendered toggle switches and saves preferences
+ * via the REST API.
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Debounce helper — delays function execution until after a pause.
+ *
+ * @param {Function} fn    Function to debounce.
+ * @param {number}   delay Delay in milliseconds.
+ * @return {Function} Debounced function.
+ */
+function debounce( fn, delay ) {
+	let timer;
+	return ( ...args ) => {
+		clearTimeout( timer );
+		timer = setTimeout( () => fn( ...args ), delay );
+	};
+}
+
+/**
+ * Initialise a single notification preferences block.
+ *
+ * @param {HTMLElement} container The block root element.
+ */
+function initBlock( container ) {
+	const prefsData = container.dataset.preferences;
+	const preferences = prefsData ? JSON.parse( prefsData ) : {};
+	const statusEl = container.querySelector(
+		'.wp-block-groups-notification-preferences__status'
+	);
+	const toggles = container.querySelectorAll(
+		'.wp-block-groups-notification-preferences__toggle'
+	);
+
+	/**
+	 * Show a temporary status message.
+	 *
+	 * @param {string} message  The message to display.
+	 * @param {string} type     'success' or 'error'.
+	 */
+	function showStatus( message, type ) {
+		if ( ! statusEl ) {
+			return;
+		}
+		statusEl.textContent = message;
+		statusEl.className =
+			'wp-block-groups-notification-preferences__status wp-block-groups-notification-preferences__status--' +
+			type;
+
+		if ( type === 'success' ) {
+			setTimeout( () => {
+				statusEl.textContent = '';
+				statusEl.className =
+					'wp-block-groups-notification-preferences__status';
+			}, 3000 );
+		}
+	}
+
+	/**
+	 * Save a single preference to the server.
+	 *
+	 * @param {string}  type    Notification type key.
+	 * @param {boolean} enabled Whether the notification is enabled.
+	 */
+	const savePreference = debounce( async ( type, enabled ) => {
+		try {
+			await apiFetch( {
+				path: '/groups/v1/preferences',
+				method: 'PUT',
+				data: { [ type ]: enabled },
+			} );
+			showStatus(
+				__( 'Preferences saved.', 'wordpress-groups' ),
+				'success'
+			);
+		} catch ( err ) {
+			showStatus(
+				err.message ||
+					__(
+						'Failed to save preferences. Please try again.',
+						'wordpress-groups'
+					),
+				'error'
+			);
+		}
+	}, 300 );
+
+	toggles.forEach( ( toggle ) => {
+		toggle.addEventListener( 'click', () => {
+			const item = toggle.closest(
+				'.wp-block-groups-notification-preferences__item'
+			);
+			const type = item?.dataset.type;
+			if ( ! type ) {
+				return;
+			}
+
+			const isCurrentlyChecked = toggle.getAttribute( 'aria-checked' ) === 'true';
+			const newValue = ! isCurrentlyChecked;
+
+			// Update the UI immediately.
+			toggle.setAttribute( 'aria-checked', String( newValue ) );
+			toggle.classList.toggle( 'is-checked', newValue );
+
+			// Update local state.
+			preferences[ type ] = newValue;
+
+			// Save to server.
+			savePreference( type, newValue );
+		} );
+	} );
+}
+
+/**
+ * Initialise all notification preference blocks on the page.
+ */
+function init() {
+	const containers = document.querySelectorAll(
+		'.wp-block-groups-notification-preferences[data-preferences]'
+	);
+	containers.forEach( initBlock );
+}
+
+// Hydrate when the DOM is ready (skip during tests).
+if ( typeof document !== 'undefined' ) {
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -96,5 +96,8 @@ class Plugin {
 
 		$directory_controller = new REST\Directory_Controller();
 		$directory_controller->register_routes();
+
+		$preferences_controller = new REST\Preferences_Controller();
+		$preferences_controller->register_routes();
 	}
 }

--- a/wp-content/plugins/wordpress-groups/includes/rest/class-preferences-controller.php
+++ b/wp-content/plugins/wordpress-groups/includes/rest/class-preferences-controller.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * REST API controller for user notification preferences.
+ *
+ * @package Groups\REST
+ */
+
+namespace Groups\REST;
+
+use Groups\Notifications\User_Preferences;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles reading and updating notification preferences via the REST API.
+ *
+ * Endpoint: /groups/v1/preferences
+ */
+class Preferences_Controller extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST routes.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'groups/v1';
+
+	/**
+	 * Base path for preferences routes.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'preferences';
+
+	/**
+	 * Register REST routes.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_items' ],
+					'permission_callback' => [ $this, 'get_items_permissions_check' ],
+				],
+				[
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => [ $this, 'update_items' ],
+					'permission_callback' => [ $this, 'update_items_permissions_check' ],
+					'args'                => $this->get_update_args(),
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Permission check for reading preferences — must be logged in.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to view notification preferences.', 'wordpress-groups' ),
+				[ 'status' => 401 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieve the current user's notification preferences.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$user_id = get_current_user_id();
+		$prefs   = [];
+
+		foreach ( User_Preferences::TYPES as $type ) {
+			$prefs[ $type ] = User_Preferences::is_opted_in( $user_id, $type );
+		}
+
+		return new WP_REST_Response( $prefs, 200 );
+	}
+
+	/**
+	 * Permission check for updating preferences — must be logged in.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function update_items_permissions_check( $request ) {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to update notification preferences.', 'wordpress-groups' ),
+				[ 'status' => 401 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Update the current user's notification preferences.
+	 *
+	 * Accepts one or more notification type keys with boolean values.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_items( WP_REST_Request $request ) {
+		$user_id = get_current_user_id();
+		$updated = [];
+
+		foreach ( User_Preferences::TYPES as $type ) {
+			$value = $request->get_param( $type );
+
+			if ( null === $value ) {
+				continue;
+			}
+
+			$enabled = (bool) $value;
+			$result  = User_Preferences::set_preference( $user_id, $type, $enabled );
+
+			if ( ! $result ) {
+				return new WP_Error(
+					'rest_preference_update_failed',
+					sprintf(
+						/* translators: %s: notification type */
+						__( 'Failed to update preference for "%s".', 'wordpress-groups' ),
+						$type
+					),
+					[ 'status' => 500 ]
+				);
+			}
+
+			$updated[ $type ] = $enabled;
+		}
+
+		if ( empty( $updated ) ) {
+			return new WP_Error(
+				'rest_no_preferences_provided',
+				__( 'No valid notification preferences were provided.', 'wordpress-groups' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		// Return the full current state.
+		$prefs = [];
+		foreach ( User_Preferences::TYPES as $type ) {
+			$prefs[ $type ] = User_Preferences::is_opted_in( $user_id, $type );
+		}
+
+		return new WP_REST_Response( $prefs, 200 );
+	}
+
+	/**
+	 * Build argument definitions for the update endpoint.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	private function get_update_args(): array {
+		$args = [];
+
+		foreach ( User_Preferences::TYPES as $type ) {
+			$args[ $type ] = [
+				'description' => sprintf(
+					/* translators: %s: notification type */
+					__( 'Enable or disable %s notifications.', 'wordpress-groups' ),
+					str_replace( '_', ' ', $type )
+				),
+				'type'     => 'boolean',
+				'required' => false,
+			];
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Get the preferences schema for responses.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_item_schema(): array {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$properties = [];
+
+		foreach ( User_Preferences::TYPES as $type ) {
+			$properties[ $type ] = [
+				'description' => sprintf(
+					/* translators: %s: notification type */
+					__( 'Whether %s notifications are enabled.', 'wordpress-groups' ),
+					str_replace( '_', ' ', $type )
+				),
+				'type'    => 'boolean',
+				'context' => [ 'view', 'edit' ],
+			];
+		}
+
+		$this->schema = [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'notification-preferences',
+			'type'       => 'object',
+			'properties' => $properties,
+		];
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/seed-data.php
+++ b/wp-content/plugins/wordpress-groups/seed-data.php
@@ -232,6 +232,10 @@ $pages = [
 		'title'   => 'About',
 		'content' => "<!-- wp:heading -->\n<h2>About WordPress Melbourne</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>We're a friendly community of WordPress enthusiasts in Melbourne, Australia. We meet regularly to learn, share, and connect.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Whether you're a developer, designer, content creator, or just getting started with WordPress — you're welcome here!</p>\n<!-- /wp:paragraph -->",
 	],
+	'settings' => [
+		'title'   => 'Settings',
+		'content' => "<!-- wp:heading -->\n<h2>Your Settings</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Manage your notification preferences and account settings.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:groups/notification-preferences /-->",
+	],
 ];
 
 foreach ( $pages as $slug => $page_data ) {
@@ -247,7 +251,7 @@ foreach ( $pages as $slug => $page_data ) {
 		] );
 	}
 }
-echo "✓ Pages created (events, members, about).\n";
+echo "✓ Pages created (events, members, about, settings).\n";
 
 // Set front page to show events.
 $front = get_page_by_path( 'events' );


### PR DESCRIPTION
## Summary
- Create `groups/notification-preferences` block with server-rendered toggle switches for event reminders, announcements, and RSVP confirmations (only visible to logged-in users)
- Add `PUT /groups/v1/preferences` REST endpoint via new `Preferences_Controller` that reads and updates user notification preferences using the existing `User_Preferences` backend
- Add a `/settings/` page to seed data containing the notification preferences block

## Details

### Block (`blocks/notification-preferences/`)
- **render.php**: Server-renders toggle switches with initial preference state from `User_Preferences::is_opted_in()`. Hidden for logged-out users.
- **view.js**: Hydrates toggles with click handlers that call the REST endpoint. Uses optimistic UI updates with debounced saves and status messages.
- **style.scss**: Clean toggle/switch UI with accessible focus styles, following WordPress.org design language.
- **edit.js / index.js**: Editor placeholder preview.

### REST Endpoint (`includes/rest/class-preferences-controller.php`)
- `GET /groups/v1/preferences` — returns current user's preferences
- `PUT /groups/v1/preferences` — accepts one or more notification type keys with boolean values

### Integration
- Registered in `Plugin::register_rest_routes()`
- Settings page added to seed data

## Test plan
- [ ] Visit `/settings/` as a logged-in user and verify three toggles appear
- [ ] Toggle each preference and confirm "Preferences saved" status message
- [ ] Refresh the page and confirm preferences persist
- [ ] Visit `/settings/` as a logged-out user and verify block is hidden
- [ ] Test `PUT /groups/v1/preferences` endpoint directly with `{ "event_reminders": false }`
- [ ] Verify 401 response when calling endpoint without authentication

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)