### PR TITLE
Implement visual design spec for groups-site theme

### DIFF
--- a/wp-content/themes/groups-site/assets/css/custom.css
+++ b/wp-content/themes/groups-site/assets/css/custom.css
@@ -1,0 +1,1123 @@
+/**
+ * Custom styles for Groups Site theme.
+ *
+ * Implements component designs from the design spec (DESIGN-SPEC.md).
+ * Uses CSS custom properties from theme.json.
+ *
+ * @package Groups_Site
+ */
+
+/* ==========================================================================
+   CSS Custom Properties
+   ========================================================================== */
+
+:root {
+	/* Font stacks */
+	--font-heading: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+	--font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+	--font-mono: 'JetBrains Mono', 'IBM Plex Mono', 'Fira Code', monospace;
+
+	/* Type scale */
+	--text-h1: clamp(32px, 2rem + 1.8vw, 56px);
+	--text-h2: clamp(26px, 1.625rem + 1.2vw, 42px);
+	--text-h3: clamp(22px, 1.375rem + 0.6vw, 30px);
+	--text-h4: clamp(18px, 1.125rem + 0.4vw, 24px);
+	--text-h5: clamp(16px, 1rem + 0.2vw, 20px);
+	--text-h6: clamp(14px, 0.875rem + 0.1vw, 16px);
+	--text-body: clamp(15px, 0.9375rem + 0.1vw, 17px);
+	--text-body-lg: clamp(17px, 1.0625rem + 0.15vw, 19px);
+	--text-small: clamp(13px, 0.8125rem + 0.05vw, 14px);
+	--text-caption: clamp(11px, 0.6875rem, 12px);
+
+	/* Spacing */
+	--edge-space: clamp(16px, 4vw, 80px);
+
+	/* Layout widths */
+	--content-sm: 640px;
+	--content-md: 768px;
+	--content-lg: 960px;
+	--content-xl: 1120px;
+	--page-max: 1280px;
+
+	/* Border radius */
+	--radius-sm: 4px;
+	--radius-md: 8px;
+	--radius-lg: 12px;
+	--radius-xl: 16px;
+	--radius-full: 9999px;
+
+	/* Shadows */
+	--shadow-sm: 0 1px 2px rgba(20, 17, 24, 0.05);
+	--shadow-md: 0 2px 8px rgba(20, 17, 24, 0.08), 0 1px 2px rgba(20, 17, 24, 0.04);
+	--shadow-lg: 0 8px 24px rgba(20, 17, 24, 0.12), 0 2px 8px rgba(20, 17, 24, 0.06);
+	--shadow-xl: 0 16px 48px rgba(20, 17, 24, 0.16), 0 4px 12px rgba(20, 17, 24, 0.08);
+}
+
+/* ==========================================================================
+   Global resets / base
+   ========================================================================== */
+
+*:focus-visible {
+	outline: 2px solid var(--wp--preset--color--primary-500);
+	outline-offset: 2px;
+}
+
+/* Skip link */
+.skip-link {
+	position: absolute;
+	top: -100px;
+	left: 8px;
+	z-index: 999;
+	padding: 8px 16px;
+	background: var(--wp--preset--color--primary-700);
+	color: var(--wp--preset--color--neutral-0);
+	font-family: var(--font-body);
+	font-size: var(--text-small);
+	font-weight: 600;
+	border-radius: var(--radius-md);
+	text-decoration: none;
+}
+
+.skip-link:focus {
+	top: 8px;
+}
+
+/* ==========================================================================
+   Local Header (Group navigation)
+   ========================================================================== */
+
+.groups-site-local-header {
+	position: sticky;
+	top: 0;
+	z-index: 100;
+	backdrop-filter: blur(8px);
+	background: rgba(255, 255, 255, 0.9) !important;
+}
+
+.groups-site-local-header .wp-block-navigation a {
+	color: var(--wp--preset--color--neutral-700);
+	text-decoration: none;
+	font-weight: 500;
+	font-size: var(--text-small);
+	transition: color 0.15s ease;
+}
+
+.groups-site-local-header .wp-block-navigation a:hover {
+	color: var(--wp--preset--color--neutral-950);
+}
+
+.groups-site-local-header .wp-block-navigation .current-menu-item > a {
+	color: var(--wp--preset--color--primary-700);
+	border-bottom: 2px solid var(--wp--preset--color--primary-500);
+	padding-bottom: 2px;
+}
+
+/* ==========================================================================
+   Sub-navigation (Group sections)
+   ========================================================================== */
+
+.groups-site-subnav {
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+	scrollbar-width: none;
+}
+
+.groups-site-subnav::-webkit-scrollbar {
+	display: none;
+}
+
+.groups-site-subnav__nav .wp-block-navigation-item a {
+	display: block;
+	padding: 12px 16px;
+	text-decoration: none;
+	color: var(--wp--preset--color--neutral-600);
+	font-size: var(--text-small);
+	font-weight: 500;
+	border-bottom: 2px solid transparent;
+	transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.groups-site-subnav__nav .wp-block-navigation-item a:hover {
+	color: var(--wp--preset--color--neutral-800);
+}
+
+.groups-site-subnav__nav .wp-block-navigation-item.current-menu-item a {
+	color: var(--wp--preset--color--neutral-950);
+	border-bottom-color: var(--wp--preset--color--primary-500);
+}
+
+/* ==========================================================================
+   Hero section
+   ========================================================================== */
+
+.groups-site-hero {
+	background-color: var(--wp--preset--color--neutral-100) !important;
+}
+
+.groups-site-hero .groups-site-hero__stats {
+	font-size: var(--text-small);
+	color: var(--wp--preset--color--neutral-500);
+}
+
+/* Overline text pattern */
+.groups-site-overline {
+	font-family: var(--font-body);
+	font-size: var(--text-caption);
+	font-weight: 600;
+	line-height: 1.2;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--wp--preset--color--neutral-500);
+}
+
+.groups-site-overline--primary {
+	color: var(--wp--preset--color--primary-500);
+}
+
+/* ==========================================================================
+   Event Cards
+   ========================================================================== */
+
+.wp-block-groups-event-card {
+	background: var(--wp--preset--color--neutral-0);
+	border: 1px solid var(--wp--preset--color--neutral-200);
+	border-radius: var(--radius-lg);
+	box-shadow: var(--shadow-sm);
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	min-width: 280px;
+	text-decoration: none;
+	color: inherit;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.wp-block-groups-event-card {
+		transition: box-shadow 0.2s ease-out, border-color 0.2s ease-out, transform 0.2s ease-out;
+	}
+}
+
+.wp-block-groups-event-card:hover {
+	box-shadow: var(--shadow-lg);
+	border-color: var(--wp--preset--color--neutral-300);
+	transform: translateY(-2px);
+}
+
+.wp-block-groups-event-card:focus-visible {
+	outline: 2px solid var(--wp--preset--color--primary-500);
+	outline-offset: 2px;
+	box-shadow: var(--shadow-sm);
+}
+
+.wp-block-groups-event-card a {
+	text-decoration: none;
+	color: inherit;
+}
+
+/* Card thumbnail */
+.wp-block-groups-event-card__thumbnail {
+	width: 100%;
+	height: 180px;
+	overflow: hidden;
+	position: relative;
+	background: linear-gradient(135deg, var(--wp--preset--color--primary-100), var(--wp--preset--color--accent-100));
+}
+
+.wp-block-groups-event-card__thumbnail img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.wp-block-groups-event-card__thumbnail img {
+		transition: transform 0.2s ease-out;
+	}
+
+	.wp-block-groups-event-card:hover .wp-block-groups-event-card__thumbnail img {
+		transform: scale(1.03);
+	}
+}
+
+/* Past event overlay */
+.wp-block-groups-event-card--past .wp-block-groups-event-card__thumbnail::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	background: rgba(28, 25, 34, 0.4);
+}
+
+.wp-block-groups-event-card__past-badge {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	z-index: 1;
+	font-family: var(--font-body);
+	font-size: var(--text-caption);
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--wp--preset--color--neutral-0);
+	background: var(--wp--preset--color--neutral-700);
+	border-radius: var(--radius-sm);
+	padding: 4px 8px;
+}
+
+/* Card content */
+.wp-block-groups-event-card__content {
+	padding: 24px;
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+	flex: 1;
+}
+
+.wp-block-groups-event-card__date {
+	font-family: var(--font-body);
+	font-size: var(--text-caption);
+	font-weight: 600;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--wp--preset--color--neutral-500);
+	line-height: 1.2;
+	margin-bottom: 8px;
+}
+
+.wp-block-groups-event-card__title {
+	font-family: var(--font-heading);
+	font-size: var(--text-h4);
+	font-weight: 600;
+	color: var(--wp--preset--color--neutral-950);
+	line-height: 1.3;
+	letter-spacing: -0.01em;
+	margin-bottom: 12px;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.wp-block-groups-event-card__location {
+	font-size: var(--text-small);
+	color: var(--wp--preset--color--neutral-600);
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-bottom: 16px;
+}
+
+.wp-block-groups-event-card__location svg {
+	flex-shrink: 0;
+	width: 16px;
+	height: 16px;
+}
+
+.wp-block-groups-event-card__footer {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-top: auto;
+}
+
+.wp-block-groups-event-card__avatars {
+	display: flex;
+}
+
+.wp-block-groups-event-card__avatars img {
+	width: 24px;
+	height: 24px;
+	border-radius: var(--radius-full);
+	border: 2px solid var(--wp--preset--color--neutral-0);
+	margin-left: -8px;
+}
+
+.wp-block-groups-event-card__avatars img:first-child {
+	margin-left: 0;
+}
+
+.wp-block-groups-event-card__attendees {
+	font-size: var(--text-small);
+	color: var(--wp--preset--color--neutral-500);
+}
+
+/* ==========================================================================
+   Next Event Spotlight (front page)
+   ========================================================================== */
+
+.groups-site-next-event-card {
+	background: var(--wp--preset--color--neutral-0);
+	border: 1px solid var(--wp--preset--color--neutral-200);
+	border-radius: var(--radius-lg);
+	box-shadow: var(--shadow-md);
+	overflow: hidden;
+	display: flex;
+	flex-direction: row;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.groups-site-next-event-card {
+		transition: box-shadow 0.2s ease-out;
+	}
+}
+
+.groups-site-next-event-card:hover {
+	box-shadow: var(--shadow-lg);
+}
+
+.groups-site-next-event-card__image {
+	width: 40%;
+	min-height: 280px;
+	background: linear-gradient(135deg, var(--wp--preset--color--primary-100), var(--wp--preset--color--accent-100));
+	overflow: hidden;
+}
+
+.groups-site-next-event-card__image img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
+.groups-site-next-event-card__content {
+	width: 60%;
+	padding: 32px;
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+}
+
+@media (max-width: 767px) {
+	.groups-site-next-event-card {
+		flex-direction: column;
+	}
+
+	.groups-site-next-event-card__image,
+	.groups-site-next-event-card__content {
+		width: 100%;
+	}
+
+	.groups-site-next-event-card__image {
+		min-height: 200px;
+	}
+}
+
+/* ==========================================================================
+   RSVP Button States
+   ========================================================================== */
+
+.wp-block-groups-rsvp-button .groups-rsvp-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	width: 100%;
+	height: 48px;
+	border-radius: var(--radius-md);
+	font-family: var(--font-body);
+	font-size: 16px;
+	font-weight: 600;
+	border: none;
+	cursor: pointer;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.wp-block-groups-rsvp-button .groups-rsvp-btn {
+		transition: all 0.15s ease;
+	}
+}
+
+/* Not Attending (default) */
+.wp-block-groups-rsvp-button .groups-rsvp-btn--default {
+	background: var(--wp--preset--color--primary-700);
+	color: var(--wp--preset--color--neutral-0);
+}
+
+.wp-block-groups-rsvp-button .groups-rsvp-btn--default:hover {
+	background: var(--wp--preset--color--primary-600);
+	box-shadow: var(--shadow-sm);
+}
+
+/* Attending (confirmed) */
+.wp-block-groups-rsvp-button .groups-rsvp-btn--attending {
+	background: var(--wp--preset--color--success-100);
+	color: var(--wp--preset--color--success-700);
+	border: 1px solid var(--wp--preset--color--success-500);
+}
+
+.wp-block-groups-rsvp-button .groups-rsvp-btn--attending:hover {
+	background: var(--wp--preset--color--error-100);
+	color: var(--wp--preset--color--error-700);
+	border-color: var(--wp--preset--color--error-500);
+}
+
+/* Waitlisted */
+.wp-block-groups-rsvp-button .groups-rsvp-btn--waitlisted {
+	background: var(--wp--preset--color--warning-100);
+	color: var(--wp--preset--color--warning-700);
+	border: 1px solid var(--wp--preset--color--warning-500);
+}
+
+.wp-block-groups-rsvp-button .groups-rsvp-btn--waitlisted:hover {
+	background: var(--wp--preset--color--error-100);
+	color: var(--wp--preset--color--error-700);
+	border-color: var(--wp--preset--color--error-500);
+}
+
+/* Loading */
+.wp-block-groups-rsvp-button .groups-rsvp-btn--loading {
+	background: var(--wp--preset--color--neutral-100);
+	color: var(--wp--preset--color--neutral-400);
+	border: 1px solid var(--wp--preset--color--neutral-200);
+	pointer-events: none;
+	opacity: 0.7;
+}
+
+/* Disabled (past event / logged out) */
+.wp-block-groups-rsvp-button .groups-rsvp-btn--disabled {
+	background: var(--wp--preset--color--neutral-100);
+	color: var(--wp--preset--color--neutral-400);
+	border: 1px solid var(--wp--preset--color--neutral-200);
+	cursor: not-allowed;
+}
+
+/* Spinner animation */
+@keyframes groups-rsvp-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.wp-block-groups-rsvp-button .groups-rsvp-btn__spinner {
+	width: 18px;
+	height: 18px;
+	border: 2px solid var(--wp--preset--color--neutral-300);
+	border-top-color: var(--wp--preset--color--neutral-500);
+	border-radius: var(--radius-full);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.wp-block-groups-rsvp-button .groups-rsvp-btn__spinner {
+		animation: groups-rsvp-spin 0.8s linear infinite;
+	}
+}
+
+/* ==========================================================================
+   Member Avatars
+   ========================================================================== */
+
+/* Inline variant (RSVP list, attendee row) */
+.groups-site-member-inline {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.groups-site-member-inline__avatar {
+	width: 36px;
+	height: 36px;
+	border-radius: var(--radius-full);
+	object-fit: cover;
+	flex-shrink: 0;
+}
+
+.groups-site-member-inline__name {
+	font-family: var(--font-body);
+	font-size: var(--text-body);
+	font-weight: 500;
+	color: var(--wp--preset--color--neutral-900);
+}
+
+/* Card variant (Members page grid) */
+.groups-site-member-card {
+	background: var(--wp--preset--color--neutral-0);
+	border: 1px solid var(--wp--preset--color--neutral-200);
+	border-radius: var(--radius-lg);
+	box-shadow: var(--shadow-sm);
+	padding: 24px;
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.groups-site-member-card {
+		transition: box-shadow 0.2s ease-out;
+	}
+}
+
+.groups-site-member-card:hover {
+	box-shadow: var(--shadow-md);
+}
+
+.groups-site-member-card__avatar {
+	width: 64px;
+	height: 64px;
+	border-radius: var(--radius-full);
+	object-fit: cover;
+	margin-bottom: 12px;
+}
+
+.groups-site-member-card__name {
+	font-family: var(--font-heading);
+	font-size: var(--text-h5);
+	font-weight: 600;
+	color: var(--wp--preset--color--neutral-950);
+	margin-bottom: 4px;
+}
+
+.groups-site-member-card__username {
+	font-size: var(--text-small);
+	color: var(--wp--preset--color--neutral-500);
+	margin-bottom: 8px;
+}
+
+/* Avatar stack (overlapping) */
+.groups-site-avatar-stack {
+	display: flex;
+}
+
+.groups-site-avatar-stack img {
+	width: 24px;
+	height: 24px;
+	border-radius: var(--radius-full);
+	border: 2px solid var(--wp--preset--color--neutral-0);
+	margin-left: -8px;
+}
+
+.groups-site-avatar-stack img:first-child {
+	margin-left: 0;
+}
+
+/* Avatar fallback (initials) */
+.groups-site-avatar-fallback {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: var(--radius-full);
+	font-family: var(--font-heading);
+	font-weight: 600;
+	color: var(--wp--preset--color--primary-700);
+	background: var(--wp--preset--color--primary-200);
+}
+
+/* ==========================================================================
+   Role Badges
+   ========================================================================== */
+
+.groups-site-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-family: var(--font-body);
+	font-size: var(--text-caption);
+	font-weight: 500;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	border-radius: var(--radius-full);
+	padding: 4px 12px;
+	white-space: nowrap;
+}
+
+.groups-site-badge--organizer {
+	color: var(--wp--preset--color--primary-800);
+	background: var(--wp--preset--color--primary-100);
+	border: 1px solid var(--wp--preset--color--primary-200);
+}
+
+.groups-site-badge--co-organizer {
+	color: var(--wp--preset--color--primary-700);
+	background: var(--wp--preset--color--primary-50);
+	border: 1px solid var(--wp--preset--color--primary-200);
+}
+
+.groups-site-badge--speaker {
+	color: var(--wp--preset--color--accent-700);
+	background: var(--wp--preset--color--accent-100);
+	border: 1px solid var(--wp--preset--color--accent-200);
+}
+
+.groups-site-badge--member {
+	color: var(--wp--preset--color--neutral-600);
+	background: var(--wp--preset--color--neutral-100);
+	border: 1px solid var(--wp--preset--color--neutral-200);
+}
+
+/* ==========================================================================
+   Status Badges
+   ========================================================================== */
+
+.groups-site-status {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-family: var(--font-body);
+	font-size: var(--text-caption);
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	border-radius: var(--radius-full);
+	padding: 4px 12px;
+	white-space: nowrap;
+}
+
+.groups-site-status__dot {
+	width: 8px;
+	height: 8px;
+	border-radius: var(--radius-full);
+	flex-shrink: 0;
+}
+
+.groups-site-status--upcoming {
+	color: var(--wp--preset--color--primary-800);
+	background: var(--wp--preset--color--primary-100);
+}
+
+.groups-site-status--upcoming .groups-site-status__dot {
+	background: var(--wp--preset--color--primary-500);
+}
+
+.groups-site-status--happening-now {
+	color: var(--wp--preset--color--success-700);
+	background: var(--wp--preset--color--success-100);
+}
+
+.groups-site-status--happening-now .groups-site-status__dot {
+	background: var(--wp--preset--color--success-500);
+}
+
+@keyframes groups-pulse {
+	0%, 100% { opacity: 1; }
+	50% { opacity: 0.4; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.groups-site-status--happening-now .groups-site-status__dot {
+		animation: groups-pulse 1.5s ease-in-out infinite;
+	}
+}
+
+.groups-site-status--past {
+	color: var(--wp--preset--color--neutral-600);
+	background: var(--wp--preset--color--neutral-100);
+}
+
+.groups-site-status--cancelled {
+	color: var(--wp--preset--color--error-700);
+	background: var(--wp--preset--color--error-100);
+}
+
+.groups-site-status--draft {
+	color: var(--wp--preset--color--warning-700);
+	background: var(--wp--preset--color--warning-100);
+}
+
+.groups-site-status--full {
+	color: var(--wp--preset--color--neutral-600);
+	background: var(--wp--preset--color--neutral-100);
+}
+
+.groups-site-status--spots-available {
+	color: var(--wp--preset--color--success-700);
+	background: var(--wp--preset--color--success-100);
+}
+
+.groups-site-status--online {
+	color: var(--wp--preset--color--info-700);
+	background: var(--wp--preset--color--info-100);
+}
+
+.groups-site-status--in-person {
+	color: var(--wp--preset--color--neutral-700);
+	background: var(--wp--preset--color--neutral-100);
+}
+
+.groups-site-status--hybrid {
+	color: var(--wp--preset--color--primary-700);
+	background: var(--wp--preset--color--primary-100);
+}
+
+/* ==========================================================================
+   Event Sidebar Info Card
+   ========================================================================== */
+
+.groups-site-event-info-card {
+	border-radius: var(--radius-lg) !important;
+	box-shadow: var(--shadow-md);
+	border-color: var(--wp--preset--color--neutral-200) !important;
+}
+
+.groups-site-event-info-card .groups-site-info-label {
+	font-family: var(--font-body);
+	font-size: var(--text-caption);
+	font-weight: 600;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--wp--preset--color--neutral-500);
+	line-height: 1.2;
+	margin-bottom: 8px;
+}
+
+.groups-site-event-info-card .groups-site-info-value {
+	font-size: var(--text-body);
+	font-weight: 500;
+	color: var(--wp--preset--color--neutral-900);
+}
+
+.groups-site-event-info-card hr.wp-block-separator {
+	border-color: var(--wp--preset--color--neutral-150) !important;
+	margin: 20px 0 !important;
+	opacity: 1;
+}
+
+/* ==========================================================================
+   Form Fields
+   ========================================================================== */
+
+input[type="text"],
+input[type="email"],
+input[type="url"],
+input[type="password"],
+input[type="search"],
+input[type="tel"],
+input[type="number"],
+textarea,
+select {
+	height: 44px;
+	padding: 12px 16px;
+	background: var(--wp--preset--color--neutral-0);
+	border: 1px solid var(--wp--preset--color--neutral-300);
+	border-radius: var(--radius-md);
+	font-family: var(--font-body);
+	font-size: var(--text-body);
+	color: var(--wp--preset--color--neutral-900);
+	width: 100%;
+	box-sizing: border-box;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	input[type="text"],
+	input[type="email"],
+	input[type="url"],
+	input[type="password"],
+	input[type="search"],
+	input[type="tel"],
+	input[type="number"],
+	textarea,
+	select {
+		transition: border-color 0.15s ease, box-shadow 0.15s ease;
+	}
+}
+
+textarea {
+	height: auto;
+	min-height: 120px;
+}
+
+input::placeholder,
+textarea::placeholder {
+	color: var(--wp--preset--color--neutral-500);
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+	border-color: var(--wp--preset--color--primary-500);
+	box-shadow: 0 0 0 3px var(--wp--preset--color--primary-200);
+	outline: none;
+}
+
+input:disabled,
+textarea:disabled,
+select:disabled {
+	background: var(--wp--preset--color--neutral-100);
+	color: var(--wp--preset--color--neutral-400);
+	border-color: var(--wp--preset--color--neutral-200);
+	cursor: not-allowed;
+}
+
+/* Error state */
+input.has-error,
+textarea.has-error,
+select.has-error {
+	border-color: var(--wp--preset--color--error-500);
+	box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
+}
+
+/* Labels */
+.groups-site-label {
+	display: block;
+	font-family: var(--font-body);
+	font-size: var(--text-small);
+	font-weight: 600;
+	color: var(--wp--preset--color--neutral-800);
+	margin-bottom: 8px;
+}
+
+.groups-site-label .required {
+	color: var(--wp--preset--color--error-500);
+	margin-left: 4px;
+}
+
+/* Helper text */
+.groups-site-helper {
+	font-size: var(--text-small);
+	font-weight: 400;
+	color: var(--wp--preset--color--neutral-500);
+	margin-top: 8px;
+}
+
+.groups-site-helper--error {
+	color: var(--wp--preset--color--error-700);
+}
+
+/* Select */
+select {
+	appearance: none;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23A9A5B0' stroke-width='1.75' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+	background-repeat: no-repeat;
+	background-position: right 16px center;
+	padding-right: 44px;
+}
+
+/* Checkbox / Radio */
+input[type="checkbox"],
+input[type="radio"] {
+	width: 18px;
+	height: 18px;
+	border: 2px solid var(--wp--preset--color--neutral-300);
+	padding: 0;
+	cursor: pointer;
+}
+
+input[type="checkbox"] {
+	border-radius: var(--radius-sm);
+}
+
+input[type="radio"] {
+	border-radius: var(--radius-full);
+}
+
+input[type="checkbox"]:checked,
+input[type="radio"]:checked {
+	background: var(--wp--preset--color--primary-700);
+	border-color: var(--wp--preset--color--primary-700);
+}
+
+input[type="checkbox"]:focus,
+input[type="radio"]:focus {
+	box-shadow: 0 0 0 3px var(--wp--preset--color--primary-200);
+}
+
+/* Search input within block search */
+.wp-block-search__input {
+	border-radius: var(--radius-md) !important;
+	border-color: var(--wp--preset--color--neutral-300) !important;
+}
+
+.wp-block-search__input:focus {
+	border-color: var(--wp--preset--color--primary-500) !important;
+	box-shadow: 0 0 0 3px var(--wp--preset--color--primary-200);
+}
+
+.wp-block-search__button {
+	border-radius: 0 var(--radius-md) var(--radius-md) 0 !important;
+	background: var(--wp--preset--color--primary-700) !important;
+	border: none !important;
+}
+
+.wp-block-search__button:hover {
+	background: var(--wp--preset--color--primary-600) !important;
+}
+
+/* ==========================================================================
+   Community Callout Band
+   ========================================================================== */
+
+.groups-site-community-callout {
+	background: var(--wp--preset--color--surface-dark-2) !important;
+}
+
+.groups-site-community-callout p {
+	font-family: var(--font-heading);
+	font-weight: 500;
+}
+
+.groups-site-community-callout .wp-block-button.is-style-outline .wp-block-button__link {
+	border-color: rgba(255, 255, 255, 0.2) !important;
+	color: var(--wp--preset--color--neutral-0) !important;
+	border-radius: var(--radius-md);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.groups-site-community-callout .wp-block-button.is-style-outline .wp-block-button__link {
+		transition: background 0.15s ease;
+	}
+}
+
+.groups-site-community-callout .wp-block-button.is-style-outline .wp-block-button__link:hover {
+	background: rgba(255, 255, 255, 0.1) !important;
+}
+
+/* ==========================================================================
+   Footer
+   ========================================================================== */
+
+.groups-site-footer {
+	background: var(--wp--preset--color--surface-dark-1) !important;
+}
+
+.groups-site-footer a {
+	color: var(--wp--preset--color--surface-dark-muted) !important;
+	text-decoration: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.groups-site-footer a {
+		transition: color 0.15s ease;
+	}
+}
+
+.groups-site-footer a:hover {
+	color: var(--wp--preset--color--neutral-0) !important;
+}
+
+.groups-site-footer .groups-site-code-is-poetry {
+	font-family: var(--font-mono);
+	font-size: var(--text-caption);
+	color: var(--wp--preset--color--neutral-500);
+}
+
+/* ==========================================================================
+   Tag pills
+   ========================================================================== */
+
+.groups-site-tag {
+	display: inline-flex;
+	align-items: center;
+	font-family: var(--font-body);
+	font-size: var(--text-caption);
+	font-weight: 500;
+	color: var(--wp--preset--color--primary-700);
+	background: var(--wp--preset--color--primary-100);
+	border-radius: var(--radius-full);
+	padding: 4px 12px;
+}
+
+/* ==========================================================================
+   Pagination
+   ========================================================================== */
+
+.wp-block-query-pagination {
+	font-family: var(--font-body);
+	font-size: var(--text-small);
+}
+
+.wp-block-query-pagination-numbers .page-numbers {
+	color: var(--wp--preset--color--neutral-600);
+	text-decoration: none;
+	padding: 4px 8px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.wp-block-query-pagination-numbers .page-numbers {
+		transition: color 0.15s ease;
+	}
+}
+
+.wp-block-query-pagination-numbers .page-numbers:hover {
+	color: var(--wp--preset--color--neutral-900);
+}
+
+.wp-block-query-pagination-numbers .page-numbers.current {
+	color: var(--wp--preset--color--primary-700);
+	font-weight: 600;
+}
+
+.wp-block-query-pagination-previous,
+.wp-block-query-pagination-next {
+	color: var(--wp--preset--color--neutral-500);
+}
+
+.wp-block-query-pagination-previous:hover,
+.wp-block-query-pagination-next:hover {
+	color: var(--wp--preset--color--neutral-900);
+}
+
+/* ==========================================================================
+   Event grid layouts (block-level)
+   ========================================================================== */
+
+.wp-block-groups-upcoming-events,
+.wp-block-groups-past-events {
+	display: grid;
+	gap: 24px;
+	grid-template-columns: 1fr;
+}
+
+@media (min-width: 640px) {
+	.wp-block-groups-upcoming-events,
+	.wp-block-groups-past-events {
+		grid-template-columns: repeat(2, 1fr);
+	}
+}
+
+@media (min-width: 1024px) {
+	.wp-block-groups-upcoming-events,
+	.wp-block-groups-past-events {
+		grid-template-columns: repeat(3, 1fr);
+	}
+}
+
+/* Member grid */
+.wp-block-groups-group-members {
+	display: grid;
+	gap: 16px;
+	grid-template-columns: repeat(2, 1fr);
+}
+
+@media (min-width: 640px) {
+	.wp-block-groups-group-members {
+		grid-template-columns: repeat(3, 1fr);
+	}
+}
+
+@media (min-width: 1024px) {
+	.wp-block-groups-group-members {
+		grid-template-columns: repeat(4, 1fr);
+	}
+}
+
+/* ==========================================================================
+   Reduced motion
+   ========================================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		transition-duration: 0.01ms !important;
+		animation-duration: 0.01ms !important;
+	}
+}
+
+/* ==========================================================================
+   Navigation overlay (hamburger menu)
+   ========================================================================== */
+
+.wp-block-navigation__responsive-container.is-menu-open {
+	background-color: var(--wp--preset--color--neutral-0, #ffffff);
+	color: var(--wp--preset--color--neutral-900);
+	padding: 32px;
+}
+
+.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation-item a {
+	font-size: var(--text-body-lg);
+	padding: 8px 0;
+	color: var(--wp--preset--color--neutral-700);
+}
+
+.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation-item a:hover {
+	color: var(--wp--preset--color--neutral-950);
+}

--- a/wp-content/themes/groups-site/assets/css/responsive.css
+++ b/wp-content/themes/groups-site/assets/css/responsive.css
@@ -1,16 +1,18 @@
 /**
  * Responsive styles for Groups Site theme.
  *
- * Breakpoints:
- *   - Small (mobile):  up to 599px
- *   - Medium (tablet):  600px - 1023px
- *   - Large (desktop):  1024px+
+ * Breakpoints (from design spec):
+ *   - Mobile:  0 - 639px
+ *   - Tablet:  640px - 1023px
+ *   - Desktop: 1024px - 1279px
+ *   - Wide:    1280px - 1439px
+ *   - Ultra:   1440px+
  *
  * @package Groups_Site
  */
 
 /* ==========================================================================
-   Mobile-first base adjustments (applies to all sizes, overridden upward)
+   Mobile-first base adjustments
    ========================================================================== */
 
 img,
@@ -21,59 +23,14 @@ iframe {
 }
 
 /* ==========================================================================
-   Global header styles
+   Small screens - up to 639px
    ========================================================================== */
-
-.groups-site-subnav__nav .wp-block-navigation-item a {
-	display: block;
-	padding: 12px 16px;
-	text-decoration: none;
-	border-bottom: 2px solid transparent;
-	transition: border-color 0.15s ease;
-}
-
-.groups-site-subnav__nav .wp-block-navigation-item a:hover,
-.groups-site-subnav__nav .wp-block-navigation-item.current-menu-item a {
-	border-bottom-color: var(--wp--preset--color--blueberry-1, #3858e9);
-}
-
-@media (min-width: 1024px) {
-	.groups-site-event-info-card {
-		position: sticky;
-		top: 32px;
-	}
-}
-
-/* ==========================================================================
-   Small screens - up to 599px
-   ========================================================================== */
-@media (max-width: 599px) {
-
-	.groups-site-global-header .wp-block-group > .wp-block-group {
-		flex-direction: column;
-		align-items: flex-start;
-		gap: var(--wp--preset--spacing--10, 10px);
-	}
+@media (max-width: 639px) {
 
 	.groups-site-local-header .wp-block-group > .wp-block-group {
 		flex-direction: column;
 		align-items: flex-start;
-		gap: var(--wp--preset--spacing--10, 10px);
-	}
-
-	h1,
-	.has-heading-1-font-size {
-		font-size: clamp(28px, 7vw, 36px) !important;
-	}
-
-	h2,
-	.has-heading-2-font-size {
-		font-size: clamp(24px, 5.5vw, 32px) !important;
-	}
-
-	h3,
-	.has-heading-3-font-size {
-		font-size: clamp(20px, 4.5vw, 26px) !important;
+		gap: 8px;
 	}
 
 	.groups-site-event-layout {
@@ -82,45 +39,29 @@ iframe {
 
 	.groups-site-event-layout .wp-block-column {
 		flex-basis: 100% !important;
-	}
-
-	.wp-block-groups-upcoming-events,
-	.wp-block-groups-past-events,
-	.wp-block-groups-event-directory {
-		display: flex !important;
-		flex-direction: column;
-		gap: var(--wp--preset--spacing--20, 20px);
 	}
 
 	.wp-block-groups-event-card__thumbnail {
 		max-height: 160px;
 	}
 
-	.wp-block-groups-event-hero {
-		min-height: 180px;
-	}
-
 	.groups-site-community-callout .wp-block-group > .wp-block-group,
 	.groups-site-footer .wp-block-group > .wp-block-group {
 		flex-direction: column;
 		align-items: flex-start;
-		gap: var(--wp--preset--spacing--10, 10px);
+		gap: 8px;
 	}
 
 	.groups-site-subnav {
 		overflow-x: auto;
 		-webkit-overflow-scrolling: touch;
 	}
-
-	.wp-block-groups-group-members {
-		grid-template-columns: 1fr !important;
-	}
 }
 
 /* ==========================================================================
-   Medium screens - 600px to 1023px
+   Tablet - 640px to 1023px
    ========================================================================== */
-@media (min-width: 600px) and (max-width: 1023px) {
+@media (min-width: 640px) and (max-width: 1023px) {
 
 	.groups-site-event-layout {
 		flex-direction: column !important;
@@ -129,59 +70,16 @@ iframe {
 	.groups-site-event-layout .wp-block-column {
 		flex-basis: 100% !important;
 	}
-
-	.wp-block-groups-upcoming-events,
-	.wp-block-groups-past-events,
-	.wp-block-groups-event-directory {
-		display: grid !important;
-		grid-template-columns: repeat(2, 1fr);
-		gap: var(--wp--preset--spacing--20, 20px);
-	}
-
-	.wp-block-groups-group-members {
-		grid-template-columns: repeat(2, 1fr) !important;
-	}
-
-	.wp-block-groups-event-hero {
-		min-height: 240px;
-	}
 }
 
 /* ==========================================================================
-   Large screens - 1024px+
+   Desktop - 1024px+
    ========================================================================== */
 @media (min-width: 1024px) {
 
-	.wp-block-groups-upcoming-events,
-	.wp-block-groups-past-events,
-	.wp-block-groups-event-directory {
-		display: grid !important;
-		grid-template-columns: repeat(3, 1fr);
-		gap: var(--wp--preset--spacing--30, 30px);
-	}
-
-	.wp-block-groups-group-members {
-		grid-template-columns: repeat(3, 1fr) !important;
-	}
-
-	.wp-block-groups-event-hero {
-		min-height: 320px;
-	}
-}
-
-/* ==========================================================================
-   Extra-large screens - 1440px+
-   ========================================================================== */
-@media (min-width: 1440px) {
-
-	.wp-block-groups-upcoming-events,
-	.wp-block-groups-past-events,
-	.wp-block-groups-event-directory {
-		grid-template-columns: repeat(4, 1fr);
-	}
-
-	.wp-block-groups-group-members {
-		grid-template-columns: repeat(4, 1fr) !important;
+	.groups-site-event-info-card {
+		position: sticky;
+		top: 92px;
 	}
 }
 
@@ -193,8 +91,8 @@ iframe {
 	width: 100%;
 	overflow: hidden;
 	border-radius: 0;
-	margin-bottom: var(--wp--preset--spacing--30, 30px);
-	background-color: var(--wp--preset--color--blueberry-4, #eff2ff);
+	margin-bottom: 32px;
+	background: linear-gradient(135deg, var(--wp--preset--color--primary-100), var(--wp--preset--color--accent-100));
 }
 
 .wp-block-groups-event-hero img {
@@ -204,41 +102,16 @@ iframe {
 	display: block;
 }
 
-.wp-block-groups-event-hero--placeholder {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	color: var(--wp--preset--color--blueberry-2, #9fb1ff);
-	font-size: 48px;
-}
-
-/* ==========================================================================
-   Event card thumbnail
-   ========================================================================== */
-.wp-block-groups-event-card__thumbnail {
-	margin: calc(-1 * var(--wp--preset--spacing--30, 20px));
-	margin-bottom: var(--wp--preset--spacing--20, 20px);
-	overflow: hidden;
-	border-radius: 4px 4px 0 0;
-}
-
-.wp-block-groups-event-card__thumbnail img {
-	width: 100%;
-	height: 180px;
-	object-fit: cover;
-	display: block;
-}
-
 /* ==========================================================================
    Navigation overlay (hamburger)
    ========================================================================== */
 .wp-block-navigation__responsive-container.is-menu-open {
-	background-color: var(--wp--preset--color--white, #ffffff);
-	color: var(--wp--preset--color--charcoal-1, #1e1e1e);
-	padding: var(--wp--preset--spacing--40, 40px);
+	background-color: var(--wp--preset--color--neutral-0, #ffffff);
+	color: var(--wp--preset--color--neutral-900);
+	padding: 32px;
 }
 
 .wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation-item a {
-	font-size: var(--wp--preset--font-size--large, 18px);
-	padding: var(--wp--preset--spacing--10, 10px) 0;
+	font-size: var(--wp--preset--font-size--body-lg, 18px);
+	padding: 8px 0;
 }

--- a/wp-content/themes/groups-site/functions.php
+++ b/wp-content/themes/groups-site/functions.php
@@ -20,17 +20,25 @@ add_action( 'after_setup_theme', 'groups_site_setup' );
  * Enqueue fonts and theme stylesheets.
  */
 function groups_site_enqueue_assets() {
+	// Google Fonts: Plus Jakarta Sans (headings) + Inter (body) + JetBrains Mono (mono).
 	wp_enqueue_style(
 		'groups-site-google-fonts',
-		'https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Inter:wght@300;400;500;600;700&display=swap',
+		'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap',
 		[],
 		null
 	);
 
 	wp_enqueue_style(
+		'groups-site-custom',
+		get_theme_file_uri( 'assets/css/custom.css' ),
+		[ 'groups-site-google-fonts' ],
+		filemtime( get_theme_file_path( 'assets/css/custom.css' ) )
+	);
+
+	wp_enqueue_style(
 		'groups-site-responsive',
 		get_theme_file_uri( 'assets/css/responsive.css' ),
-		[],
+		[ 'groups-site-custom' ],
 		filemtime( get_theme_file_path( 'assets/css/responsive.css' ) )
 	);
 }

--- a/wp-content/themes/groups-site/parts/footer.html
+++ b/wp-content/themes/groups-site/parts/footer.html
@@ -1,15 +1,15 @@
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|blueberry-3"}}}}},"backgroundColor":"charcoal-1","textColor":"white","layout":{"type":"constrained","wideSize":"1600px"},"className":"groups-site-community-callout"} -->
-<div class="wp-block-group groups-site-community-callout has-white-color has-charcoal-1-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space)">
-	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"elements":{"link":{"color":{"text":"var:preset|color|surface-dark-text"},":hover":{"color":{"text":"var:preset|color|neutral-0"}}}}},"backgroundColor":"surface-dark-2","textColor":"surface-dark-text","layout":{"type":"constrained","wideSize":"1280px"},"className":"groups-site-community-callout"} -->
+<div class="wp-block-group groups-site-community-callout has-surface-dark-text-color has-surface-dark-2-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"var:preset|spacing|50"}}} -->
 	<div class="wp-block-group">
-		<!-- wp:paragraph {"style":{"typography":{"fontWeight":"400"}},"fontFamily":"eb-garamond","fontSize":"heading-4"} -->
-		<p class="has-eb-garamond-font-family has-heading-4-font-size" style="font-weight:400">Want to bring WordPress to your community? Become an organizer and start hosting events.</p>
+		<!-- wp:paragraph {"style":{"typography":{"fontWeight":"500"}},"fontFamily":"heading","fontSize":"heading-4"} -->
+		<p class="has-heading-font-family has-heading-4-font-size" style="font-weight:500">Want to bring WordPress to your community? Become an organizer and start hosting events.</p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:buttons -->
 		<div class="wp-block-buttons">
-			<!-- wp:button {"className":"is-style-outline","style":{"color":{"text":"var:preset|color|white"},"border":{"color":"var:preset|color|white-opacity-15"}},"fontSize":"small"} -->
-			<div class="wp-block-button is-style-outline has-small-font-size"><a class="wp-block-button__link has-text-color has-border-color wp-element-button" href="https://make.wordpress.org/community/" style="border-color:var(--wp--preset--color--white-opacity-15);color:var(--wp--preset--color--white)">Learn more</a></div>
+			<!-- wp:button {"className":"is-style-outline","style":{"color":{"text":"var:preset|color|neutral-0"},"border":{"color":"#ffffff33","radius":"8px"}},"fontSize":"small"} -->
+			<div class="wp-block-button is-style-outline has-small-font-size"><a class="wp-block-button__link has-text-color has-border-color wp-element-button" href="https://make.wordpress.org/community/" style="border-color:#ffffff33;color:var(--wp--preset--color--neutral-0);border-radius:8px">Learn more</a></div>
 			<!-- /wp:button -->
 		</div>
 		<!-- /wp:buttons -->
@@ -18,11 +18,11 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|blueberry-3"}}}}},"backgroundColor":"deep-blueberry","textColor":"white","layout":{"type":"constrained","wideSize":"1600px"},"className":"groups-site-footer"} -->
-<div class="wp-block-group groups-site-footer has-white-color has-deep-blueberry-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space)">
-	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"elements":{"link":{"color":{"text":"var:preset|color|surface-dark-muted"},":hover":{"color":{"text":"var:preset|color|neutral-0"}}}}},"backgroundColor":"surface-dark-1","textColor":"surface-dark-muted","layout":{"type":"constrained","wideSize":"1280px"},"className":"groups-site-footer"} -->
+<div class="wp-block-group groups-site-footer has-surface-dark-muted-color has-surface-dark-1-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"var:preset|spacing|50"}}} -->
 	<div class="wp-block-group">
-		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}}} -->
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"24px"}}} -->
 		<div class="wp-block-group">
 			<!-- wp:paragraph {"fontSize":"small"} -->
 			<p class="has-small-font-size"><a href="https://wordpress.org/">WordPress.org</a></p>
@@ -42,7 +42,7 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}}} -->
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"24px"}}} -->
 		<div class="wp-block-group">
 			<!-- wp:paragraph {"fontSize":"small"} -->
 			<p class="has-small-font-size"><a href="https://wordpress.org/about/privacy/">Privacy</a></p>
@@ -52,8 +52,8 @@
 			<p class="has-small-font-size"><a href="https://www.wordpress.org/about/license/">License</a></p>
 			<!-- /wp:paragraph -->
 
-			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size">Code is Poetry.</p>
+			<!-- wp:paragraph {"fontSize":"caption","className":"groups-site-code-is-poetry","fontFamily":"mono"} -->
+			<p class="has-caption-font-size groups-site-code-is-poetry has-mono-font-family">Code is Poetry.</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/wp-content/themes/groups-site/parts/group-navigation.html
+++ b/wp-content/themes/groups-site/parts/group-navigation.html
@@ -1,6 +1,6 @@
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"backgroundColor":"light-grey-2","layout":{"type":"constrained","wideSize":"1600px"},"className":"groups-site-subnav"} -->
-<div class="wp-block-group groups-site-subnav has-light-grey-2-background-color has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
-	<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"blockGap":"0"},"typography":{"fontWeight":"500"}},"fontSize":"small","className":"groups-site-subnav__nav"} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"border":{"bottom":{"color":"var:preset|color|neutral-200","width":"1px"}}},"backgroundColor":"neutral-0","layout":{"type":"constrained","wideSize":"1280px"},"className":"groups-site-subnav"} -->
+<div class="wp-block-group groups-site-subnav has-neutral-0-background-color has-background" style="border-bottom-color:var(--wp--preset--color--neutral-200);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"blockGap":"0"},"typography":{"fontWeight":"500"}},"fontSize":"small","className":"groups-site-subnav__nav","fontFamily":"body"} -->
 		<!-- wp:page-list /-->
 	<!-- /wp:navigation -->
 </div>

--- a/wp-content/themes/groups-site/parts/header.html
+++ b/wp-content/themes/groups-site/parts/header.html
@@ -2,49 +2,13 @@
 <a class="skip-link screen-reader-text" href="#main">Skip to content</a>
 <!-- /wp:html -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|blueberry-3"}}}}},"backgroundColor":"charcoal-1","textColor":"white","layout":{"type":"constrained","wideSize":"1600px"},"className":"groups-site-global-header"} -->
-<div class="wp-block-group groups-site-global-header has-white-color has-charcoal-1-background-color has-text-color has-background" style="padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
-	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"},"style":{"spacing":{"padding":{"top":"10px","bottom":"10px"},"blockGap":"var:preset|spacing|20"}}} -->
-	<div class="wp-block-group" style="padding-top:10px;padding-bottom:10px">
-		<!-- wp:paragraph {"fontSize":"extra-small","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|blueberry-3"}}}}}} -->
-		<p class="has-extra-small-font-size"><a href="https://wordpress.org/">WordPress.org</a></p>
-		<!-- /wp:paragraph -->
-
-		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"16px"}}} -->
-		<div class="wp-block-group">
-			<!-- wp:paragraph {"fontSize":"extra-small","style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-5"},":hover":{"color":{"text":"var:preset|color|white"}}}}}} -->
-			<p class="has-extra-small-font-size"><a href="https://wordpress.org/showcase/">Showcase</a></p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:paragraph {"fontSize":"extra-small","style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-5"},":hover":{"color":{"text":"var:preset|color|white"}}}}}} -->
-			<p class="has-extra-small-font-size"><a href="https://wordpress.org/hosting/">Hosting</a></p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:paragraph {"fontSize":"extra-small","style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-5"},":hover":{"color":{"text":"var:preset|color|white"}}}}}} -->
-			<p class="has-extra-small-font-size"><a href="https://wordpress.org/extend/">Extend</a></p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:paragraph {"fontSize":"extra-small","style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-5"},":hover":{"color":{"text":"var:preset|color|white"}}}}}} -->
-			<p class="has-extra-small-font-size"><a href="https://learn.wordpress.org/">Learn</a></p>
-			<!-- /wp:paragraph -->
-
-			<!-- wp:paragraph {"fontSize":"extra-small","style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-5"},":hover":{"color":{"text":"var:preset|color|white"}}}}}} -->
-			<p class="has-extra-small-font-size"><a href="https://make.wordpress.org/">Community</a></p>
-			<!-- /wp:paragraph -->
-		</div>
-		<!-- /wp:group -->
-	</div>
-	<!-- /wp:group -->
-</div>
-<!-- /wp:group -->
-
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}},"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}}},"backgroundColor":"white","textColor":"charcoal-1","layout":{"type":"constrained","wideSize":"1600px"},"className":"groups-site-local-header"} -->
-<div class="wp-block-group groups-site-local-header has-charcoal-1-color has-white-background-color has-text-color has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"border":{"bottom":{"color":"var:preset|color|neutral-200","width":"1px"}}},"backgroundColor":"neutral-0","textColor":"neutral-900","layout":{"type":"constrained","wideSize":"1280px"},"className":"groups-site-local-header"} -->
+<div class="wp-block-group groups-site-local-header has-neutral-900-color has-neutral-0-background-color has-text-color has-background" style="border-bottom-color:var(--wp--preset--color--neutral-200);border-bottom-width:1px;padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:0;padding-left:var(--wp--preset--spacing--edge-space)">
 	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"},"style":{"spacing":{"padding":{"top":"14px","bottom":"14px"},"blockGap":"var:preset|spacing|20"}}} -->
 	<div class="wp-block-group" style="padding-top:14px;padding-bottom:14px">
-		<!-- wp:site-title {"level":0,"fontSize":"small","style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-0"},"typography":{"textDecoration":"none"},":hover":{"color":{"text":"var:preset|color|blueberry-1"}}}},"typography":{"fontWeight":"600"}}} /-->
+		<!-- wp:site-title {"level":0,"fontSize":"heading-5","style":{"elements":{"link":{"color":{"text":"var:preset|color|neutral-950"},"typography":{"textDecoration":"none"},":hover":{"color":{"text":"var:preset|color|primary-700"}}}},"typography":{"fontWeight":"700"}},"fontFamily":"heading"} /-->
 
-		<!-- wp:navigation {"overlayMenu":"mobile","overlayBackgroundColor":"white","overlayTextColor":"charcoal-1","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","style":{"typography":{"fontWeight":"500"}}} -->
+		<!-- wp:navigation {"overlayMenu":"mobile","overlayBackgroundColor":"neutral-0","overlayTextColor":"neutral-900","layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small","style":{"typography":{"fontWeight":"500"}},"fontFamily":"body"} -->
 			<!-- wp:page-list /-->
 		<!-- /wp:navigation -->
 	</div>

--- a/wp-content/themes/groups-site/templates/archive-event.html
+++ b/wp-content/themes/groups-site/templates/archive-event.html
@@ -1,16 +1,16 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","metadata":{"name":"Main Content"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1600px"}} -->
-<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"tagName":"main","metadata":{"name":"Main Content"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1280px"}} -->
+<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
 
 	<!-- wp:heading {"level":1,"fontSize":"heading-1"} -->
 	<h1 class="wp-block-heading has-heading-1-font-size">Events</h1>
 	<!-- /wp:heading -->
 
-	<!-- wp:search {"label":"Search events","placeholder":"Search events\u2026","query":{"post_type":"event"},"buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}},"className":"wp-block-groups-event-search"} /-->
+	<!-- wp:search {"label":"Search events","placeholder":"Search events\u2026","query":{"post_type":"event"},"buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}},"className":"wp-block-groups-event-search"} /-->
 
-	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained","wideSize":"1600px","justifyContent":"left"}} -->
-	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--60)">
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|50","margin":{"bottom":"var:preset|spacing|80"}}},"layout":{"type":"constrained","wideSize":"1280px","justifyContent":"left"}} -->
+	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--80)">
 		<!-- wp:heading {"level":2,"fontSize":"heading-2"} -->
 		<h2 class="wp-block-heading has-heading-2-font-size">Upcoming</h2>
 		<!-- /wp:heading -->
@@ -19,12 +19,12 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:separator {"className":"is-style-wide","color":"light-grey-1"} -->
-	<hr class="wp-block-separator has-text-color has-light-grey-1-color has-alpha-channel-opacity has-light-grey-1-background-color has-background is-style-wide"/>
+	<!-- wp:separator {"className":"is-style-wide","backgroundColor":"neutral-200"} -->
+	<hr class="wp-block-separator has-text-color has-neutral-200-color has-alpha-channel-opacity has-neutral-200-background-color has-background is-style-wide"/>
 	<!-- /wp:separator -->
 
-	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained","wideSize":"1600px","justifyContent":"left"}} -->
-	<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|50","margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained","wideSize":"1280px","justifyContent":"left"}} -->
+	<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--80)">
 		<!-- wp:heading {"level":2,"fontSize":"heading-2"} -->
 		<h2 class="wp-block-heading has-heading-2-font-size">Past Events</h2>
 		<!-- /wp:heading -->

--- a/wp-content/themes/groups-site/templates/front-page.html
+++ b/wp-content/themes/groups-site/templates/front-page.html
@@ -1,24 +1,24 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|blueberry-3"}}}}},"backgroundColor":"charcoal-0","textColor":"white","layout":{"type":"constrained","wideSize":"1600px"},"className":"groups-site-hero"} -->
-<div class="wp-block-group groups-site-hero has-white-color has-charcoal-0-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"neutral-100","layout":{"type":"constrained","wideSize":"1280px"},"className":"groups-site-hero"} -->
+<div class="wp-block-group groups-site-hero has-neutral-100-background-color has-background" style="padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
 	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"constrained","contentSize":"720px","justifyContent":"left"}} -->
 	<div class="wp-block-group">
-		<!-- wp:site-title {"level":1,"fontSize":"heading-1","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"},"typography":{"textDecoration":"none"}}}}} /-->
+		<!-- wp:site-title {"level":1,"fontSize":"heading-1","style":{"elements":{"link":{"color":{"text":"var:preset|color|neutral-950"},"typography":{"textDecoration":"none"}}}}} /-->
 
-		<!-- wp:paragraph {"fontSize":"large","style":{"color":{"text":"var:preset|color|charcoal-5"}}} -->
-		<p class="has-large-font-size" style="color:var(--wp--preset--color--charcoal-5)">Welcome to our WordPress community group. Join us for local meetups, workshops, and learning opportunities.</p>
+		<!-- wp:paragraph {"fontSize":"body-lg","textColor":"neutral-600"} -->
+		<p class="has-neutral-600-color has-text-color has-body-lg-font-size">Welcome to our WordPress community group. Join us for local meetups, workshops, and learning opportunities.</p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1600px"}} -->
-<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1280px"}} -->
+<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained","wideSize":"1600px","justifyContent":"left"}} -->
-	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--60)">
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|60","margin":{"bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained","wideSize":"1280px","justifyContent":"left"}} -->
+	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--70)">
 		<!-- wp:heading {"level":2,"fontSize":"heading-2"} -->
 		<h2 class="wp-block-heading has-heading-2-font-size">Upcoming Events</h2>
 		<!-- /wp:heading -->
@@ -27,12 +27,12 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:separator {"className":"is-style-wide","color":"light-grey-1"} -->
-	<hr class="wp-block-separator has-text-color has-light-grey-1-color has-alpha-channel-opacity has-light-grey-1-background-color has-background is-style-wide"/>
+	<!-- wp:separator {"className":"is-style-wide","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"backgroundColor":"neutral-200"} -->
+	<hr class="wp-block-separator has-text-color has-neutral-200-color has-alpha-channel-opacity has-neutral-200-background-color has-background is-style-wide" style="margin-top:0;margin-bottom:0"/>
 	<!-- /wp:separator -->
 
-	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20","margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained","wideSize":"1600px","justifyContent":"left"}} -->
-	<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40","margin":{"top":"var:preset|spacing|70"}}},"layout":{"type":"constrained","contentSize":"768px","justifyContent":"left"}} -->
+	<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--70)">
 		<!-- wp:heading {"level":2,"fontSize":"heading-2"} -->
 		<h2 class="wp-block-heading has-heading-2-font-size">About This Group</h2>
 		<!-- /wp:heading -->

--- a/wp-content/themes/groups-site/templates/page-members.html
+++ b/wp-content/themes/groups-site/templates/page-members.html
@@ -1,11 +1,19 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1600px"}} -->
-<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1280px"}} -->
+<main class="wp-block-group" id="main" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
 
 	<!-- wp:heading {"level":1,"fontSize":"heading-1"} -->
 	<h1 class="wp-block-heading has-heading-1-font-size">Members</h1>
 	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"textColor":"neutral-600","fontSize":"body"} -->
+	<p class="has-neutral-600-color has-text-color has-body-font-size">Community members who help make this group thrive.</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
+	<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
 
 	<!-- wp:groups/group-members /-->
 

--- a/wp-content/themes/groups-site/templates/single-event.html
+++ b/wp-content/themes/groups-site/templates/single-event.html
@@ -1,18 +1,18 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1600px"}} -->
-<main class="wp-block-group" id="main" style="padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|80","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1280px"}} -->
+<main class="wp-block-group" id="main" style="padding-top:0;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--edge-space)">
 
-	<!-- wp:post-featured-image {"aspectRatio":"3/1","style":{"border":{"radius":"0px"},"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}},"className":"wp-block-groups-event-hero","align":"wide"} /-->
+	<!-- wp:post-featured-image {"aspectRatio":"3/1","style":{"border":{"radius":"0px"},"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}},"className":"wp-block-groups-event-hero","align":"wide"} /-->
 
 	<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|60"}}},"className":"groups-site-event-layout"} -->
 	<div class="wp-block-columns groups-site-event-layout">
-		<!-- wp:column {"width":"65%","className":"groups-site-event-content"} -->
-		<div class="wp-block-column groups-site-event-content" style="flex-basis:65%">
+		<!-- wp:column {"width":"62%","className":"groups-site-event-content"} -->
+		<div class="wp-block-column groups-site-event-content" style="flex-basis:62%">
 			<!-- wp:post-title {"level":1,"fontSize":"heading-1"} /-->
 
-			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40)">
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--60)">
 				<!-- wp:heading {"level":2,"fontSize":"heading-3"} -->
 				<h2 class="wp-block-heading has-heading-3-font-size">Details</h2>
 				<!-- /wp:heading -->
@@ -21,8 +21,8 @@
 			</div>
 			<!-- /wp:group -->
 
-			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20","margin":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--40)">
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--60)">
 				<!-- wp:heading {"level":2,"fontSize":"heading-3"} -->
 				<h2 class="wp-block-heading has-heading-3-font-size">Attendees</h2>
 				<!-- /wp:heading -->
@@ -33,18 +33,18 @@
 		</div>
 		<!-- /wp:column -->
 
-		<!-- wp:column {"width":"35%","className":"groups-site-event-sidebar"} -->
-		<div class="wp-block-column groups-site-event-sidebar" style="flex-basis:35%">
-			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"},"blockGap":"var:preset|spacing|20"},"border":{"radius":"4px","width":"1px","color":"var:preset|color|light-grey-1"}},"backgroundColor":"white","layout":{"type":"constrained"},"className":"groups-site-event-info-card"} -->
-			<div class="wp-block-group groups-site-event-info-card has-border-color has-white-background-color has-background" style="border-color:var(--wp--preset--color--light-grey-1);border-width:1px;border-radius:4px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+		<!-- wp:column {"width":"38%","className":"groups-site-event-sidebar"} -->
+		<div class="wp-block-column groups-site-event-sidebar" style="flex-basis:38%">
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|20"},"border":{"radius":"12px","width":"1px","color":"var:preset|color|neutral-200"}},"backgroundColor":"neutral-0","layout":{"type":"constrained"},"className":"groups-site-event-info-card"} -->
+			<div class="wp-block-group groups-site-event-info-card has-border-color has-neutral-0-background-color has-background" style="border-color:var(--wp--preset--color--neutral-200);border-width:1px;border-radius:12px;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
 				<!-- wp:heading {"level":3,"fontSize":"heading-5","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}}} -->
 				<h3 class="wp-block-heading has-heading-5-font-size" style="margin-bottom:var(--wp--preset--spacing--10)">Date &amp; Time</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:groups/event-datetime /-->
 
-				<!-- wp:separator {"className":"is-style-wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"color":"light-grey-1"} -->
-				<hr class="wp-block-separator has-text-color has-light-grey-1-color has-alpha-channel-opacity has-light-grey-1-background-color has-background is-style-wide" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)"/>
+				<!-- wp:separator {"className":"is-style-wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"backgroundColor":"neutral-150"} -->
+				<hr class="wp-block-separator has-text-color has-neutral-150-color has-alpha-channel-opacity has-neutral-150-background-color has-background is-style-wide" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)"/>
 				<!-- /wp:separator -->
 
 				<!-- wp:heading {"level":3,"fontSize":"heading-5","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}}} -->
@@ -53,14 +53,14 @@
 
 				<!-- wp:groups/venue-map /-->
 
-				<!-- wp:separator {"className":"is-style-wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"color":"light-grey-1"} -->
-				<hr class="wp-block-separator has-text-color has-light-grey-1-color has-alpha-channel-opacity has-light-grey-1-background-color has-background is-style-wide" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)"/>
+				<!-- wp:separator {"className":"is-style-wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"backgroundColor":"neutral-150"} -->
+				<hr class="wp-block-separator has-text-color has-neutral-150-color has-alpha-channel-opacity has-neutral-150-background-color has-background is-style-wide" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)"/>
 				<!-- /wp:separator -->
 
 				<!-- wp:groups/rsvp-button /-->
 
-				<!-- wp:separator {"className":"is-style-wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"color":"light-grey-1"} -->
-				<hr class="wp-block-separator has-text-color has-light-grey-1-color has-alpha-channel-opacity has-light-grey-1-background-color has-background is-style-wide" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20)"/>
+				<!-- wp:separator {"className":"is-style-wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"backgroundColor":"neutral-150"} -->
+				<hr class="wp-block-separator has-text-color has-neutral-150-color has-alpha-channel-opacity has-neutral-150-background-color has-background is-style-wide" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)"/>
 				<!-- /wp:separator -->
 
 				<!-- wp:heading {"level":3,"fontSize":"heading-5","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}}} -->

--- a/wp-content/themes/groups-site/theme.json
+++ b/wp-content/themes/groups-site/theme.json
@@ -6,98 +6,182 @@
 		"color": {
 			"gradients": [],
 			"palette": [
-				{ "slug": "charcoal-0", "color": "#1a1919", "name": "Charcoal 0" },
-				{ "slug": "charcoal-1", "color": "#1e1e1e", "name": "Charcoal" },
-				{ "slug": "charcoal-2", "color": "#23282d", "name": "Charcoal 2" },
-				{ "slug": "charcoal-3", "color": "#40464d", "name": "Charcoal 3" },
-				{ "slug": "charcoal-4", "color": "#656a71", "name": "Charcoal 4" },
-				{ "slug": "charcoal-5", "color": "#979aa1", "name": "Charcoal 5" },
-				{ "slug": "light-grey-1", "color": "#d9d9d9", "name": "Light Grey" },
-				{ "slug": "light-grey-2", "color": "#f6f6f6", "name": "Light Grey 2" },
-				{ "slug": "white", "color": "#ffffff", "name": "White" },
-				{ "slug": "white-opacity-15", "color": "#ffffff26", "name": "White 15%" },
-				{ "slug": "black-opacity-15", "color": "#00000026", "name": "Black 15%" },
-				{ "slug": "dark-blueberry", "color": "#1d35b4", "name": "Dark Blueberry" },
-				{ "slug": "deep-blueberry", "color": "#213fd4", "name": "Deep Blueberry" },
-				{ "slug": "blueberry-1", "color": "#3858e9", "name": "Blueberry" },
-				{ "slug": "blueberry-2", "color": "#9fb1ff", "name": "Blueberry 2" },
-				{ "slug": "blueberry-3", "color": "#c7d1ff", "name": "Blueberry 3" },
-				{ "slug": "blueberry-4", "color": "#eff2ff", "name": "Blueberry 4" },
-				{ "slug": "pomegrade-1", "color": "#e26f56", "name": "Pomegrade" },
-				{ "slug": "pomegrade-2", "color": "#ffb7a7", "name": "Pomegrade 2" },
-				{ "slug": "pomegrade-3", "color": "#ffe9de", "name": "Pomegrade 3" },
-				{ "slug": "acid-green-1", "color": "#33f078", "name": "Acid Green" },
-				{ "slug": "acid-green-2", "color": "#c7ffdb", "name": "Acid Green 2" },
-				{ "slug": "acid-green-3", "color": "#e2ffed", "name": "Acid Green 3" },
-				{ "slug": "lemon-1", "color": "#fff972", "name": "Lemon" },
-				{ "slug": "lemon-2", "color": "#fffcb5", "name": "Lemon 2" },
-				{ "slug": "lemon-3", "color": "#fffdd6", "name": "Lemon 3" }
+				{ "slug": "primary-900", "color": "#1B2559", "name": "Primary 900" },
+				{ "slug": "primary-800", "color": "#243380", "name": "Primary 800" },
+				{ "slug": "primary-700", "color": "#2D41A6", "name": "Primary" },
+				{ "slug": "primary-600", "color": "#3B54D4", "name": "Primary 600" },
+				{ "slug": "primary-500", "color": "#5570F1", "name": "Primary Light" },
+				{ "slug": "primary-400", "color": "#7B91F5", "name": "Primary 400" },
+				{ "slug": "primary-300", "color": "#A8B8FA", "name": "Primary 300" },
+				{ "slug": "primary-200", "color": "#CDD5FC", "name": "Primary 200" },
+				{ "slug": "primary-100", "color": "#E8ECFE", "name": "Primary Tint" },
+				{ "slug": "primary-50", "color": "#F4F6FF", "name": "Primary 50" },
+				{ "slug": "accent-700", "color": "#B83D2B", "name": "Accent 700" },
+				{ "slug": "accent-600", "color": "#D4503C", "name": "Accent 600" },
+				{ "slug": "accent-500", "color": "#EF6351", "name": "Accent" },
+				{ "slug": "accent-400", "color": "#F4887A", "name": "Accent 400" },
+				{ "slug": "accent-300", "color": "#F9AEA4", "name": "Accent 300" },
+				{ "slug": "accent-200", "color": "#FCDAD5", "name": "Accent 200" },
+				{ "slug": "accent-100", "color": "#FEF0EE", "name": "Accent Tint" },
+				{ "slug": "neutral-950", "color": "#141118", "name": "Ink" },
+				{ "slug": "neutral-900", "color": "#1C1922", "name": "Ink Light" },
+				{ "slug": "neutral-800", "color": "#2E2B36", "name": "Neutral 800" },
+				{ "slug": "neutral-700", "color": "#47434F", "name": "Neutral 700" },
+				{ "slug": "neutral-600", "color": "#635E6C", "name": "Muted" },
+				{ "slug": "neutral-500", "color": "#817C8A", "name": "Neutral 500" },
+				{ "slug": "neutral-400", "color": "#A9A5B0", "name": "Neutral 400" },
+				{ "slug": "neutral-300", "color": "#CCC9D1", "name": "Neutral 300" },
+				{ "slug": "neutral-200", "color": "#E4E2E7", "name": "Border" },
+				{ "slug": "neutral-150", "color": "#EDEBF0", "name": "Neutral 150" },
+				{ "slug": "neutral-100", "color": "#F5F4F7", "name": "Surface" },
+				{ "slug": "neutral-50", "color": "#FAFAFA", "name": "Neutral 50" },
+				{ "slug": "neutral-0", "color": "#FFFFFF", "name": "White" },
+				{ "slug": "success-700", "color": "#15803D", "name": "Success 700" },
+				{ "slug": "success-500", "color": "#22C55E", "name": "Success" },
+				{ "slug": "success-100", "color": "#F0FDF4", "name": "Success Tint" },
+				{ "slug": "warning-700", "color": "#A16207", "name": "Warning 700" },
+				{ "slug": "warning-500", "color": "#EAB308", "name": "Warning" },
+				{ "slug": "warning-100", "color": "#FEFCE8", "name": "Warning Tint" },
+				{ "slug": "error-700", "color": "#B91C1C", "name": "Error 700" },
+				{ "slug": "error-500", "color": "#EF4444", "name": "Error" },
+				{ "slug": "error-100", "color": "#FEF2F2", "name": "Error Tint" },
+				{ "slug": "info-700", "color": "#1D4ED8", "name": "Info 700" },
+				{ "slug": "info-500", "color": "#3B82F6", "name": "Info" },
+				{ "slug": "info-100", "color": "#EFF6FF", "name": "Info Tint" },
+				{ "slug": "surface-dark-1", "color": "#141118", "name": "Dark Surface 1" },
+				{ "slug": "surface-dark-2", "color": "#1C1922", "name": "Dark Surface 2" },
+				{ "slug": "surface-dark-3", "color": "#2E2B36", "name": "Dark Surface 3" },
+				{ "slug": "surface-dark-text", "color": "#E4E2E7", "name": "Dark Surface Text" },
+				{ "slug": "surface-dark-muted", "color": "#817C8A", "name": "Dark Surface Muted" }
 			]
 		},
 		"typography": {
 			"fluid": true,
 			"fontFamilies": [
-				{ "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif", "name": "Inter", "slug": "inter" },
-				{ "fontFamily": "'EB Garamond', serif", "name": "EB Garamond", "slug": "eb-garamond" },
-				{ "fontFamily": "'IBM Plex Mono', monospace", "name": "IBM Plex Mono", "slug": "ibm-plex-mono" }
+				{
+					"fontFamily": "'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+					"name": "Plus Jakarta Sans",
+					"slug": "heading"
+				},
+				{
+					"fontFamily": "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+					"name": "Inter",
+					"slug": "body"
+				},
+				{
+					"fontFamily": "'JetBrains Mono', 'IBM Plex Mono', 'Fira Code', monospace",
+					"name": "JetBrains Mono",
+					"slug": "mono"
+				}
 			],
 			"fontSizes": [
-				{ "name": "Extra Small", "size": "12px", "slug": "extra-small" },
-				{ "name": "Small", "size": "clamp(14px, 0.875rem + 0.1vw, 15px)", "slug": "small" },
-				{ "name": "Normal", "size": "clamp(16px, 1rem + 0.125vw, 17px)", "slug": "normal" },
-				{ "name": "Large", "size": "clamp(18px, 1.125rem + 0.25vw, 21px)", "slug": "large" },
-				{ "name": "Extra Large", "size": "clamp(24px, 1.5rem + 0.5vw, 28px)", "slug": "extra-large" },
-				{ "name": "Heading 5", "size": "clamp(20px, 1.25rem + 0.5vw, 26px)", "slug": "heading-5" },
-				{ "name": "Heading 4", "size": "clamp(22px, 1.375rem + 0.625vw, 30px)", "slug": "heading-4" },
-				{ "name": "Heading 3", "size": "clamp(26px, 1.625rem + 0.75vw, 36px)", "slug": "heading-3" },
-				{ "name": "Heading 2", "size": "clamp(32px, 2rem + 1.5vw, 50px)", "slug": "heading-2" },
-				{ "name": "Heading 1", "size": "clamp(30px, 2rem + 2vw, 50px)", "slug": "heading-1" }
+				{ "name": "Caption", "size": "clamp(11px, 0.6875rem, 12px)", "slug": "caption" },
+				{ "name": "Small", "size": "clamp(13px, 0.8125rem + 0.05vw, 14px)", "slug": "small" },
+				{ "name": "Body", "size": "clamp(15px, 0.9375rem + 0.1vw, 17px)", "slug": "body" },
+				{ "name": "Body Large", "size": "clamp(17px, 1.0625rem + 0.15vw, 19px)", "slug": "body-lg" },
+				{ "name": "Heading 6", "size": "clamp(14px, 0.875rem + 0.1vw, 16px)", "slug": "heading-6" },
+				{ "name": "Heading 5", "size": "clamp(16px, 1rem + 0.2vw, 20px)", "slug": "heading-5" },
+				{ "name": "Heading 4", "size": "clamp(18px, 1.125rem + 0.4vw, 24px)", "slug": "heading-4" },
+				{ "name": "Heading 3", "size": "clamp(22px, 1.375rem + 0.6vw, 30px)", "slug": "heading-3" },
+				{ "name": "Heading 2", "size": "clamp(26px, 1.625rem + 1.2vw, 42px)", "slug": "heading-2" },
+				{ "name": "Heading 1", "size": "clamp(32px, 2rem + 1.8vw, 56px)", "slug": "heading-1" }
 			]
 		},
 		"spacing": {
 			"spacingScale": { "steps": 0 },
 			"spacingSizes": [
-				{ "name": "3X-Small", "size": "10px", "slug": "10" },
-				{ "name": "2X-Small", "size": "clamp(10px, 2vw, 20px)", "slug": "20" },
-				{ "name": "X-Small", "size": "clamp(20px, 3vw, 30px)", "slug": "30" },
-				{ "name": "Small", "size": "clamp(20px, 4vw, 40px)", "slug": "40" },
-				{ "name": "Medium", "size": "clamp(30px, 5vw, 50px)", "slug": "50" },
-				{ "name": "Large", "size": "clamp(30px, 6vw, 60px)", "slug": "60" },
-				{ "name": "X-Large", "size": "clamp(40px, 8vw, 80px)", "slug": "70" },
-				{ "name": "Edge Space", "size": "clamp(20px, 4vw, 80px)", "slug": "edge-space" }
+				{ "name": "4px", "size": "4px", "slug": "10" },
+				{ "name": "8px", "size": "8px", "slug": "20" },
+				{ "name": "12px", "size": "12px", "slug": "30" },
+				{ "name": "16px", "size": "16px", "slug": "40" },
+				{ "name": "24px", "size": "24px", "slug": "50" },
+				{ "name": "32px", "size": "32px", "slug": "60" },
+				{ "name": "48px", "size": "48px", "slug": "70" },
+				{ "name": "64px", "size": "64px", "slug": "80" },
+				{ "name": "96px", "size": "96px", "slug": "90" },
+				{ "name": "Edge Space", "size": "clamp(16px, 4vw, 80px)", "slug": "edge-space" }
 			],
 			"units": [ "px", "em", "rem", "vh", "vw", "%" ]
 		},
 		"layout": {
 			"contentSize": "960px",
-			"wideSize": "1600px"
+			"wideSize": "1280px"
 		},
 		"custom": {
-			"body": { "typography": { "lineHeight": 1.875 } },
-			"heading": { "typography": { "fontFamily": "var(--wp--preset--font-family--eb-garamond)", "fontWeight": 400, "lineHeight": 1.3 } },
-			"button": { "typography": { "lineHeight": "16px" }, "spacing": { "padding": { "top": "17px", "right": "32px", "bottom": "17px", "left": "32px" } } }
+			"body": { "typography": { "lineHeight": 1.65 } },
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--heading)",
+					"fontWeight": 700,
+					"lineHeight": 1.15
+				}
+			},
+			"button": {
+				"typography": { "lineHeight": "1.25" },
+				"spacing": {
+					"padding": {
+						"top": "12px",
+						"right": "24px",
+						"bottom": "12px",
+						"left": "24px"
+					}
+				}
+			}
 		}
 	},
 	"styles": {
-		"color": { "background": "var(--wp--preset--color--white)", "text": "var(--wp--preset--color--charcoal-1)" },
-		"typography": { "fontFamily": "var(--wp--preset--font-family--inter)", "fontSize": "var(--wp--preset--font-size--normal)", "lineHeight": "var(--wp--custom--body--typography--line-height)" },
-		"spacing": { "blockGap": "var(--wp--preset--spacing--20)" },
+		"color": {
+			"background": "var(--wp--preset--color--neutral-0)",
+			"text": "var(--wp--preset--color--neutral-900)"
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--body)",
+			"fontSize": "var(--wp--preset--font-size--body)",
+			"lineHeight": "var(--wp--custom--body--typography--line-height)"
+		},
+		"spacing": {
+			"blockGap": "var(--wp--preset--spacing--40)"
+		},
 		"elements": {
-			"heading": { "typography": { "fontFamily": "var(--wp--preset--font-family--eb-garamond)", "fontWeight": "400", "lineHeight": "1.3" }, "color": { "text": "var(--wp--preset--color--charcoal-0)" } },
-			"h1": { "typography": { "fontSize": "var(--wp--preset--font-size--heading-1)" } },
-			"h2": { "typography": { "fontSize": "var(--wp--preset--font-size--heading-2)" } },
-			"h3": { "typography": { "fontSize": "var(--wp--preset--font-size--heading-3)" } },
-			"h4": { "typography": { "fontSize": "var(--wp--preset--font-size--heading-4)" } },
-			"h5": { "typography": { "fontSize": "var(--wp--preset--font-size--heading-5)" } },
-			"link": { "color": { "text": "var(--wp--preset--color--blueberry-1)" }, ":hover": { "color": { "text": "var(--wp--preset--color--deep-blueberry)" } } },
-			"button": { "color": { "background": "var(--wp--preset--color--blueberry-1)", "text": "var(--wp--preset--color--white)" }, "typography": { "fontFamily": "var(--wp--preset--font-family--inter)", "fontSize": "var(--wp--preset--font-size--normal)", "fontWeight": "600", "lineHeight": "var(--wp--custom--button--typography--line-height)" }, "border": { "radius": "2px" }, ":hover": { "color": { "background": "var(--wp--preset--color--deep-blueberry)" } } }
+			"heading": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--heading)",
+					"fontWeight": "700",
+					"lineHeight": "1.15"
+				},
+				"color": {
+					"text": "var(--wp--preset--color--neutral-950)"
+				}
+			},
+			"h1": { "typography": { "fontSize": "var(--wp--preset--font-size--heading-1)", "fontWeight": "800", "lineHeight": "1.1", "letterSpacing": "-0.025em" } },
+			"h2": { "typography": { "fontSize": "var(--wp--preset--font-size--heading-2)", "fontWeight": "700", "lineHeight": "1.15", "letterSpacing": "-0.02em" } },
+			"h3": { "typography": { "fontSize": "var(--wp--preset--font-size--heading-3)", "fontWeight": "700", "lineHeight": "1.2", "letterSpacing": "-0.015em" } },
+			"h4": { "typography": { "fontSize": "var(--wp--preset--font-size--heading-4)", "fontWeight": "600", "lineHeight": "1.3", "letterSpacing": "-0.01em" } },
+			"h5": { "typography": { "fontSize": "var(--wp--preset--font-size--heading-5)", "fontWeight": "600", "lineHeight": "1.35" } },
+			"h6": { "typography": { "fontSize": "var(--wp--preset--font-size--heading-6)", "fontWeight": "600", "lineHeight": "1.4", "letterSpacing": "0.02em" } },
+			"link": {
+				"color": { "text": "var(--wp--preset--color--primary-700)" },
+				":hover": { "color": { "text": "var(--wp--preset--color--primary-600)" } }
+			},
+			"button": {
+				"color": { "background": "var(--wp--preset--color--primary-700)", "text": "var(--wp--preset--color--neutral-0)" },
+				"typography": { "fontFamily": "var(--wp--preset--font-family--body)", "fontSize": "var(--wp--preset--font-size--body)", "fontWeight": "600", "lineHeight": "var(--wp--custom--button--typography--line-height)" },
+				"border": { "radius": "8px" },
+				":hover": { "color": { "background": "var(--wp--preset--color--primary-600)" } }
+			}
 		},
 		"blocks": {
-			"core/site-title": { "typography": { "fontSize": "var(--wp--preset--font-size--large)", "fontWeight": "700" }, "elements": { "link": { "color": { "text": "var(--wp--preset--color--charcoal-0)" }, "typography": { "textDecoration": "none" } } } },
+			"core/site-title": {
+				"typography": { "fontFamily": "var(--wp--preset--font-family--heading)", "fontSize": "var(--wp--preset--font-size--heading-5)", "fontWeight": "700" },
+				"elements": { "link": { "color": { "text": "var(--wp--preset--color--neutral-950)" }, "typography": { "textDecoration": "none" } } }
+			},
 			"core/navigation": { "typography": { "fontSize": "var(--wp--preset--font-size--small)", "fontWeight": "500" } },
-			"core/post-title": { "typography": { "fontSize": "var(--wp--preset--font-size--heading-1)" }, "elements": { "link": { "color": { "text": "var(--wp--preset--color--charcoal-0)" }, "typography": { "textDecoration": "none" }, ":hover": { "typography": { "textDecoration": "underline" } } } } },
+			"core/post-title": {
+				"typography": { "fontSize": "var(--wp--preset--font-size--heading-1)" },
+				"elements": { "link": { "color": { "text": "var(--wp--preset--color--neutral-950)" }, "typography": { "textDecoration": "none" }, ":hover": { "color": { "text": "var(--wp--preset--color--primary-700)" } } } }
+			},
 			"core/query-pagination": { "typography": { "fontSize": "var(--wp--preset--font-size--small)" } },
-			"core/separator": { "color": { "text": "var(--wp--preset--color--light-grey-1)" } }
+			"core/separator": { "color": { "text": "var(--wp--preset--color--neutral-200)" } }
 		}
 	},
 	"templateParts": [


### PR DESCRIPTION
## Summary

- **Color palette**: Replaced charcoal/blueberry system with warm design tokens -- primary indigo (10-shade scale), warm coral accent, warm gray neutrals, and semantic colors (success, warning, error, info) with tints
- **Typography**: Switched from EB Garamond/Inter to Plus Jakarta Sans (headings, 500-800 weight) + Inter (body, 400-600) + JetBrains Mono; fluid `clamp()` type scale from 11px caption to 56px h1 with proper letter-spacing
- **Spacing**: Fixed 4px-base scale (4/8/12/16/24/32/48/64/96px) replacing old fluid clamp values; edge space `clamp(16px, 4vw, 80px)`; layout max 1280px (was 1600px)
- **Header**: Clean single-row with sticky positioning, backdrop blur, site title in heading font + page-list nav; removed dark WordPress.org global bar
- **Footer**: Two-tier dark surface -- community callout band (`surface-dark-2`) + footer proper (`surface-dark-1`) with "Code is Poetry" in mono font
- **Custom CSS** (`assets/css/custom.css`): 1100+ lines implementing event cards (shadow lift, thumbnail zoom on hover), RSVP button states (default/attending/waitlisted/loading/disabled with proper color transitions), member avatar cards, role badges (organizer/co-org/speaker/member), status badges (upcoming/happening-now with pulse/past/cancelled/draft), form fields with focus rings, and navigation styles
- **Templates**: All updated with new spacing tokens (generous whitespace), 1280px max width, new color references; single-event uses 62/38 column split with sticky sidebar at 92px offset; front-page has warm `neutral-100` hero section; members page includes descriptive subtitle
- **Accessibility**: All transitions wrapped in `prefers-reduced-motion`, focus-visible outlines using `primary-500`, skip link styled

## Test plan

- [ ] Verify Google Fonts load (Plus Jakarta Sans, Inter, JetBrains Mono)
- [ ] Check front-page hero uses warm gray background, not dark charcoal
- [ ] Confirm header is sticky with blur effect on scroll
- [ ] Verify no dark WordPress.org bar appears at top
- [ ] Test event card hover states (lift + shadow + thumbnail zoom)
- [ ] Check single event page two-column layout with sticky sidebar
- [ ] Verify footer shows community callout + dark footer with "Code is Poetry" in mono
- [ ] Test mobile responsiveness (sidebar stacks, grids collapse)
- [ ] Verify `npm run build:blocks` succeeds
- [ ] Check `prefers-reduced-motion: reduce` disables animations

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)