### PR TITLE
Add event comments/discussion and photo gallery

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/post-types/class-event.php
+++ b/wp-content/plugins/wordpress-groups/includes/post-types/class-event.php
@@ -76,7 +76,7 @@ class Event {
 			'rest_base'           => 'events',
 			'menu_position'       => 5,
 			'menu_icon'           => 'dashicons-calendar-alt',
-			'supports'            => [ 'title', 'editor', 'thumbnail', 'excerpt', 'custom-fields' ],
+			'supports'            => [ 'title', 'editor', 'thumbnail', 'excerpt', 'custom-fields', 'comments' ],
 			'has_archive'         => true,
 			'rewrite'             => [ 'slug' => 'event' ],
 			'capability_type'     => 'post',

--- a/wp-content/plugins/wordpress-groups/seed-data-tokyo.php
+++ b/wp-content/plugins/wordpress-groups/seed-data-tokyo.php
@@ -105,7 +105,7 @@ $events_data = [
 	],
 	[
 		'title'  => 'WordPress Translation Day',
-		'content' => "We contributed to translating WordPress core and plugins into Japanese.\n\n12 new strings translated!",
+		'content' => "We contributed to translating WordPress core and plugins into Japanese.\n\n12 new strings translated!\n\n<!-- wp:heading {\"level\":3} -->\n<h3 class=\"wp-block-heading\">Event Photos</h3>\n<!-- /wp:heading -->\n\n<!-- wp:gallery {\"linkTo\":\"none\",\"columns\":3,\"className\":\"groups-site-event-photo-gallery\"} -->\n<figure class=\"wp-block-gallery has-nested-images columns-3 is-cropped groups-site-event-photo-gallery\">\n<!-- wp:image {\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://picsum.photos/seed/tokyo-translate1/800/600\" alt=\"Translation sprint in progress\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:image {\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://picsum.photos/seed/tokyo-translate2/800/600\" alt=\"Team celebrating completed translations\"/></figure>\n<!-- /wp:image -->\n</figure>\n<!-- /wp:gallery -->",
 		'offset' => '-14 days',
 		'time'   => '10:00:00',
 		'hours'  => 4,
@@ -162,6 +162,47 @@ foreach ( $event_ids as $eid ) {
 	}
 }
 echo "✓ $rsvp_count RSVPs.\n";
+
+// Discussion comments on the past event.
+$past_event_id = $event_ids[3] ?? 0;
+if ( $past_event_id ) {
+	$discussion_comments = [
+		[
+			'user'    => 'sakura',
+			'content' => 'This was such a productive day! I learned a lot about the translation workflow.',
+		],
+		[
+			'user'    => 'kenji',
+			'content' => 'Great work everyone. 12 strings is a solid contribution for one session!',
+		],
+		[
+			'user'    => 'yuki',
+			'content' => 'Thanks to all who participated. We will schedule another translation sprint next month.',
+		],
+	];
+
+	$dc_count = 0;
+	foreach ( $discussion_comments as $dc ) {
+		$uid  = $user_ids[ $dc['user'] ] ?? 0;
+		$user = $uid ? get_user_by( 'ID', $uid ) : null;
+		if ( ! $user ) {
+			continue;
+		}
+		$cid = wp_insert_comment( [
+			'comment_post_ID'      => $past_event_id,
+			'user_id'              => $uid,
+			'comment_author'       => $user->display_name,
+			'comment_author_email' => $user->user_email,
+			'comment_type'         => 'comment',
+			'comment_approved'     => 1,
+			'comment_content'      => $dc['content'],
+		] );
+		if ( $cid ) {
+			$dc_count++;
+		}
+	}
+	echo "✓ $dc_count discussion comments.\n";
+}
 
 // Pages.
 foreach ( [ 'events' => 'Events', 'members' => 'Members', 'about' => 'About' ] as $slug => $title ) {

--- a/wp-content/plugins/wordpress-groups/seed-data.php
+++ b/wp-content/plugins/wordpress-groups/seed-data.php
@@ -141,7 +141,7 @@ $events = [
 	],
 	[
 		'title'   => 'WordPress 6.7 Release Party',
-		'content' => "We celebrated the release of WordPress 6.7 with demos, lightning talks, and cake!\n\nThanks to everyone who came.",
+		'content' => "We celebrated the release of WordPress 6.7 with demos, lightning talks, and cake!\n\nThanks to everyone who came.\n\n<!-- wp:heading {\"level\":3} -->\n<h3 class=\"wp-block-heading\">Event Photos</h3>\n<!-- /wp:heading -->\n\n<!-- wp:gallery {\"linkTo\":\"none\",\"columns\":3,\"className\":\"groups-site-event-photo-gallery\"} -->\n<figure class=\"wp-block-gallery has-nested-images columns-3 is-cropped groups-site-event-photo-gallery\">\n<!-- wp:image {\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://picsum.photos/seed/wp67-party1/800/600\" alt=\"Attendees gathering for the release party\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:image {\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://picsum.photos/seed/wp67-party2/800/600\" alt=\"Lightning talk presentation\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:image {\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://picsum.photos/seed/wp67-party3/800/600\" alt=\"Group photo at the end of the event\"/></figure>\n<!-- /wp:image -->\n</figure>\n<!-- /wp:gallery -->",
 		'offset'  => '-7 days',
 		'time'    => '18:30:00',
 		'hours'   => 2,
@@ -217,6 +217,53 @@ foreach ( $event_ids as $event_id ) {
 	}
 }
 echo "✓ $rsvp_count RSVPs created.\n";
+
+// --- Discussion comments on the past event ---
+$past_event_id = $event_ids[3] ?? 0; // The release party (4th event).
+if ( $past_event_id ) {
+	$discussion_comments = [
+		[
+			'user'    => 'member1',
+			'content' => 'Great event! The lightning talks were really informative. Looking forward to the next one.',
+		],
+		[
+			'user'    => 'member2',
+			'content' => 'Thanks for organising this! The demo of the new block editor features was my favourite part.',
+		],
+		[
+			'user'    => 'organizer',
+			'content' => 'Thanks everyone for coming! We had a fantastic turnout. Slides from the talks will be posted soon.',
+		],
+		[
+			'user'    => 'member3',
+			'content' => 'Does anyone have a link to that theme customisation tool that was mentioned during the Q&A?',
+		],
+	];
+
+	$comment_count = 0;
+	foreach ( $discussion_comments as $dc ) {
+		$uid  = $user_ids[ $dc['user'] ] ?? 0;
+		$user = $uid ? get_user_by( 'ID', $uid ) : null;
+		if ( ! $user ) {
+			continue;
+		}
+
+		$cid = wp_insert_comment( [
+			'comment_post_ID'      => $past_event_id,
+			'user_id'              => $uid,
+			'comment_author'       => $user->display_name,
+			'comment_author_email' => $user->user_email,
+			'comment_type'         => 'comment',
+			'comment_approved'     => 1,
+			'comment_content'      => $dc['content'],
+		] );
+
+		if ( $cid ) {
+			$comment_count++;
+		}
+	}
+	echo "✓ $comment_count discussion comments created on past event.\n";
+}
 
 // --- Pages ---
 $pages = [

--- a/wp-content/themes/groups-site/templates/single-event.html
+++ b/wp-content/themes/groups-site/templates/single-event.html
@@ -30,6 +30,60 @@
 				<!-- wp:groups/rsvp-list /-->
 			</div>
 			<!-- /wp:group -->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"},"className":"groups-site-event-gallery"} -->
+			<div class="wp-block-group groups-site-event-gallery" style="margin-bottom:var(--wp--preset--spacing--60)">
+				<!-- wp:heading {"level":2,"fontSize":"heading-3"} -->
+				<h2 class="wp-block-heading has-heading-3-font-size">Photo Gallery</h2>
+				<!-- /wp:heading -->
+
+				<!-- wp:paragraph {"fontSize":"small","style":{"color":{"text":"var:preset|color|neutral-500"}}} -->
+				<p class="has-small-font-size" style="color:var(--wp--preset--color--neutral-500)">Photos from this event are displayed within the event content above. Organizers can add a gallery using the block editor.</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"},"className":"groups-site-event-discussion"} -->
+			<div class="wp-block-group groups-site-event-discussion" style="margin-bottom:var(--wp--preset--spacing--60)">
+				<!-- wp:heading {"level":2,"fontSize":"heading-3"} -->
+				<h2 class="wp-block-heading has-heading-3-font-size">Discussion</h2>
+				<!-- /wp:heading -->
+
+				<!-- wp:comments -->
+				<div class="wp-block-comments">
+					<!-- wp:comments-title {"level":3,"fontSize":"heading-5"} /-->
+
+					<!-- wp:comment-template -->
+						<!-- wp:columns {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}}} -->
+						<div class="wp-block-columns">
+							<!-- wp:column {"width":"40px"} -->
+							<div class="wp-block-column" style="flex-basis:40px">
+								<!-- wp:avatar {"size":40,"style":{"border":{"radius":"20px"}}} /-->
+							</div>
+							<!-- /wp:column -->
+
+							<!-- wp:column -->
+							<div class="wp-block-column">
+								<!-- wp:comment-author-name {"fontSize":"small"} /-->
+								<!-- wp:comment-date {"fontSize":"small","style":{"color":{"text":"var:preset|color|neutral-500"}}} /-->
+								<!-- wp:comment-content /-->
+								<!-- wp:comment-reply-link {"fontSize":"small"} /-->
+							</div>
+							<!-- /wp:column -->
+						</div>
+						<!-- /wp:columns -->
+					<!-- /wp:comment-template -->
+
+					<!-- wp:comments-pagination -->
+						<!-- wp:comments-pagination-previous /-->
+						<!-- wp:comments-pagination-numbers /-->
+						<!-- wp:comments-pagination-next /-->
+					<!-- /wp:comments-pagination -->
+
+					<!-- wp:post-comments-form /-->
+				</div>
+				<!-- /wp:comments -->
+			</div>
+			<!-- /wp:group -->
 		</div>
 		<!-- /wp:column -->
 


### PR DESCRIPTION
## Summary
- **Comments/Discussion (#129):** Enable `comments` support on the `event` CPT and add a full Discussion section to the single-event template using core `wp:comments`, `wp:comment-template`, and `wp:post-comments-form` blocks with avatar, author name, date, reply link, and pagination
- **Photo Gallery (#130):** Add a Photo Gallery guidance section to the single-event template; seed past events with `wp:gallery` blocks containing placeholder images from picsum.photos to demonstrate the pattern
- **Seed data:** Add sample discussion comments (4 for Melbourne, 3 for Tokyo) on past events so the feature is visible out of the box

Closes #129, Closes #130

## Test plan
- [ ] Run seed data scripts and verify discussion comments appear on past events
- [ ] Visit a single event page and confirm the Discussion section renders with comment form
- [ ] Verify the Photo Gallery section appears in the template
- [ ] Check that the past event seed data includes a gallery block with placeholder images
- [ ] Confirm comments can be posted on events via the front-end form

🤖 Generated with [Claude Code](https://claude.com/claude-code)