### PR TITLE
Add map view toggle to group directory block

### DIFF
--- a/wp-content/plugins/wordpress-groups/blocks/group-directory/render.php
+++ b/wp-content/plugins/wordpress-groups/blocks/group-directory/render.php
@@ -50,6 +50,8 @@ foreach ( $query->posts as $post ) {
 		'name'         => esc_html( $post->post_title ),
 		'city'         => sanitize_text_field( get_post_meta( $post->ID, '_meetup_city', true ) ),
 		'country'      => sanitize_text_field( get_post_meta( $post->ID, '_meetup_country', true ) ),
+		'latitude'     => (float) get_post_meta( $post->ID, '_meetup_latitude', true ),
+		'longitude'    => (float) get_post_meta( $post->ID, '_meetup_longitude', true ),
 		'member_count' => absint( get_post_meta( $post->ID, '_meetup_member_count', true ) ),
 		'site_url'     => $site_url,
 	];
@@ -57,12 +59,46 @@ foreach ( $query->posts as $post ) {
 
 restore_current_blog();
 
+// Build a JSON array of groups with valid coordinates for the map view.
+$map_groups = [];
+foreach ( $groups as $group ) {
+	if ( ! empty( $group['latitude'] ) && ! empty( $group['longitude'] ) ) {
+		$map_groups[] = [
+			'id'        => $group['id'],
+			'name'      => $group['name'],
+			'city'      => $group['city'],
+			'country'   => $group['country'],
+			'latitude'  => $group['latitude'],
+			'longitude' => $group['longitude'],
+			'site_url'  => $group['site_url'],
+		];
+	}
+}
+
+// Enqueue Leaflet CSS from CDN (same as venue-map block).
+wp_enqueue_style(
+	'leaflet',
+	'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css',
+	[],
+	'1.9.4'
+);
+
+// Enqueue Leaflet JS from CDN (same as venue-map block).
+wp_enqueue_script(
+	'leaflet',
+	'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js',
+	[],
+	'1.9.4',
+	true
+);
+
 $wrapper_attributes = get_block_wrapper_attributes( [
-	'class'          => 'wp-block-groups-group-directory',
-	'data-per-page'  => $per_page,
-	'data-total'     => $total,
-	'data-pages'     => $total_pages,
-	'data-groups'    => wp_json_encode( $groups ),
+	'class'            => 'wp-block-groups-group-directory',
+	'data-per-page'    => $per_page,
+	'data-total'       => $total,
+	'data-pages'       => $total_pages,
+	'data-groups'      => wp_json_encode( $groups ),
+	'data-map-groups'  => wp_json_encode( $map_groups ),
 ] );
 ?>
 

--- a/wp-content/plugins/wordpress-groups/blocks/group-directory/style.scss
+++ b/wp-content/plugins/wordpress-groups/blocks/group-directory/style.scss
@@ -187,6 +187,123 @@
 		color: var(--wp--preset--color--charcoal-4, #656a71);
 	}
 
+	// Toolbar: search + view toggle side by side.
+	&__toolbar {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--wp--preset--spacing--20, 16px);
+		margin-bottom: var(--wp--preset--spacing--40, 30px);
+	}
+
+	// When toolbar is present, remove standalone search margin.
+	&__toolbar &__search {
+		margin-bottom: 0;
+	}
+
+	// View toggle buttons.
+	&__view-toggle {
+		display: flex;
+		gap: 0;
+		border: 1px solid var(--wp--preset--color--light-grey-1, #d9d9d9);
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	&__view-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: var(--wp--preset--spacing--10, 8px) var(--wp--preset--spacing--20, 16px);
+		border: none;
+		background: var(--wp--preset--color--white, #ffffff);
+		color: var(--wp--preset--color--charcoal-3, #40464d);
+		font-size: var(--wp--preset--font-size--small, 14px);
+		font-family: inherit;
+		cursor: pointer;
+		transition: background-color 0.2s ease, color 0.2s ease;
+
+		&:not(:last-child) {
+			border-right: 1px solid var(--wp--preset--color--light-grey-1, #d9d9d9);
+		}
+
+		&:hover:not(&--active) {
+			background: var(--wp--preset--color--light-grey-2, #f6f6f6);
+		}
+
+		&--active {
+			background: var(--wp--preset--color--blueberry-1, #3858e9);
+			color: var(--wp--preset--color--white, #ffffff);
+		}
+	}
+
+	// Map view container.
+	&__map-wrapper {
+		position: relative;
+	}
+
+	&__map-container {
+		width: 100%;
+		height: 400px;
+		background: var(--wp--preset--color--light-grey-2, #f6f6f6);
+		border-radius: 4px;
+		overflow: hidden;
+		z-index: 0;
+
+		.leaflet-container {
+			width: 100%;
+			height: 100%;
+			font-family: inherit;
+		}
+	}
+
+	// Geolocation button.
+	&__geolocate-btn {
+		position: absolute;
+		top: var(--wp--preset--spacing--10, 10px);
+		right: var(--wp--preset--spacing--10, 10px);
+		z-index: 1000;
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: var(--wp--preset--spacing--10, 8px) var(--wp--preset--spacing--20, 12px);
+		border: 2px solid rgba(0, 0, 0, 0.2);
+		border-radius: 4px;
+		background: var(--wp--preset--color--white, #ffffff);
+		color: var(--wp--preset--color--charcoal-3, #40464d);
+		font-size: var(--wp--preset--font-size--small, 14px);
+		font-family: inherit;
+		cursor: pointer;
+		box-shadow: 0 1px 5px rgba(0, 0, 0, 0.16);
+		transition: background-color 0.2s ease;
+
+		&:hover:not(:disabled) {
+			background: var(--wp--preset--color--light-grey-2, #f6f6f6);
+		}
+
+		&:disabled {
+			opacity: 0.65;
+			cursor: wait;
+		}
+	}
+
+	// Responsive: shorter map on small screens.
+	@media (max-width: 600px) {
+		&__map-container {
+			height: 280px;
+		}
+
+		&__toolbar {
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		&__view-toggle {
+			align-self: flex-start;
+		}
+	}
+
 	// Editor preview styles.
 	&__editor-preview {
 		width: 100%;

--- a/wp-content/plugins/wordpress-groups/blocks/group-directory/view.js
+++ b/wp-content/plugins/wordpress-groups/blocks/group-directory/view.js
@@ -2,7 +2,7 @@
  * Group Directory — frontend interactive script.
  *
  * Hydrates the server-rendered directory container with interactive search,
- * filtering, and pagination via the REST API.
+ * filtering, pagination, and an optional Leaflet map view.
  */
 
 import apiFetch from '@wordpress/api-fetch';
@@ -156,21 +156,218 @@ function Pagination( { currentPage, totalPages, onPageChange } ) {
 }
 
 /**
+ * Map View component using Leaflet.
+ *
+ * Renders an OpenStreetMap with markers for each group that has coordinates.
+ *
+ * @param {Object}   props
+ * @param {Array}    props.mapGroups   Groups with lat/lon data for the map.
+ * @param {Function} props.onLoadAll   Callback to fetch all groups for the map.
+ */
+function MapView( { mapGroups, onLoadAll } ) {
+	const mapRef = useRef( null );
+	const mapInstanceRef = useRef( null );
+	const markersRef = useRef( [] );
+	const [ geolocating, setGeolocating ] = useState( false );
+
+	/**
+	 * Initialize the Leaflet map on first render.
+	 */
+	useEffect( () => {
+		if ( ! mapRef.current || ! window.L ) {
+			return;
+		}
+
+		if ( mapInstanceRef.current ) {
+			return;
+		}
+
+		const map = window.L.map( mapRef.current, {
+			scrollWheelZoom: false,
+		} ).setView( [ 20, 0 ], 2 );
+
+		window.L.tileLayer( 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+			attribution:
+				'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+			maxZoom: 19,
+		} ).addTo( map );
+
+		mapInstanceRef.current = map;
+
+		// Trigger a load of all groups for the map.
+		if ( onLoadAll ) {
+			onLoadAll();
+		}
+
+		// Invalidate size after layout settles.
+		setTimeout( () => map.invalidateSize(), 100 );
+
+		return () => {
+			map.remove();
+			mapInstanceRef.current = null;
+		};
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	/**
+	 * Update markers when mapGroups changes.
+	 */
+	useEffect( () => {
+		const map = mapInstanceRef.current;
+		if ( ! map || ! window.L ) {
+			return;
+		}
+
+		// Clear existing markers.
+		markersRef.current.forEach( ( m ) => m.remove() );
+		markersRef.current = [];
+
+		const bounds = [];
+
+		mapGroups.forEach( ( group ) => {
+			if ( ! group.latitude || ! group.longitude ) {
+				return;
+			}
+
+			const latlng = [ group.latitude, group.longitude ];
+			bounds.push( latlng );
+
+			const locationParts = [ group.city, group.country ].filter( Boolean );
+			const location = locationParts.join( ', ' );
+
+			let popupContent = `<strong>${ group.name }</strong>`;
+			if ( location ) {
+				popupContent += `<br>${ location }`;
+			}
+			if ( group.site_url ) {
+				popupContent += `<br><a href="${ group.site_url }">${ __( 'Visit group', 'wordpress-groups' ) }</a>`;
+			}
+
+			const marker = window.L.marker( latlng )
+				.bindPopup( popupContent )
+				.addTo( map );
+
+			markersRef.current.push( marker );
+		} );
+
+		// Fit the map to show all markers.
+		if ( bounds.length > 0 ) {
+			map.fitBounds( bounds, { padding: [ 40, 40 ], maxZoom: 12 } );
+		}
+	}, [ mapGroups ] );
+
+	/**
+	 * Handle geolocation button click.
+	 */
+	const handleGeolocate = useCallback( () => {
+		if ( ! navigator.geolocation || ! mapInstanceRef.current ) {
+			return;
+		}
+
+		setGeolocating( true );
+
+		navigator.geolocation.getCurrentPosition(
+			( position ) => {
+				const { latitude, longitude } = position.coords;
+				mapInstanceRef.current.setView( [ latitude, longitude ], 10 );
+				setGeolocating( false );
+			},
+			() => {
+				setGeolocating( false );
+			},
+			{ timeout: 10000 }
+		);
+	}, [] );
+
+	const supportsGeolocation = typeof navigator !== 'undefined' && 'geolocation' in navigator;
+
+	return createElement(
+		'div',
+		{ className: 'wp-block-groups-group-directory__map-wrapper' },
+		supportsGeolocation &&
+			createElement(
+				'button',
+				{
+					type: 'button',
+					className: 'wp-block-groups-group-directory__geolocate-btn',
+					onClick: handleGeolocate,
+					disabled: geolocating,
+					'aria-label': __( 'Center map on my location', 'wordpress-groups' ),
+				},
+				geolocating
+					? __( 'Locating\u2026', 'wordpress-groups' )
+					: __( 'My location', 'wordpress-groups' )
+			),
+		createElement( 'div', {
+			ref: mapRef,
+			className: 'wp-block-groups-group-directory__map-container',
+			role: 'application',
+			'aria-label': __( 'Interactive map of community groups', 'wordpress-groups' ),
+		} )
+	);
+}
+
+/**
+ * View toggle buttons for switching between list and map.
+ *
+ * @param {Object}   props
+ * @param {string}   props.activeView  Current view ('list' or 'map').
+ * @param {Function} props.onToggle    Callback when a view is selected.
+ */
+function ViewToggle( { activeView, onToggle } ) {
+	return createElement(
+		'div',
+		{
+			className: 'wp-block-groups-group-directory__view-toggle',
+			role: 'tablist',
+			'aria-label': __( 'Directory view', 'wordpress-groups' ),
+		},
+		createElement(
+			'button',
+			{
+				type: 'button',
+				role: 'tab',
+				className: `wp-block-groups-group-directory__view-btn${ activeView === 'list' ? ' wp-block-groups-group-directory__view-btn--active' : '' }`,
+				onClick: () => onToggle( 'list' ),
+				'aria-selected': activeView === 'list',
+				'aria-controls': 'group-directory-list-view',
+			},
+			__( 'List View', 'wordpress-groups' )
+		),
+		createElement(
+			'button',
+			{
+				type: 'button',
+				role: 'tab',
+				className: `wp-block-groups-group-directory__view-btn${ activeView === 'map' ? ' wp-block-groups-group-directory__view-btn--active' : '' }`,
+				onClick: () => onToggle( 'map' ),
+				'aria-selected': activeView === 'map',
+				'aria-controls': 'group-directory-map-view',
+			},
+			__( 'Map View', 'wordpress-groups' )
+		)
+	);
+}
+
+/**
  * Main Group Directory component.
  *
  * @param {Object}   props
- * @param {number}   props.perPage       Groups per page.
- * @param {Array}    props.initialGroups  Server-rendered initial groups.
- * @param {number}   props.initialTotal   Total number of groups.
- * @param {number}   props.initialPages   Total number of pages.
+ * @param {number}   props.perPage         Groups per page.
+ * @param {Array}    props.initialGroups    Server-rendered initial groups.
+ * @param {number}   props.initialTotal     Total number of groups.
+ * @param {number}   props.initialPages     Total number of pages.
+ * @param {Array}    props.initialMapGroups Initial groups with coordinates for the map.
  */
-export function GroupDirectory( { perPage, initialGroups, initialTotal, initialPages } ) {
+export function GroupDirectory( { perPage, initialGroups, initialTotal, initialPages, initialMapGroups } ) {
 	const [ groups, setGroups ] = useState( initialGroups );
 	const [ search, setSearch ] = useState( '' );
 	const [ currentPage, setCurrentPage ] = useState( 1 );
 	const [ totalPages, setTotalPages ] = useState( initialPages );
 	const [ total, setTotal ] = useState( initialTotal );
 	const [ isLoading, setIsLoading ] = useState( false );
+	const [ activeView, setActiveView ] = useState( 'list' );
+	const [ mapGroups, setMapGroups ] = useState( initialMapGroups );
+	const [ allMapGroupsLoaded, setAllMapGroupsLoaded ] = useState( false );
 	const abortRef = useRef( null );
 
 	/**
@@ -220,6 +417,33 @@ export function GroupDirectory( { perPage, initialGroups, initialTotal, initialP
 	}, [ perPage ] );
 
 	/**
+	 * Fetch all groups with coordinates for the map view.
+	 * Uses a large per_page to get everything in one request.
+	 */
+	const fetchAllMapGroups = useCallback( async () => {
+		if ( allMapGroupsLoaded ) {
+			return;
+		}
+
+		try {
+			const response = await apiFetch( {
+				path: '/groups/v1/groups?per_page=200',
+				parse: false,
+			} );
+
+			const data = await response.json();
+			const geoGroups = data.filter(
+				( g ) => g.latitude && g.longitude
+			);
+
+			setMapGroups( geoGroups );
+			setAllMapGroupsLoaded( true );
+		} catch {
+			// On error, keep the initial map groups from server render.
+		}
+	}, [ allMapGroupsLoaded ] );
+
+	/**
 	 * Debounced search handler.
 	 */
 	const debouncedSearch = useCallback(
@@ -252,64 +476,92 @@ export function GroupDirectory( { perPage, initialGroups, initialTotal, initialP
 		{ className: 'wp-block-groups-group-directory__inner' },
 		createElement(
 			'div',
-			{ className: 'wp-block-groups-group-directory__search' },
+			{ className: 'wp-block-groups-group-directory__toolbar' },
 			createElement(
-				'label',
-				{
-					htmlFor: 'group-directory-search',
-					className: 'screen-reader-text',
-				},
-				__( 'Search groups', 'wordpress-groups' )
+				'div',
+				{ className: 'wp-block-groups-group-directory__search' },
+				createElement(
+					'label',
+					{
+						htmlFor: 'group-directory-search',
+						className: 'screen-reader-text',
+					},
+					__( 'Search groups', 'wordpress-groups' )
+				),
+				createElement( 'input', {
+					type: 'search',
+					id: 'group-directory-search',
+					className: 'wp-block-groups-group-directory__search-input',
+					placeholder: __( 'Search groups\u2026', 'wordpress-groups' ),
+					value: search,
+					onChange: handleSearchChange,
+				} )
 			),
-			createElement( 'input', {
-				type: 'search',
-				id: 'group-directory-search',
-				className: 'wp-block-groups-group-directory__search-input',
-				placeholder: __( 'Search groups\u2026', 'wordpress-groups' ),
-				value: search,
-				onChange: handleSearchChange,
+			createElement( ViewToggle, {
+				activeView,
+				onToggle: setActiveView,
 			} )
 		),
-		createElement(
-			'div',
-			{
-				className: 'wp-block-groups-group-directory__results',
-				'aria-live': 'polite',
-				'aria-busy': isLoading,
-			},
-			isLoading &&
+		activeView === 'list' &&
+			createElement(
+				'div',
+				{
+					id: 'group-directory-list-view',
+					role: 'tabpanel',
+				},
 				createElement(
 					'div',
-					{ className: 'wp-block-groups-group-directory__loading' },
-					createElement( 'span', {
-						className: 'wp-block-groups-group-directory__spinner',
-						'aria-hidden': 'true',
-					} ),
-					__( 'Loading groups\u2026', 'wordpress-groups' )
+					{
+						className: 'wp-block-groups-group-directory__results',
+						'aria-live': 'polite',
+						'aria-busy': isLoading,
+					},
+					isLoading &&
+						createElement(
+							'div',
+							{ className: 'wp-block-groups-group-directory__loading' },
+							createElement( 'span', {
+								className: 'wp-block-groups-group-directory__spinner',
+								'aria-hidden': 'true',
+							} ),
+							__( 'Loading groups\u2026', 'wordpress-groups' )
+						),
+					! isLoading && groups.length === 0 &&
+						createElement(
+							'p',
+							{ className: 'wp-block-groups-group-directory__empty' },
+							search
+								? __( 'No groups found matching your search.', 'wordpress-groups' )
+								: __( 'No groups found.', 'wordpress-groups' )
+						),
+					! isLoading && groups.length > 0 &&
+						createElement(
+							'div',
+							{ className: 'wp-block-groups-group-directory__grid' },
+							groups.map( ( group ) =>
+								createElement( GroupCard, { key: group.id, group } )
+							)
+						)
 				),
-			! isLoading && groups.length === 0 &&
-				createElement(
-					'p',
-					{ className: 'wp-block-groups-group-directory__empty' },
-					search
-						? __( 'No groups found matching your search.', 'wordpress-groups' )
-						: __( 'No groups found.', 'wordpress-groups' )
-				),
-			! isLoading && groups.length > 0 &&
-				createElement(
-					'div',
-					{ className: 'wp-block-groups-group-directory__grid' },
-					groups.map( ( group ) =>
-						createElement( GroupCard, { key: group.id, group } )
-					)
-				)
-		),
-		! isLoading &&
-			createElement( Pagination, {
-				currentPage,
-				totalPages,
-				onPageChange: handlePageChange,
-			} )
+				! isLoading &&
+					createElement( Pagination, {
+						currentPage,
+						totalPages,
+						onPageChange: handlePageChange,
+					} )
+			),
+		activeView === 'map' &&
+			createElement(
+				'div',
+				{
+					id: 'group-directory-map-view',
+					role: 'tabpanel',
+				},
+				createElement( MapView, {
+					mapGroups,
+					onLoadAll: fetchAllMapGroups,
+				} )
+			)
 	);
 }
 
@@ -331,6 +583,13 @@ function init() {
 			initialGroups = [];
 		}
 
+		let initialMapGroups = [];
+		try {
+			initialMapGroups = JSON.parse( container.dataset.mapGroups || '[]' );
+		} catch {
+			initialMapGroups = [];
+		}
+
 		const root = createRoot( container );
 		root.render(
 			createElement( GroupDirectory, {
@@ -338,6 +597,7 @@ function init() {
 				initialGroups,
 				initialTotal,
 				initialPages,
+				initialMapGroups,
 			} )
 		);
 	} );


### PR DESCRIPTION
## Summary
- Adds a **List View / Map View** toggle to the group directory block, rendering a Leaflet map with OpenStreetMap tiles showing markers for all groups with coordinates
- Server-side `render.php` now includes `latitude`, `longitude` in the group data and outputs a `data-map-groups` attribute with pre-filtered geo-enabled groups; also enqueues Leaflet CSS/JS (same CDN as the venue-map block)
- Map view fetches all groups (up to 200) via the REST API on first toggle, with marker popups showing group name, location, and a link to visit the group
- Includes a **"My location"** geolocation button that uses `navigator.geolocation` to center the map on the user's position
- Responsive: map height reduces to 280px on mobile, toolbar stacks vertically

## Test plan
- [ ] Verify the group directory block renders with List View / Map View toggle buttons
- [ ] Click "Map View" and confirm a Leaflet map loads with markers for groups that have coordinates
- [ ] Click a marker popup and verify it shows group name, location, and a "Visit group" link
- [ ] Click "My location" button and confirm the map centers on the browser's geolocation (grant permission when prompted)
- [ ] Switch back to "List View" and verify search/pagination still works normally
- [ ] Test on mobile viewport: map should be 280px tall, toolbar should stack vertically
- [ ] Verify no JS errors in console when Leaflet is already loaded (e.g., venue-map block on same page)

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)