### PR TITLE
Fix: Escape venue title in REST API response

### DIFF
--- a/wp-content/plugins/wordpress-groups/includes/rest/class-venue-controller.php
+++ b/wp-content/plugins/wordpress-groups/includes/rest/class-venue-controller.php
@@ -480,7 +480,7 @@ class Venue_Controller extends WP_REST_Controller {
 
 		$data = [
 			'id'       => (int) $post->ID,
-			'title'    => $post->post_title,
+			'title'    => esc_html( $post->post_title ),
 			'content'  => wp_kses_post( $post->post_content ),
 			'status'   => esc_html( $post->post_status ),
 			'author'   => (int) $post->post_author,


### PR DESCRIPTION
## Summary
- Escape `post_title` with `esc_html()` in the Venue REST controller's `prepare_item_for_response` method, matching the Event controller's existing practice.

This is a defense-in-depth fix found during the full security review (#169). The Event controller already escapes the title on line 616 of `class-event-controller.php`, but the Venue controller was passing the raw `post_title`.

## Test plan
- [ ] Verify venue REST API responses still return the venue title correctly
- [ ] Verify venue titles with special characters (e.g., `&`, `<`, `"`) are properly escaped in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)