### PR TITLE
Fix Visit Group Site button, add calendar link, add Add to Calendar block

### DIFF
--- a/wp-content/themes/groups-directory/functions.php
+++ b/wp-content/themes/groups-directory/functions.php
@@ -6,3 +6,51 @@
  */
 
 defined( 'ABSPATH' ) || exit;
+
+/**
+ * Set up theme support.
+ */
+function groups_directory_setup() {
+	add_theme_support( 'post-thumbnails' );
+	add_theme_support( 'editor-styles' );
+}
+add_action( 'after_setup_theme', 'groups_directory_setup' );
+
+/**
+ * Enqueue fonts and theme stylesheets.
+ */
+function groups_directory_enqueue_assets() {
+	// Google Fonts: Plus Jakarta Sans (headings) + Inter (body) — matching groups-site.
+	wp_enqueue_style(
+		'groups-directory-google-fonts',
+		'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Inter:wght@400;500;600&display=swap',
+		[],
+		null
+	);
+
+	// Enqueue custom.css if the file exists.
+	$custom_css_path = get_theme_file_path( 'assets/css/custom.css' );
+	if ( file_exists( $custom_css_path ) ) {
+		wp_enqueue_style(
+			'groups-directory-custom',
+			get_theme_file_uri( 'assets/css/custom.css' ),
+			[ 'groups-directory-google-fonts' ],
+			filemtime( $custom_css_path )
+		);
+	}
+}
+add_action( 'wp_enqueue_scripts', 'groups_directory_enqueue_assets' );
+add_action( 'enqueue_block_editor_assets', 'groups_directory_enqueue_assets' );
+
+/**
+ * Register block pattern category for the theme.
+ */
+function groups_directory_register_pattern_category() {
+	register_block_pattern_category(
+		'groups-directory',
+		[
+			'label' => __( 'Groups Directory', 'groups-directory' ),
+		]
+	);
+}
+add_action( 'init', 'groups_directory_register_pattern_category' );

--- a/wp-content/themes/groups-directory/templates/single-wp_meetup.html
+++ b/wp-content/themes/groups-directory/templates/single-wp_meetup.html
@@ -41,13 +41,9 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:buttons -->
-	<div class="wp-block-buttons">
-		<!-- wp:button -->
-		<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Visit Group Site</a></div>
-		<!-- /wp:button -->
-	</div>
-	<!-- /wp:buttons -->
+	<!-- wp:shortcode -->
+	[groups_visit_site_button]
+	<!-- /wp:shortcode -->
 
 </main>
 <!-- /wp:group -->

--- a/wp-content/themes/groups-site/templates/archive-event.html
+++ b/wp-content/themes/groups-site/templates/archive-event.html
@@ -7,7 +7,15 @@
 	<h1 class="wp-block-heading has-heading-1-font-size">Events</h1>
 	<!-- /wp:heading -->
 
-	<!-- wp:search {"label":"Search events","placeholder":"Search events\u2026","query":{"post_type":"event"},"buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}},"className":"wp-block-groups-event-search"} /-->
+	<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap","verticalAlignment":"center"},"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"},"blockGap":"var:preset|spacing|40"}}} -->
+	<div class="wp-block-group">
+		<!-- wp:search {"label":"Search events","placeholder":"Search events\u2026","query":{"post_type":"event"},"buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"wp-block-groups-event-search"} /-->
+
+		<!-- wp:paragraph {"fontSize":"small"} -->
+		<p class="has-small-font-size"><a href="?ical=1">Subscribe to Calendar (.ics)</a></p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:group -->
 
 	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|50","margin":{"bottom":"var:preset|spacing|80"}}},"layout":{"type":"constrained","wideSize":"1280px","justifyContent":"left"}} -->
 	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--80)">

--- a/wp-content/themes/groups-site/templates/single-event.html
+++ b/wp-content/themes/groups-site/templates/single-event.html
@@ -118,6 +118,16 @@
 				<!-- /wp:separator -->
 
 				<!-- wp:heading {"level":3,"fontSize":"heading-5","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}}} -->
+				<h3 class="wp-block-heading has-heading-5-font-size" style="margin-bottom:var(--wp--preset--spacing--10)">Add to Calendar</h3>
+				<!-- /wp:heading -->
+
+				<!-- wp:groups/add-to-calendar /-->
+
+				<!-- wp:separator {"className":"is-style-wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"backgroundColor":"neutral-150"} -->
+				<hr class="wp-block-separator has-text-color has-neutral-150-color has-alpha-channel-opacity has-neutral-150-background-color has-background is-style-wide" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)"/>
+				<!-- /wp:separator -->
+
+				<!-- wp:heading {"level":3,"fontSize":"heading-5","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|10"}}}} -->
 				<h3 class="wp-block-heading has-heading-5-font-size" style="margin-bottom:var(--wp--preset--spacing--10)">Share</h3>
 				<!-- /wp:heading -->
 


### PR DESCRIPTION
## Summary

- **#177**: The "Visit Group Site" button on `single-wp_meetup.html` had an empty `href`. Replaced the static button with a `[groups_visit_site_button]` shortcode that resolves the group's sub-site URL from `_meetup_site_id` post meta via `get_blog_details()`. If no site is linked, the button is hidden.
- **#173**: Added a "Subscribe to Calendar (.ics)" link on the events archive page (`archive-event.html`) next to the search bar, linking to the existing `?ical=1` endpoint.
- **#180**: Added the `groups/add-to-calendar` block to the single-event sidebar (`single-event.html`) between the RSVP button and the Share section, with its own heading and separator.

## Test plan

- [ ] Visit a single meetup page (`wp_meetup` post type) that has a `_meetup_site_id` meta value -- verify the "Visit Group Site" button links to the correct sub-site URL
- [ ] Visit a single meetup page without `_meetup_site_id` -- verify no button is rendered
- [ ] Visit the events archive page on a group site -- verify the "Subscribe to Calendar (.ics)" link appears and downloads a valid `.ics` file
- [ ] Visit a single event page -- verify the "Add to Calendar" dropdown appears in the sidebar between RSVP and Share sections
- [ ] Test the Add to Calendar dropdown links (Google Calendar, Outlook, iCal) work correctly

Closes #177, closes #173, closes #180

Generated with [Claude Code](https://claude.com/claude-code)