### PR TITLE
Fix: Online badges, venue geocoding, event duplication, logged-out RSVP

### DIFF
--- a/wp-content/plugins/wordpress-groups/blocks/event-card/render.php
+++ b/wp-content/plugins/wordpress-groups/blocks/event-card/render.php
@@ -79,15 +79,21 @@ if ( $start_datetime ) {
 	}
 }
 
-// Venue name.
-$venue_name = '';
+// Venue name and format badge (Online / Hybrid / in-person).
+$venue_name   = '';
+$format_badge = '';
 if ( $venue_id ) {
 	$venue = get_post( $venue_id );
 	if ( $venue && 'venue' === $venue->post_type ) {
 		$venue_name = $venue->post_title;
 	}
+	if ( $online_link ) {
+		// Has both a physical venue and an online link — hybrid event.
+		$format_badge = __( 'Hybrid', 'wordpress-groups' );
+	}
 } elseif ( $online_link ) {
-	$venue_name = __( 'Online', 'wordpress-groups' );
+	$venue_name   = __( 'Online', 'wordpress-groups' );
+	$format_badge = __( 'Online', 'wordpress-groups' );
 }
 
 // Build the status CSS class modifier.
@@ -120,6 +126,12 @@ $wrapper_attributes = get_block_wrapper_attributes( [
 		</span>
 	<?php endif; ?>
 
+	<?php if ( $format_badge ) : ?>
+		<span class="wp-block-groups-event-card__format-badge wp-block-groups-event-card__format-badge--<?php echo esc_attr( sanitize_html_class( strtolower( $format_badge ) ) ); ?>">
+			<?php echo esc_html( $format_badge ); ?>
+		</span>
+	<?php endif; ?>
+
 	<h3 class="wp-block-groups-event-card__title">
 		<a href="<?php echo esc_url( get_permalink( $event_id ) ); ?>">
 			<?php echo esc_html( get_the_title( $event_id ) ); ?>
@@ -140,6 +152,14 @@ $wrapper_attributes = get_block_wrapper_attributes( [
 	<?php if ( $venue_name ) : ?>
 		<div class="wp-block-groups-event-card__venue">
 			<?php echo esc_html( $venue_name ); ?>
+		</div>
+	<?php endif; ?>
+
+	<?php if ( $online_link && is_singular( 'event' ) ) : ?>
+		<div class="wp-block-groups-event-card__online-link">
+			<a href="<?php echo esc_url( $online_link ); ?>" target="_blank" rel="noopener noreferrer">
+				<?php esc_html_e( 'Join Online Meeting', 'wordpress-groups' ); ?>
+			</a>
 		</div>
 	<?php endif; ?>
 

--- a/wp-content/plugins/wordpress-groups/blocks/rsvp-button/render.php
+++ b/wp-content/plugins/wordpress-groups/blocks/rsvp-button/render.php
@@ -87,20 +87,37 @@ $wrapper_attributes = get_block_wrapper_attributes( $data_attributes );
 $button_text = match ( $initial_state ) {
 	'attending'     => __( 'Attending', 'wordpress-groups' ),
 	'waitlisted'    => __( 'On Waitlist', 'wordpress-groups' ),
-	'not-logged-in' => __( 'Log in to RSVP', 'wordpress-groups' ),
+	'not-logged-in' => __( 'RSVP to this Event', 'wordpress-groups' ),
 	default         => __( 'RSVP', 'wordpress-groups' ),
 };
 
 ?>
 <div <?php echo $wrapper_attributes; ?>>
 	<?php if ( 'not-logged-in' === $initial_state && $login_url ) : ?>
-		<a
-			class="wp-block-groups-rsvp-button__btn wp-block-groups-rsvp-button__btn--not-logged-in"
-			href="<?php echo esc_url( $login_url ); ?>"
-			aria-label="<?php echo esc_attr( $button_text ); ?>"
-		>
-			<span class="wp-block-groups-rsvp-button__label"><?php echo esc_html( $button_text ); ?></span>
-		</a>
+		<div class="wp-block-groups-rsvp-button__guest-prompt">
+			<p class="wp-block-groups-rsvp-button__guest-text">
+				<?php esc_html_e( 'Want to attend this event?', 'wordpress-groups' ); ?>
+			</p>
+			<a
+				class="wp-block-groups-rsvp-button__btn wp-block-groups-rsvp-button__btn--login"
+				href="<?php echo esc_url( $login_url ); ?>"
+				aria-label="<?php esc_attr_e( 'Log in to RSVP for this event', 'wordpress-groups' ); ?>"
+			>
+				<span class="wp-block-groups-rsvp-button__label"><?php esc_html_e( 'Log in to RSVP', 'wordpress-groups' ); ?></span>
+			</a>
+			<?php
+			$register_url = wp_registration_url();
+			if ( get_option( 'users_can_register' ) && $register_url ) :
+			?>
+				<a
+					class="wp-block-groups-rsvp-button__btn wp-block-groups-rsvp-button__btn--register"
+					href="<?php echo esc_url( add_query_arg( 'redirect_to', urlencode( get_permalink( $event_id ) ), $register_url ) ); ?>"
+					aria-label="<?php esc_attr_e( 'Create an account to RSVP', 'wordpress-groups' ); ?>"
+				>
+					<span class="wp-block-groups-rsvp-button__label"><?php esc_html_e( 'Create Account', 'wordpress-groups' ); ?></span>
+				</a>
+			<?php endif; ?>
+		</div>
 	<?php else : ?>
 		<button
 			class="wp-block-groups-rsvp-button__btn wp-block-groups-rsvp-button__btn--<?php echo esc_attr( $initial_state ); ?>"

--- a/wp-content/plugins/wordpress-groups/includes/admin/class-event-duplicator.php
+++ b/wp-content/plugins/wordpress-groups/includes/admin/class-event-duplicator.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Event Duplicator — adds a "Duplicate Event" action to the admin list table.
+ *
+ * @package Groups\Admin
+ */
+
+namespace Groups\Admin;
+
+use Groups\Models\Event as Event_Model;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adds a row action to duplicate an event and handles the duplication request.
+ */
+class Event_Duplicator {
+
+	/**
+	 * Constructor — register hooks.
+	 */
+	public function __construct() {
+		add_filter( 'post_row_actions', [ $this, 'add_duplicate_link' ], 10, 2 );
+		add_action( 'admin_action_duplicate_event', [ $this, 'handle_duplication' ] );
+	}
+
+	/**
+	 * Add a "Duplicate" link to event row actions.
+	 *
+	 * @param array    $actions Existing row actions.
+	 * @param \WP_Post $post    Current post.
+	 * @return array Modified actions.
+	 */
+	public function add_duplicate_link( array $actions, \WP_Post $post ): array {
+		if ( 'event' !== $post->post_type ) {
+			return $actions;
+		}
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return $actions;
+		}
+
+		$url = wp_nonce_url(
+			admin_url( 'admin.php?action=duplicate_event&post=' . $post->ID ),
+			'duplicate_event_' . $post->ID
+		);
+
+		$actions['duplicate'] = sprintf(
+			'<a href="%s" aria-label="%s">%s</a>',
+			esc_url( $url ),
+			/* translators: %s: Event title. */
+			esc_attr( sprintf( __( 'Duplicate &#8220;%s&#8221;', 'wordpress-groups' ), $post->post_title ) ),
+			esc_html__( 'Duplicate', 'wordpress-groups' )
+		);
+
+		return $actions;
+	}
+
+	/**
+	 * Handle the duplication admin action.
+	 */
+	public function handle_duplication(): void {
+		$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
+
+		if ( ! $post_id ) {
+			wp_die( esc_html__( 'No event specified.', 'wordpress-groups' ) );
+		}
+
+		check_admin_referer( 'duplicate_event_' . $post_id );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_die( esc_html__( 'You do not have permission to duplicate events.', 'wordpress-groups' ) );
+		}
+
+		$source = get_post( $post_id );
+
+		if ( ! $source || 'event' !== $source->post_type ) {
+			wp_die( esc_html__( 'Invalid event.', 'wordpress-groups' ) );
+		}
+
+		// Clone the event as a draft.
+		$new_post_id = wp_insert_post( [
+			'post_type'    => 'event',
+			'post_title'   => sprintf(
+				/* translators: %s: Original event title. */
+				__( '%s (Copy)', 'wordpress-groups' ),
+				$source->post_title
+			),
+			'post_content' => $source->post_content,
+			'post_excerpt' => $source->post_excerpt,
+			'post_status'  => 'event-draft',
+			'post_author'  => get_current_user_id(),
+		], true );
+
+		if ( is_wp_error( $new_post_id ) ) {
+			wp_die( esc_html( $new_post_id->get_error_message() ) );
+		}
+
+		// Copy all event meta.
+		foreach ( Event_Model::META_KEYS as $key => $meta_key ) {
+			$value = get_post_meta( $post_id, $meta_key, true );
+			if ( '' !== $value ) {
+				update_post_meta( $new_post_id, $meta_key, $value );
+			}
+		}
+
+		// Copy the featured image.
+		$thumbnail_id = get_post_thumbnail_id( $post_id );
+		if ( $thumbnail_id ) {
+			set_post_thumbnail( $new_post_id, $thumbnail_id );
+		}
+
+		// Redirect to the edit screen for the new event.
+		wp_safe_redirect( admin_url( 'post.php?action=edit&post=' . $new_post_id ) );
+		exit;
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/class-geocoder.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-geocoder.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Geocoder — auto-geocode venues via OpenStreetMap Nominatim.
+ *
+ * @package Groups
+ */
+
+namespace Groups;
+
+use Groups\Post_Types\Venue;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Listens for venue saves and geocodes the address when lat/lon are missing.
+ */
+class Geocoder {
+
+	/**
+	 * Nominatim API endpoint.
+	 *
+	 * @var string
+	 */
+	const API_URL = 'https://nominatim.openstreetmap.org/search';
+
+	/**
+	 * Constructor — hook into venue save.
+	 */
+	public function __construct() {
+		add_action( 'save_post_venue', [ $this, 'maybe_geocode' ], 20, 2 );
+	}
+
+	/**
+	 * Geocode a venue on save if it has an address but no coordinates.
+	 *
+	 * @param int      $post_id Post ID.
+	 * @param \WP_Post $post    Post object.
+	 */
+	public function maybe_geocode( int $post_id, \WP_Post $post ): void {
+		// Don't run during autosave or revisions.
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
+		$latitude  = get_post_meta( $post_id, '_venue_latitude', true );
+		$longitude = get_post_meta( $post_id, '_venue_longitude', true );
+
+		// Already has coordinates — skip.
+		if ( '' !== $latitude && '' !== $longitude ) {
+			return;
+		}
+
+		$address = $this->build_address_string( $post_id );
+
+		if ( empty( $address ) ) {
+			return;
+		}
+
+		$coords = $this->geocode( $address );
+
+		if ( $coords ) {
+			update_post_meta( $post_id, '_venue_latitude', $coords['lat'] );
+			update_post_meta( $post_id, '_venue_longitude', $coords['lon'] );
+		}
+	}
+
+	/**
+	 * Build a geocodable address string from venue meta.
+	 *
+	 * @param int $post_id Venue post ID.
+	 * @return string Address string, or empty if no address parts exist.
+	 */
+	private function build_address_string( int $post_id ): string {
+		$parts = array_filter( [
+			get_post_meta( $post_id, '_venue_address', true ),
+			get_post_meta( $post_id, '_venue_city', true ),
+			get_post_meta( $post_id, '_venue_state', true ),
+			get_post_meta( $post_id, '_venue_zip', true ),
+			get_post_meta( $post_id, '_venue_country', true ),
+		] );
+
+		return implode( ', ', $parts );
+	}
+
+	/**
+	 * Query Nominatim for coordinates.
+	 *
+	 * @param string $address Human-readable address.
+	 * @return array{lat: float, lon: float}|null Coordinates or null on failure.
+	 */
+	public function geocode( string $address ): ?array {
+		$url = add_query_arg(
+			[
+				'q'      => $address,
+				'format' => 'jsonv2',
+				'limit'  => 1,
+			],
+			self::API_URL
+		);
+
+		$response = wp_remote_get(
+			$url,
+			[
+				'timeout'    => 5,
+				'user-agent' => 'WordPress-Groups/0.1.0 (events.wordpress.org)',
+				'headers'    => [
+					'Accept' => 'application/json',
+				],
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $code ) {
+			return null;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( empty( $body[0]['lat'] ) || empty( $body[0]['lon'] ) ) {
+			return null;
+		}
+
+		return [
+			'lat' => (float) $body[0]['lat'],
+			'lon' => (float) $body[0]['lon'],
+		];
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -67,10 +67,12 @@ class Plugin {
 		new Integrations\WordPress_Org_Profile();
 		new Admin\Application_Tracker();
 		new Admin\Reports();
+		new Admin\Event_Duplicator();
 		new Workflow\Organizer_Onboarding();
 		new Notifications\Rsvp_Notifications();
 		new Blocks\Recurrence_Panel();
 		new SEO();
+		new Geocoder();
 
 		Cache::register_hooks();
 


### PR DESCRIPTION
## Summary

- **#176 Online event support**: Shows "Online" or "Hybrid" format badge on event cards when `_event_online_link` is set. On single-event pages, displays a "Join Online Meeting" link to the meeting URL.
- **#175 Venue geocoding via Nominatim**: New `Geocoder` class auto-geocodes venues on save when an address exists but lat/lon coordinates are missing. Uses OpenStreetMap Nominatim with a proper browser UA string.
- **#178 Event duplication**: Adds a "Duplicate Event" row action in the WordPress admin event list. Clones the event post and all event meta into a new draft via `wp_insert_post`.
- **#172 Better logged-out RSVP**: Replaces the bare "Log in to RSVP" link with a guest prompt section showing "Want to attend this event?" text, a "Log in to RSVP" button, and (when registration is enabled) a "Create Account" button. Both buttons redirect back to the event page after auth.

## Test plan

- [ ] Create an event with only an online link (no venue) — verify "Online" badge appears on the event card
- [ ] Create an event with both a venue and an online link — verify "Hybrid" badge appears
- [ ] View a single event with an online link — verify "Join Online Meeting" link appears
- [ ] Save a venue with an address but no lat/lon — verify coordinates are auto-populated (requires network access to Nominatim)
- [ ] In the admin Events list, click "Duplicate" on an event — verify a new draft is created with copied meta
- [ ] View an event while logged out — verify the RSVP section shows the guest prompt with login/register buttons
- [ ] Click "Log in to RSVP" while logged out — verify redirect returns to the event page after login

Closes #176, closes #175, closes #178, closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)