### PR TITLE
Remove no-op use statements from test files

### DIFF
--- a/wp-content/plugins/wordpress-groups/tests/phpunit/rest/Test_Directory_Controller.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/rest/Test_Directory_Controller.php
@@ -6,7 +6,6 @@
  */
 
 use Groups\REST\Directory_Controller;
-use WP_REST_Server;
 
 /**
  * @coversDefaultClass \Groups\REST\Directory_Controller

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/rest/Test_Event_Controller.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/rest/Test_Event_Controller.php
@@ -5,10 +5,8 @@
  * @package Groups\Tests\REST
  */
 
-
 use Groups\Post_Types\Event;
 use Groups\REST\Event_Controller;
-use WP_REST_Server;
 
 /**
  * @coversDefaultClass \Groups\REST\Event_Controller


### PR DESCRIPTION
## Summary
- Removed `use WP_REST_Server;` from `Test_Directory_Controller.php` and `Test_Event_Controller.php` -- these files are in the global namespace, so the import has no effect
- Removed a stray blank line in `Test_Event_Controller.php`

## Code quality audit findings

Checked the entire plugin for common PHP issues. Here is what the audit covered and found:

**No issues found (clean):**
- All 19 `render.php` files have `defined( 'ABSPATH' ) || exit;` guard
- All 19 `block.json` files use consistent `textdomain: "wordpress-groups"` and `apiVersion: 3`
- No `@` error suppression operators in plugin PHP files
- No TODO/FIXME/HACK comments
- No deprecated function usage detected
- All `use WP_*` statements in `includes/` are valid (files are namespaced under `Groups\*`)
- All output is properly escaped (`esc_html`, `esc_url`, `sanitize_text_field`, `wp_kses_post`)
- `test-venue-controller.php` has a namespace, so its `use WP_*` statements are valid

**Issues fixed:**
- `Test_Directory_Controller.php` (global namespace): removed no-op `use WP_REST_Server`
- `Test_Event_Controller.php` (global namespace): removed no-op `use WP_REST_Server` and extra blank line

## Test plan
- [ ] Verify PHPUnit tests still pass after removing the unused imports
- [ ] Confirm no other test files reference `WP_REST_Server` via the removed import

🤖 Generated with [Claude Code](https://claude.com/claude-code)