### PR TITLE
Fix seed data: gravatar-friendly emails and user_email sync

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -34,7 +34,7 @@ fi
 echo ""
 echo "🌏 Creating Melbourne sub-site..."
 # Always try to create — wp-cli will error if it exists, which is fine.
-npx wp-env run cli wp site create --slug=melbourne --title="WordPress Melbourne" --email=organizer@example.com 2>/dev/null || echo "  (already exists or failed)"
+npx wp-env run cli wp site create --slug=melbourne --title="WordPress Melbourne" --email=test1@example.com 2>/dev/null || echo "  (already exists or failed)"
 
 # Get the actual site URL for the Melbourne site.
 SITE_URL=$(npx wp-env run cli wp option get siteurl 2>/dev/null | grep -oE 'http://[^ ]+' | head -1)

--- a/wp-content/plugins/wordpress-groups/seed-data-tokyo.php
+++ b/wp-content/plugins/wordpress-groups/seed-data-tokyo.php
@@ -25,11 +25,11 @@ $blog_id = get_current_blog_id();
 
 // Users.
 $users = [
-	'yuki'    => [ 'Yuki', 'Tanaka', 'yuki@example.com', 'organizer' ],
-	'kenji'   => [ 'Kenji', 'Suzuki', 'kenji@example.com', 'co_organizer' ],
-	'sakura'  => [ 'Sakura', 'Yamamoto', 'sakura@example.com', 'member' ],
-	'hiroshi' => [ 'Hiroshi', 'Watanabe', 'hiroshi@example.com', 'member' ],
-	'aiko'    => [ 'Aiko', 'Sato', 'aiko@example.com', 'member' ],
+	'yuki'    => [ 'Yuki', 'Tanaka', 'yuki@wordpress.test', 'organizer' ],
+	'kenji'   => [ 'Kenji', 'Suzuki', 'kenji@wordpress.test', 'co_organizer' ],
+	'sakura'  => [ 'Sakura', 'Yamamoto', 'sakura@wordpress.test', 'member' ],
+	'hiroshi' => [ 'Hiroshi', 'Watanabe', 'hiroshi@wordpress.test', 'member' ],
+	'aiko'    => [ 'Aiko', 'Sato', 'aiko@wordpress.test', 'member' ],
 ];
 
 $user_ids = [];
@@ -41,6 +41,7 @@ foreach ( $users as $login => $info ) {
 	if ( ! is_wp_error( $user_id ) ) {
 		wp_update_user( [
 			'ID'           => $user_id,
+			'user_email'   => $info[2],
 			'display_name' => $info[0] . ' ' . $info[1],
 			'first_name'   => $info[0],
 			'last_name'    => $info[1],

--- a/wp-content/plugins/wordpress-groups/seed-data.php
+++ b/wp-content/plugins/wordpress-groups/seed-data.php
@@ -35,10 +35,10 @@ $blog_id = get_current_blog_id();
 
 // --- Users ---
 $users = [
-	'organizer' => [ 'Jane', 'Organizer', 'organizer@example.com', 'organizer' ],
-	'member1'   => [ 'Alex', 'Member', 'member1@example.com', 'member' ],
-	'member2'   => [ 'Sam', 'Contributor', 'member2@example.com', 'member' ],
-	'member3'   => [ 'Taylor', 'Developer', 'member3@example.com', 'member' ],
+	'organizer' => [ 'Jane', 'Organizer', 'test1@example.com', 'organizer' ],
+	'member1'   => [ 'Alex', 'Member', 'test2@example.com', 'member' ],
+	'member2'   => [ 'Sam', 'Contributor', 'test3@example.com', 'member' ],
+	'member3'   => [ 'Taylor', 'Developer', 'member3@wordpress.test', 'member' ],
 ];
 
 $user_ids = [];
@@ -50,6 +50,7 @@ foreach ( $users as $login => $info ) {
 	if ( ! is_wp_error( $user_id ) ) {
 		wp_update_user( [
 			'ID'           => $user_id,
+			'user_email'   => $info[2],
 			'display_name' => $info[0] . ' ' . $info[1],
 			'first_name'   => $info[0],
 			'last_name'    => $info[1],


### PR DESCRIPTION
## Summary
- **Melbourne seed**: Use `test1@example.com`, `test2@example.com`, `test3@example.com` for the first three users — these have actual Gravatar images registered
- **Tokyo seed**: Use unique `@wordpress.test` emails to avoid multisite email uniqueness conflicts while still generating Gravatar default identicons
- **Both seeds**: Add `user_email` to the `wp_update_user()` call so that re-running the seed script updates existing users' emails (and thus their RSVP comment author emails, which are read from the user object)
- **setup.sh**: Align the Melbourne site creation `--email` flag with the new organizer address; Tokyo rewrite flush was already present

## Notes
- RSVP comments already correctly set `user_id` and read `comment_author_email` from the user object — the root cause was that the user emails themselves were not gravatar-friendly
- `setup.sh` already had `wp rewrite flush --url="$TOKYO_URL"` on line 71, so no additional flush was needed

## Test plan
- [ ] Run `bin/setup.sh` on a fresh wp-env instance
- [ ] Verify Melbourne event RSVPs show Gravatar images for the first 3 users
- [ ] Verify Tokyo RSVP button is visible and functional
- [ ] Verify RSVP comments have correct `user_id` (not 0) in the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)