### PR TITLE
Fix #191, #192, #195, #188: uninstall, fonts filter, i18n, RSVP counts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 		"env:setup": "bash bin/setup.sh",
 		"env:start": "wp-env start",
 		"env:stop": "wp-env stop",
-		"env:destroy": "wp-env destroy"
+		"env:destroy": "wp-env destroy",
+		"i18n:pot": "npx wp-env run cli wp i18n make-pot wp-content/plugins/wordpress-groups wp-content/plugins/wordpress-groups/languages/wordpress-groups.pot"
 	},
 	"devDependencies": {
 		"@testing-library/jest-dom": "^6.9.1",

--- a/wp-content/plugins/wordpress-groups/blocks/organizer-dashboard/render.php
+++ b/wp-content/plugins/wordpress-groups/blocks/organizer-dashboard/render.php
@@ -132,10 +132,19 @@ if ( $upcoming_query->have_posts() ) {
 			$tz = wp_timezone();
 		}
 
+		$rsvp_count = (int) get_comments( [
+			'post_id'    => $event_id,
+			'status'     => 'approve',
+			'meta_key'   => '_rsvp_status',
+			'meta_value' => 'attending',
+			'count'      => true,
+		] );
+
 		$upcoming_events[] = [
-			'title' => get_the_title(),
-			'url'   => get_permalink(),
-			'date'  => $start_utc ? wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $start_utc ), $tz ) : '',
+			'title'      => get_the_title(),
+			'url'        => get_permalink(),
+			'date'       => $start_utc ? wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $start_utc ), $tz ) : '',
+			'rsvp_count' => $rsvp_count,
 		];
 	}
 	wp_reset_postdata();
@@ -193,6 +202,15 @@ $wrapper_attributes = get_block_wrapper_attributes( [
 								<?php echo esc_html( $event['date'] ); ?>
 							</span>
 						<?php endif; ?>
+						<span class="wp-block-groups-organizer-dashboard__event-rsvp-count">
+							<?php
+							printf(
+								/* translators: %s: number of attending RSVPs */
+								esc_html__( '%s attending', 'wordpress-groups' ),
+								esc_html( number_format_i18n( $event['rsvp_count'] ) )
+							);
+							?>
+						</span>
 					</li>
 				<?php endforeach; ?>
 			</ul>

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -76,9 +76,17 @@ class Plugin {
 
 		Cache::register_hooks();
 
+		add_action( 'init', [ $this, 'load_textdomain' ] );
 		add_action( 'init', [ Models\Membership::class, 'register_roles' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
 		REST\Rate_Limiter::register();
+	}
+
+	/**
+	 * Load the plugin text domain for translations.
+	 */
+	public function load_textdomain(): void {
+		load_plugin_textdomain( 'wordpress-groups', false, 'wordpress-groups/languages' );
 	}
 
 	/**

--- a/wp-content/plugins/wordpress-groups/uninstall.php
+++ b/wp-content/plugins/wordpress-groups/uninstall.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Uninstall handler for WordPress Groups.
+ *
+ * Fired when the plugin is deleted via the WordPress admin.
+ * Drops custom tables, removes custom roles, clears cron hooks,
+ * and deletes plugin options.
+ *
+ * @package Groups
+ */
+
+// Exit if not called by WordPress uninstall.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+global $wpdb;
+
+/*
+ * 1. Drop custom database tables.
+ */
+$base_prefix = $wpdb->base_prefix;
+$wpdb->query( "DROP TABLE IF EXISTS {$base_prefix}groups_analytics_daily" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+$wpdb->query( "DROP TABLE IF EXISTS {$base_prefix}groups_activity_log" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+
+/*
+ * 2. Remove custom roles from all sites in the network.
+ */
+$custom_roles = [ 'organizer', 'co_organizer', 'member' ];
+
+if ( is_multisite() ) {
+	$site_ids = get_sites( [
+		'fields' => 'ids',
+		'number' => 0,
+	] );
+
+	foreach ( $site_ids as $site_id ) {
+		switch_to_blog( $site_id );
+
+		foreach ( $custom_roles as $role ) {
+			remove_role( $role );
+		}
+
+		// Delete per-site options.
+		delete_option( 'groups_aggregation_batch_offset' );
+
+		restore_current_blog();
+	}
+} else {
+	foreach ( $custom_roles as $role ) {
+		remove_role( $role );
+	}
+
+	delete_option( 'groups_aggregation_batch_offset' );
+}
+
+/*
+ * 3. Clear scheduled cron hooks.
+ */
+$cron_hooks = [
+	'groups_daily_aggregation',
+	'groups_dormancy_check',
+	'groups_generate_recurring_events',
+	'groups_event_reminder_24h',
+	'groups_event_reminder_1h',
+];
+
+foreach ( $cron_hooks as $hook ) {
+	wp_unschedule_hook( $hook );
+}
+
+/*
+ * 4. Delete network-level options.
+ */
+delete_site_option( 'groups_db_version' );
+delete_site_option( 'groups_slack_webhook_url' );

--- a/wp-content/themes/groups-directory/functions.php
+++ b/wp-content/themes/groups-directory/functions.php
@@ -21,12 +21,14 @@ add_action( 'after_setup_theme', 'groups_directory_setup' );
  */
 function groups_directory_enqueue_assets() {
 	// Google Fonts: Plus Jakarta Sans (headings) + Inter (body) — matching groups-site.
-	wp_enqueue_style(
-		'groups-directory-google-fonts',
-		'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Inter:wght@400;500;600&display=swap',
-		[],
-		null
-	);
+	if ( apply_filters( 'groups_load_google_fonts', true ) ) {
+		wp_enqueue_style(
+			'groups-directory-google-fonts',
+			'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Inter:wght@400;500;600&display=swap',
+			[],
+			null
+		);
+	}
 
 	// Enqueue custom.css if the file exists.
 	$custom_css_path = get_theme_file_path( 'assets/css/custom.css' );

--- a/wp-content/themes/groups-site/functions.php
+++ b/wp-content/themes/groups-site/functions.php
@@ -21,12 +21,14 @@ add_action( 'after_setup_theme', 'groups_site_setup' );
  */
 function groups_site_enqueue_assets() {
 	// Google Fonts: Plus Jakarta Sans (headings) + Inter (body) + JetBrains Mono (mono).
-	wp_enqueue_style(
-		'groups-site-google-fonts',
-		'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap',
-		[],
-		null
-	);
+	if ( apply_filters( 'groups_load_google_fonts', true ) ) {
+		wp_enqueue_style(
+			'groups-site-google-fonts',
+			'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap',
+			[],
+			null
+		);
+	}
 
 	wp_enqueue_style(
 		'groups-site-custom',


### PR DESCRIPTION
## Summary

- **#191 — uninstall.php**: Drops `groups_analytics_daily` and `groups_activity_log` tables, removes custom roles (`organizer`, `co_organizer`, `member`) across all network sites, clears all plugin cron hooks, and deletes network options (`groups_db_version`, `groups_slack_webhook_url`). Guarded by `WP_UNINSTALL_PLUGIN`.
- **#192 — Google Fonts filter**: Wraps Google Fonts CDN enqueue in `apply_filters( 'groups_load_google_fonts', true )` in both `groups-directory` and `groups-site` theme `functions.php`. Returning `false` disables loading.
- **#195 — i18n textdomain + POT generation**: Adds `load_plugin_textdomain()` on `init` in the Plugin class and an `i18n:pot` npm script that runs `wp i18n make-pot` via wp-env. Creates `languages/` directory.
- **#188 — RSVP counts in organizer dashboard**: Queries attending RSVP comments per upcoming event and displays the count inline in the event list.

## Test plan

- [ ] Verify `uninstall.php` runs cleanly when deleting the plugin (check tables, roles, options, crons are removed)
- [ ] Add `add_filter( 'groups_load_google_fonts', '__return_false' )` and confirm Google Fonts CSS is not enqueued on both themes
- [ ] Run `npm run i18n:pot` and verify `.pot` file is generated in `languages/`
- [ ] Confirm organizer dashboard shows RSVP attending count next to each upcoming event
- [ ] Verify textdomain loads correctly with a test translation

🤖 Generated with [Claude Code](https://claude.com/claude-code)