### PR TITLE
Fix #209, #211, #214: PHPCS config, readme.txt, health endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 		"env:start": "wp-env start",
 		"env:stop": "wp-env stop",
 		"env:destroy": "wp-env destroy",
-		"i18n:pot": "npx wp-env run cli wp i18n make-pot wp-content/plugins/wordpress-groups wp-content/plugins/wordpress-groups/languages/wordpress-groups.pot"
+		"i18n:pot": "npx wp-env run cli wp i18n make-pot wp-content/plugins/wordpress-groups wp-content/plugins/wordpress-groups/languages/wordpress-groups.pot",
+		"lint:php": "npx wp-env run cli phpcs --standard=wp-content/plugins/wordpress-groups/.phpcs.xml.dist wp-content/plugins/wordpress-groups/includes/"
 	},
 	"devDependencies": {
 		"@testing-library/jest-dom": "^6.9.1",

--- a/wp-content/plugins/wordpress-groups/.phpcs.xml.dist
+++ b/wp-content/plugins/wordpress-groups/.phpcs.xml.dist
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Groups">
+	<description>PHP_CodeSniffer ruleset for the WordPress Groups plugin.</description>
+
+	<!-- What to scan. -->
+	<file>./includes</file>
+	<file>./wordpress-groups.php</file>
+	<file>./uninstall.php</file>
+
+	<!-- Exclude generated / third-party paths. -->
+	<exclude-pattern>./vendor/*</exclude-pattern>
+	<exclude-pattern>./node_modules/*</exclude-pattern>
+	<exclude-pattern>./build/*</exclude-pattern>
+	<exclude-pattern>./tests/*</exclude-pattern>
+
+	<!-- Use the WordPress-Extra ruleset (includes WordPress-Core). -->
+	<rule ref="WordPress-Extra">
+		<!-- Allow short array syntax. -->
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
+	</rule>
+
+	<!-- Check for WordPress version compatibility. -->
+	<config name="minimum_wp_version" value="6.7"/>
+
+	<!-- Check for PHP cross-version compatibility. -->
+	<config name="testVersion" value="8.3-"/>
+
+	<!-- Text domain for I18N checks. -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="wordpress-groups"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Prefixes for function / class / constant names. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="groups"/>
+				<element value="Groups"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Show colours and progress. -->
+	<arg name="colors"/>
+	<arg value="ps"/>
+
+	<!-- Use UTF-8. -->
+	<arg name="encoding" value="utf-8"/>
+</ruleset>

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -128,5 +128,8 @@ class Plugin {
 
 		$preferences_controller = new REST\Preferences_Controller();
 		$preferences_controller->register_routes();
+
+		$health_controller = new REST\Health_Controller();
+		$health_controller->register_routes();
 	}
 }

--- a/wp-content/plugins/wordpress-groups/includes/rest/class-health-controller.php
+++ b/wp-content/plugins/wordpress-groups/includes/rest/class-health-controller.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * REST API health-check controller.
+ *
+ * @package Groups\REST
+ */
+
+namespace Groups\REST;
+
+use Groups\Database\Schema;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Returns system health information for administrators.
+ */
+class Health_Controller extends WP_REST_Controller {
+
+	/**
+	 * Namespace for the REST routes.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'groups/v1';
+
+	/**
+	 * Base path for health routes.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'health';
+
+	/**
+	 * Register the health-check route.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Only administrators may access the health endpoint.
+	 *
+	 * @param WP_REST_Request $request The incoming request.
+	 * @return bool|\WP_Error
+	 */
+	public function get_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to view health status.', 'wordpress-groups' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return the health-check payload.
+	 *
+	 * @param WP_REST_Request $request The incoming request.
+	 * @return WP_REST_Response
+	 */
+	public function get_item( $request ): WP_REST_Response {
+		$data = array(
+			'plugin_version'    => GROUPS_PLUGIN_VERSION,
+			'db_schema_version' => Schema::get_schema_version(),
+			'cron_jobs'         => $this->get_cron_status(),
+			'tables'            => $this->get_table_row_counts(),
+		);
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Retrieve the next-scheduled timestamps for the plugin's cron hooks.
+	 *
+	 * @return array<string, array<string, string|false>>
+	 */
+	private function get_cron_status(): array {
+		$hooks = array(
+			'groups_daily_aggregation'         => 'Analytics aggregation',
+			'groups_dormancy_check'            => 'Dormancy detection',
+			'groups_generate_recurring_events' => 'Recurring event generation',
+		);
+
+		$status = array();
+
+		foreach ( $hooks as $hook => $label ) {
+			$next = wp_next_scheduled( $hook );
+
+			$status[ $hook ] = array(
+				'label'          => $label,
+				'next_scheduled' => $next ? gmdate( 'Y-m-d\TH:i:s\Z', $next ) : false,
+			);
+		}
+
+		return $status;
+	}
+
+	/**
+	 * Get row counts for plugin custom tables.
+	 *
+	 * @return array<string, int|null>
+	 */
+	private function get_table_row_counts(): array {
+		global $wpdb;
+
+		$base_prefix = $wpdb->base_prefix;
+		$tables      = array(
+			'groups_analytics_daily' => "{$base_prefix}groups_analytics_daily",
+			'groups_activity_log'    => "{$base_prefix}groups_activity_log",
+		);
+
+		$counts = array();
+
+		foreach ( $tables as $key => $table ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result = $wpdb->get_var(
+				$wpdb->prepare( 'SELECT COUNT(*) FROM %i', $table )
+			);
+
+			$counts[ $key ] = null !== $result ? (int) $result : null;
+		}
+
+		return $counts;
+	}
+}

--- a/wp-content/plugins/wordpress-groups/readme.txt
+++ b/wp-content/plugins/wordpress-groups/readme.txt
@@ -1,0 +1,82 @@
+=== WordPress Groups ===
+Contributors: wordpressdotorg
+Tags: community, groups, events, meetup, wordpress
+Requires at least: 6.7
+Tested up to: 6.7
+Requires PHP: 8.3
+Stable tag: 0.1.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+A community groups platform for organising WordPress meetups and events on events.wordpress.org.
+
+== Description ==
+
+WordPress Groups provides the tools needed to run a WordPress community groups programme. It powers the events.wordpress.org platform, enabling community organisers to create and manage local WordPress meetup groups, schedule events, and grow their communities.
+
+**Key features:**
+
+* Group management with membership roles (organiser, co-organiser, member).
+* Event scheduling with RSVP tracking and recurring event support.
+* Venue management with geocoding and map integration.
+* Analytics dashboard tracking group health and activity trends.
+* Dormancy detection to identify inactive groups.
+* Slack integration for event notifications.
+* iCal export for calendar subscriptions.
+* REST API for headless and block-based front ends.
+* Organiser onboarding and application workflow.
+* Email notifications for event reminders and announcements.
+
+This plugin is designed for use on WordPress multisite networks and is not intended for general-purpose installations.
+
+== Installation ==
+
+1. Ensure you are running a WordPress multisite network with PHP 8.3 or later.
+2. Upload the `wordpress-groups` folder to the `/wp-content/plugins/` directory.
+3. Network-activate the plugin through the **Network Admin > Plugins** screen.
+4. The required database tables are created automatically on activation.
+5. Configure the plugin settings via the admin dashboard.
+
+== Frequently Asked Questions ==
+
+= Is this plugin available on WordPress.org? =
+
+Not yet. WordPress Groups is currently developed as part of the WordPress.org Meta Team infrastructure.
+
+= Does it work on single-site installations? =
+
+The plugin is designed for multisite networks. Single-site usage is not officially supported.
+
+= How do I report a bug or request a feature? =
+
+Please open an issue on the project's GitHub repository.
+
+= What REST API endpoints are available? =
+
+The plugin registers endpoints under the `groups/v1` namespace for events, memberships, RSVPs, venues, the group directory, and user preferences. A health-check endpoint is also available for administrators.
+
+== Screenshots ==
+
+1. Group directory listing page.
+2. Single event view with RSVP form.
+3. Analytics dashboard showing group activity.
+4. Organiser application workflow screen.
+
+== Changelog ==
+
+= 0.1.0 =
+* Initial scaffold of the WordPress Groups plugin.
+* Event and venue post types with REST API controllers.
+* Membership model with roles and RSVP tracking.
+* Analytics aggregation and dormancy detection.
+* Recurring event generation via cron.
+* Slack and Official Events API integrations.
+* Organiser onboarding and application workflow.
+* Block editor blocks for event display.
+* iCal calendar export.
+* Email notification scheduler.
+
+== Upgrade Notice ==
+
+= 0.1.0 =
+Initial release.


### PR DESCRIPTION
## Summary
- **#209**: Created `.phpcs.xml.dist` in the plugin directory using WordPress-Extra ruleset with text domain and prefix config. Added `lint:php` npm script to `package.json`.
- **#211**: Created `readme.txt` following WordPress.org plugin directory format with description, installation, FAQ, changelog, and screenshots sections.
- **#214**: Added admin-only `GET /groups/v1/health` REST endpoint returning plugin version, DB schema version, cron job next-scheduled times, and custom table row counts.

## Test plan
- [ ] Run `npm run lint:php` to verify PHPCS config works against the includes directory
- [ ] Validate `readme.txt` passes the WordPress.org plugin readme validator
- [ ] As admin, `GET /wp-json/groups/v1/health` returns 200 with all four fields
- [ ] As unauthenticated user, `GET /wp-json/groups/v1/health` returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)