### PR TITLE
Add WP-CLI commands, rate limiter LB filters, and .distignore

### DIFF
--- a/wp-content/plugins/wordpress-groups/.distignore
+++ b/wp-content/plugins/wordpress-groups/.distignore
@@ -1,0 +1,42 @@
+# Directories
+.github/
+.claude/
+bin/
+node_modules/
+tests/
+src/
+
+# Build tooling
+.wp-env.json
+.wp-env.override.json
+.nvmrc
+.gitignore
+.editorconfig
+.eslintrc*
+.stylelintrc*
+.phpcs.xml.dist
+phpcs.xml
+phpunit.xml
+phpunit.xml.dist
+wp-tests-config.php
+jest.config.js
+webpack.config.js
+package.json
+package-lock.json
+composer.json
+composer.lock
+
+# Documentation (except readme.txt which WordPress.org requires)
+*.md
+!readme.txt
+
+# Seed / test data
+seed-data*.php
+
+# IDE and OS files
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+.idea/
+.vscode/

--- a/wp-content/plugins/wordpress-groups/includes/class-cli.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-cli.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * WP-CLI commands for WordPress Groups.
+ *
+ * Provides CLI access to common operations:
+ *   wp groups list
+ *   wp groups aggregate [--date=Y-m-d]
+ *   wp groups dormancy-check
+ *
+ * @package Groups
+ */
+
+namespace Groups;
+
+use WP_CLI;
+use WP_CLI\Formatter;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage WordPress community groups.
+ */
+class CLI {
+
+	/**
+	 * List all group sites.
+	 *
+	 * Queries wp_meetup posts across all statuses and displays them in a
+	 * table with ID, title, status, and linked site ID.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--status=<status>]
+	 * : Filter by post status. Default is any.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 *   - count
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp groups list
+	 *     wp groups list --status=meetup-active
+	 *     wp groups list --format=csv
+	 *
+	 * @subcommand list
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function list_( $args, $assoc_args ) {
+		$query_args = [
+			'post_type'      => 'wp_meetup',
+			'posts_per_page' => -1,
+			'orderby'        => 'title',
+			'order'          => 'ASC',
+		];
+
+		if ( ! empty( $assoc_args['status'] ) ) {
+			$query_args['post_status'] = sanitize_text_field( $assoc_args['status'] );
+		} else {
+			$query_args['post_status'] = 'any';
+		}
+
+		$posts = get_posts( $query_args );
+
+		if ( empty( $posts ) ) {
+			WP_CLI::warning( 'No groups found.' );
+			return;
+		}
+
+		$items = [];
+
+		foreach ( $posts as $post ) {
+			$site_id = get_post_meta( $post->ID, '_meetup_site_id', true );
+
+			$items[] = [
+				'ID'      => $post->ID,
+				'title'   => $post->post_title,
+				'status'  => $post->post_status,
+				'site_id' => $site_id ?: '—',
+			];
+		}
+
+		$format = $assoc_args['format'] ?? 'table';
+
+		$formatter = new Formatter(
+			$assoc_args,
+			[ 'ID', 'title', 'status', 'site_id' ]
+		);
+
+		$formatter->display_items( $items );
+	}
+
+	/**
+	 * Run analytics aggregation.
+	 *
+	 * Triggers the daily analytics aggregation for a specific date.
+	 * Defaults to yesterday if no date is provided.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--date=<date>]
+	 * : Date to aggregate in Y-m-d format. Defaults to yesterday.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp groups aggregate
+	 *     wp groups aggregate --date=2025-12-01
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function aggregate( $args, $assoc_args ) {
+		$date = $assoc_args['date'] ?? gmdate( 'Y-m-d', strtotime( '-1 day' ) );
+
+		// Validate the date format.
+		$parsed = \DateTime::createFromFormat( 'Y-m-d', $date );
+
+		if ( ! $parsed || $parsed->format( 'Y-m-d' ) !== $date ) {
+			WP_CLI::error( "Invalid date format: {$date}. Use Y-m-d (e.g. 2025-12-01)." );
+		}
+
+		WP_CLI::log( "Running analytics aggregation for {$date}..." );
+
+		Analytics\Aggregator::aggregate_for_date( $date );
+
+		WP_CLI::success( "Analytics aggregation complete for {$date}." );
+	}
+
+	/**
+	 * Run dormancy detection.
+	 *
+	 * Checks all active groups for inactivity and flags them as at-risk
+	 * or dormant based on their last event date.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp groups dormancy-check
+	 *
+	 * @subcommand dormancy-check
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function dormancy_check( $args, $assoc_args ) {
+		WP_CLI::log( 'Running dormancy detection...' );
+
+		$detector = new Analytics\Dormancy_Detector();
+		$detector->run();
+
+		WP_CLI::success( 'Dormancy check complete.' );
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/rest/class-rate-limiter.php
+++ b/wp-content/plugins/wordpress-groups/includes/rest/class-rate-limiter.php
@@ -5,6 +5,26 @@
  * Uses transients to track request counts per IP address.
  * Limits POST, PUT, and DELETE requests to 60 per minute.
  *
+ * ## Load Balancer / Multi-Server Note
+ *
+ * This implementation stores counters in the WordPress transient API, which
+ * defaults to the `wp_options` table on single-server installs. This works
+ * reliably for single-server deployments but has limitations in load-balanced
+ * or multi-server environments:
+ *
+ * - If an external object cache (Redis, Memcached) is configured, transients
+ *   are stored there and shared across application servers automatically.
+ * - Without an external object cache, each server maintains its own counters
+ *   in the database, which may allow a client to exceed the intended limit
+ *   by a factor of N (where N is the number of application servers).
+ *
+ * For production load-balanced environments without a shared object cache,
+ * consider using the `groups_rate_limiter_client_ip` filter to integrate
+ * with an upstream rate limiter (e.g. at the CDN or reverse proxy layer),
+ * or use the `groups_rate_limiter_disabled` filter to disable this
+ * application-level limiter entirely in favour of infrastructure-level
+ * rate limiting.
+ *
  * @package Groups\REST
  */
 
@@ -18,6 +38,16 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Applies per-IP rate limiting to write operations on the groups/v1 REST namespace.
+ *
+ * Filters:
+ * - `groups_rate_limiter_disabled` (bool)   — Return true to bypass rate limiting entirely.
+ *                                             Useful when rate limiting is handled at the
+ *                                             infrastructure layer (CDN, reverse proxy).
+ * - `groups_rate_limiter_limit`   (int)     — Override the per-window request limit (default 60).
+ * - `groups_rate_limiter_window`  (int)     — Override the time window in seconds (default 60).
+ * - `groups_rate_limiter_client_ip` (string, WP_REST_Request) — Override the resolved client IP.
+ *                                             Use this when a load balancer or proxy sets a
+ *                                             custom header for the real client IP.
  */
 class Rate_Limiter {
 
@@ -68,6 +98,19 @@ class Rate_Limiter {
 	 * @return mixed|WP_Error Original result or WP_Error if rate limit exceeded.
 	 */
 	public static function check_rate_limit( $result, $server, WP_REST_Request $request ) {
+		/**
+		 * Filters whether the rate limiter is disabled.
+		 *
+		 * Return true to bypass application-level rate limiting, for example
+		 * when rate limiting is handled at the infrastructure layer (CDN,
+		 * reverse proxy, load balancer).
+		 *
+		 * @param bool $disabled Whether rate limiting is disabled. Default false.
+		 */
+		if ( apply_filters( 'groups_rate_limiter_disabled', false ) ) {
+			return $result;
+		}
+
 		// Only limit write operations.
 		if ( ! in_array( $request->get_method(), self::WRITE_METHODS, true ) ) {
 			return $result;
@@ -79,33 +122,59 @@ class Rate_Limiter {
 			return $result;
 		}
 
-		$ip  = self::get_client_ip();
+		$ip = self::get_client_ip();
+
+		/**
+		 * Filters the resolved client IP address for rate limiting.
+		 *
+		 * Use this filter in load-balanced environments where the real client
+		 * IP is provided in a custom header not covered by the default logic.
+		 *
+		 * @param string          $ip      The resolved client IP.
+		 * @param WP_REST_Request $request The current REST request.
+		 */
+		$ip = apply_filters( 'groups_rate_limiter_client_ip', $ip, $request );
+
 		$key = 'groups_rl_' . md5( $ip );
+
+		/**
+		 * Filters the per-window request limit.
+		 *
+		 * @param int $limit The maximum number of write requests per window. Default 60.
+		 */
+		$limit = (int) apply_filters( 'groups_rate_limiter_limit', self::LIMIT );
+
+		/**
+		 * Filters the rate limit time window in seconds.
+		 *
+		 * @param int $window The time window in seconds. Default 60.
+		 */
+		$window = (int) apply_filters( 'groups_rate_limiter_window', self::WINDOW );
 
 		$current = get_transient( $key );
 
 		if ( false === $current ) {
 			// First request in this window.
-			set_transient( $key, 1, self::WINDOW );
+			set_transient( $key, 1, $window );
 			return $result;
 		}
 
 		$current = (int) $current;
 
-		if ( $current >= self::LIMIT ) {
+		if ( $current >= $limit ) {
 			return new WP_Error(
 				'rate_limit_exceeded',
 				__( 'Rate limit exceeded. Please wait before making more requests.', 'wordpress-groups' ),
 				[
 					'status'              => 429,
-					'X-RateLimit-Limit'   => self::LIMIT,
-					'X-RateLimit-Window'  => self::WINDOW,
+					'X-RateLimit-Limit'   => $limit,
+					'X-RateLimit-Window'  => $window,
 				]
 			);
 		}
 
 		// Increment the counter. Use the transient API — the TTL is already set.
-		set_transient( $key, $current + 1, self::WINDOW );
+		set_transient( $key, $current + 1, $window );
 
 		return $result;
 	}
@@ -114,6 +183,13 @@ class Rate_Limiter {
 	 * Get the client's IP address.
 	 *
 	 * Checks common proxy headers before falling back to REMOTE_ADDR.
+	 *
+	 * Note: In load-balanced environments, ensure that the trusted proxy
+	 * headers are set correctly. The X-Forwarded-For header can be spoofed
+	 * by clients if the load balancer does not strip/overwrite it. For
+	 * production deployments behind a load balancer, use the
+	 * `groups_rate_limiter_client_ip` filter to read the correct header
+	 * set by your infrastructure.
 	 *
 	 * @return string Client IP address.
 	 */

--- a/wp-content/plugins/wordpress-groups/wordpress-groups.php
+++ b/wp-content/plugins/wordpress-groups/wordpress-groups.php
@@ -55,3 +55,9 @@ register_activation_hook( __FILE__, 'groups_activate' );
 // Boot the plugin.
 require_once __DIR__ . '/includes/class-plugin.php';
 Groups\Plugin::get_instance();
+
+// Register WP-CLI commands when available.
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once __DIR__ . '/includes/class-cli.php';
+	\WP_CLI::add_command( 'groups', Groups\CLI::class );
+}


### PR DESCRIPTION
## Summary

- **#208** — Adds WP-CLI commands for common operations: `wp groups list` (list all group sites with status/format options), `wp groups aggregate [--date=Y-m-d]` (run analytics aggregation), and `wp groups dormancy-check` (run dormancy detection). Registered via `WP_CLI::add_command()` in a new `includes/class-cli.php`.
- **#213** — Documents the transient-based rate limiter's limitations in load-balanced / multi-server environments. Adds four filters for infrastructure-level overrides: `groups_rate_limiter_disabled`, `groups_rate_limiter_client_ip`, `groups_rate_limiter_limit`, and `groups_rate_limiter_window`.
- **#215** — Creates `.distignore` listing files/directories to exclude from distribution builds (tests/, node_modules/, .github/, bin/, build tooling, *.md except readme.txt, seed data, .wp-env.json, IDE files, etc.).

## Test plan

- [ ] Verify `wp groups list` outputs a table of wp_meetup posts
- [ ] Verify `wp groups aggregate --date=2025-01-01` runs without error
- [ ] Verify `wp groups dormancy-check` runs without error
- [ ] Verify rate limiter filters work: `add_filter('groups_rate_limiter_disabled', '__return_true')` bypasses limiting
- [ ] Verify `.distignore` entries are reasonable for `wp dist-archive` or similar tooling

Closes #208, closes #213, closes #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)