### PR TITLE
Add social proof stats bar to front page

### DIFF
--- a/wp-content/themes/groups-site/templates/front-page.html
+++ b/wp-content/themes/groups-site/templates/front-page.html
@@ -15,18 +15,28 @@
 		<!-- wp:site-title {"level":1,"fontSize":"heading-1","style":{"elements":{"link":{"color":{"text":"var:preset|color|neutral-0"},"typography":{"textDecoration":"none"}}}}} /-->
 
 		<!-- wp:paragraph {"fontSize":"body-lg"} -->
-		<p class="has-body-lg-font-size">Welcome to our WordPress community group. Join us for local meetups, workshops, and learning opportunities.</p>
+		<p class="has-body-lg-font-size">Connect with fellow WordPress enthusiasts. Join us for local meetups, workshops, and hands-on learning — all skill levels welcome.</p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}}} -->
+		<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 		<div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--40)">
 			<!-- wp:button {"backgroundColor":"accent-500","textColor":"neutral-0","style":{"border":{"radius":"8px"},"typography":{"fontWeight":"600"}},"fontSize":"body"} -->
 			<div class="wp-block-button has-custom-font-size has-body-font-size"><a class="wp-block-button__link has-neutral-0-color has-accent-500-background-color has-text-color has-background wp-element-button" style="border-radius:8px;font-weight:600">Browse Events</a></div>
+			<!-- /wp:button -->
+
+			<!-- wp:button {"backgroundColor":"neutral-0","textColor":"primary-700","style":{"border":{"radius":"8px","width":"2px","color":"var:preset|color|primary-300"},"typography":{"fontWeight":"600"}},"fontSize":"body","className":"is-style-outline"} -->
+			<div class="wp-block-button has-custom-font-size has-body-font-size is-style-outline"><a class="wp-block-button__link has-primary-700-color has-neutral-0-background-color has-text-color has-background wp-element-button" style="border-radius:8px;border-color:var(--wp--preset--color--primary-300);border-width:2px;font-weight:600">Join This Group</a></div>
 			<!-- /wp:button -->
 		</div>
 		<!-- /wp:buttons -->
 	</div>
 	<!-- /wp:group -->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"align":"full","backgroundColor":"primary-900","textColor":"neutral-0","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1280px"},"className":"groups-site-stats-bar"} -->
+<div class="wp-block-group alignfull groups-site-stats-bar has-neutral-0-color has-primary-900-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:groups/group-stats {"align":"wide"} /-->
 </div>
 <!-- /wp:group -->
 


### PR DESCRIPTION
## Summary
- Add a visually prominent stats bar between the hero and main content using the existing `groups/group-stats` block on a `primary-900` dark background, showing members, upcoming events, events held, attendees, and next event date
- Improve hero copy to be more welcoming and action-oriented ("Connect with fellow WordPress enthusiasts...")
- Add a secondary "Join This Group" CTA button alongside "Browse Events" for immediate engagement

## Test plan
- [ ] Verify the stats bar renders between the hero and main content on the front page
- [ ] Confirm stats cards display correct numbers (members, events, attendees, next event date)
- [ ] Check the dark background (`primary-900`) provides good contrast with white text
- [ ] Verify both CTA buttons ("Browse Events" and "Join This Group") render correctly
- [ ] Test responsive layout on mobile and tablet viewports

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)