### PR TITLE
Add social proof stats and auto-transition past events (#227, #228)

### DIFF
--- a/wp-content/plugins/wordpress-groups/email-templates/post-event-thanks.html
+++ b/wp-content/plugins/wordpress-groups/email-templates/post-event-thanks.html
@@ -1,0 +1,35 @@
+<h1 style="margin: 0 0 24px 0; font-size: 24px; font-weight: 700; color: #1e1e1e; line-height: 1.3;">
+	Thanks for Attending!
+</h1>
+
+<p style="margin: 0 0 20px 0;">
+	Hi {{user_name}},
+</p>
+
+<p style="margin: 0 0 20px 0;">
+	Thank you for attending <strong>{{event_title}}</strong>. We hope you had a great time and learned something new!
+</p>
+
+<p style="margin: 0 0 20px 0;">
+	Your participation helps make the WordPress community stronger. We look forward to seeing you at future events.
+</p>
+
+<!-- CTA Button -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 0 28px 0;">
+	<tr>
+		<td style="border-radius: 8px; background-color: #3858E9;" class="cta-button">
+			<a href="{{event_url}}" target="_blank" style="display: inline-block; padding: 14px 32px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif; font-size: 15px; font-weight: 600; color: #ffffff; text-decoration: none; border-radius: 8px;">View Event</a>
+		</td>
+	</tr>
+</table>
+
+<!-- Divider -->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: 0 0 20px 0;">
+	<tr>
+		<td class="divider" style="border-top: 1px solid #e8e8e8; font-size: 1px; line-height: 1px;">&nbsp;</td>
+	</tr>
+</table>
+
+<p style="margin: 0 0 8px 0; font-size: 14px; color: #646970;">
+	Keep an eye out for upcoming events from your group. See you next time!
+</p>

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -85,6 +85,8 @@ class Plugin {
 		new Admin\Event_Duplicator();
 		new Workflow\Organizer_Onboarding();
 		new Notifications\Rsvp_Notifications();
+		new Cron\Post_Event_Cron();
+		Cron\Post_Event_Cron::schedule_cron();
 		new Blocks\Recurrence_Panel();
 		new SEO();
 		new Geocoder();

--- a/wp-content/plugins/wordpress-groups/includes/cron/class-post-event-cron.php
+++ b/wp-content/plugins/wordpress-groups/includes/cron/class-post-event-cron.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Post-event cron tasks.
+ *
+ * Runs daily to:
+ * 1. Transition ended events to event-past status.
+ * 2. Send "Thanks for attending" emails the day after an event ends.
+ *
+ * @package Groups\Cron
+ */
+
+namespace Groups\Cron;
+
+use Groups\Models\Event;
+use Groups\Models\Rsvp;
+use Groups\Notifications\Email_Notifier;
+use Groups\Post_Types\Event as Event_Post_Type;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles daily post-event workflow tasks via WP-Cron.
+ */
+class Post_Event_Cron {
+
+	/**
+	 * Cron hook name.
+	 *
+	 * @var string
+	 */
+	const CRON_HOOK = 'groups_post_event_check';
+
+	/**
+	 * Post meta key to track that the thank-you email was sent.
+	 *
+	 * @var string
+	 */
+	const THANKED_META = '_event_thankyou_sent';
+
+	/**
+	 * Constructor. Registers hooks.
+	 */
+	public function __construct() {
+		add_action( self::CRON_HOOK, [ $this, 'run' ] );
+	}
+
+	/**
+	 * Schedule the daily cron event if not already scheduled.
+	 *
+	 * Should be called during plugin initialisation.
+	 */
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Unschedule the cron event.
+	 *
+	 * Called on plugin deactivation.
+	 */
+	public static function unschedule_cron(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Run all post-event tasks.
+	 */
+	public function run(): void {
+		$this->transition_past_events();
+		$this->send_thankyou_emails();
+	}
+
+	/**
+	 * Transition events whose end time has passed to event-past.
+	 *
+	 * Queries for event-active and event-scheduled events where
+	 * `_event_end_utc` is earlier than the current UTC time.
+	 */
+	private function transition_past_events(): void {
+		$now_utc = gmdate( 'Y-m-d H:i:s' );
+
+		$events = get_posts( [
+			'post_type'      => Event_Post_Type::POST_TYPE,
+			'post_status'    => [ 'event-active', 'event-scheduled' ],
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				[
+					'key'     => '_event_end_utc',
+					'value'   => $now_utc,
+					'compare' => '<',
+					'type'    => 'DATETIME',
+				],
+			],
+		] );
+
+		foreach ( $events as $event_id ) {
+			Event::transition_status( (int) $event_id, 'event-past' );
+		}
+	}
+
+	/**
+	 * Send thank-you emails to attendees the day after an event ends.
+	 *
+	 * Queries for event-past events whose end time was between 24 and
+	 * 48 hours ago and that have not yet had thank-you emails sent.
+	 */
+	private function send_thankyou_emails(): void {
+		$now       = time();
+		$after_utc = gmdate( 'Y-m-d H:i:s', $now - ( 2 * DAY_IN_SECONDS ) );
+		$before_utc = gmdate( 'Y-m-d H:i:s', $now - DAY_IN_SECONDS );
+
+		$events = get_posts( [
+			'post_type'      => Event_Post_Type::POST_TYPE,
+			'post_status'    => 'event-past',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				[
+					'key'     => '_event_end_utc',
+					'value'   => [ $after_utc, $before_utc ],
+					'compare' => 'BETWEEN',
+					'type'    => 'DATETIME',
+				],
+				[
+					'key'     => self::THANKED_META,
+					'compare' => 'NOT EXISTS',
+				],
+			],
+		] );
+
+		if ( empty( $events ) ) {
+			return;
+		}
+
+		$notifier = new Email_Notifier();
+
+		foreach ( $events as $event_id ) {
+			$event_id   = (int) $event_id;
+			$event_data = Event::get( $event_id );
+
+			if ( is_wp_error( $event_data ) ) {
+				continue;
+			}
+
+			// Get attendees (those who were marked as attending and confirmed attendance).
+			$rsvps = Rsvp::get_rsvps( $event_id, 'attending' );
+
+			foreach ( $rsvps as $rsvp ) {
+				$attendance_confirmed = get_comment_meta( $rsvp->comment_ID, '_rsvp_attendance_confirmed', true );
+
+				// Only send to users whose attendance was confirmed.
+				if ( ! $attendance_confirmed ) {
+					continue;
+				}
+
+				$user = get_userdata( (int) $rsvp->user_id );
+
+				if ( ! $user ) {
+					continue;
+				}
+
+				/**
+				 * Filters whether to send a thank-you email to a specific attendee.
+				 *
+				 * @param bool $send     Whether to send the email. Default true.
+				 * @param int  $event_id The event post ID.
+				 * @param int  $user_id  The user ID.
+				 */
+				if ( ! apply_filters( 'groups_send_thankyou_email', true, $event_id, (int) $rsvp->user_id ) ) {
+					continue;
+				}
+
+				$notifier->send(
+					$user->user_email,
+					sprintf(
+						/* translators: %s: event title */
+						__( 'Thanks for attending %s!', 'wordpress-groups' ),
+						$event_data['title']
+					),
+					'post-event-thanks',
+					[
+						'event_title' => $event_data['title'],
+						'event_url'   => get_permalink( $event_id ),
+						'user_name'   => $user->display_name,
+					]
+				);
+			}
+
+			// Mark the event so we do not send again.
+			update_post_meta( $event_id, self::THANKED_META, gmdate( 'Y-m-d H:i:s' ) );
+		}
+	}
+
+	/**
+	 * Get attendance summary stats for an event.
+	 *
+	 * @param int $event_id The event post ID.
+	 * @return array{attended: int, no_show: int, total_rsvps: int}
+	 */
+	public static function get_attendance_summary( int $event_id ): array {
+		$all_rsvps = Rsvp::get_rsvps( $event_id );
+		$attended  = 0;
+		$no_show   = 0;
+		$total     = 0;
+
+		foreach ( $all_rsvps as $rsvp ) {
+			$status = get_comment_meta( $rsvp->comment_ID, '_rsvp_status', true );
+
+			// Skip cancelled RSVPs.
+			if ( 'not_attending' === $status ) {
+				continue;
+			}
+
+			++$total;
+
+			if ( 'no_show' === $status ) {
+				++$no_show;
+			} elseif ( get_comment_meta( $rsvp->comment_ID, '_rsvp_attendance_confirmed', true ) ) {
+				++$attended;
+			}
+		}
+
+		return [
+			'attended'    => $attended,
+			'no_show'     => $no_show,
+			'total_rsvps' => $total,
+		];
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/models/class-event.php
+++ b/wp-content/plugins/wordpress-groups/includes/models/class-event.php
@@ -40,7 +40,7 @@ class Event {
 	 */
 	const TRANSITIONS = [
 		'event-draft'     => [ 'event-scheduled', 'event-cancelled' ],
-		'event-scheduled' => [ 'event-active', 'event-cancelled', 'event-draft' ],
+		'event-scheduled' => [ 'event-active', 'event-past', 'event-cancelled', 'event-draft' ],
 		'event-active'    => [ 'event-past', 'event-cancelled' ],
 		'event-past'      => [],
 		'event-cancelled' => [ 'event-draft' ],

--- a/wp-content/themes/groups-site/templates/front-page.html
+++ b/wp-content/themes/groups-site/templates/front-page.html
@@ -30,6 +30,8 @@
 </div>
 <!-- /wp:group -->
 
+<!-- wp:groups/group-stats {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}}} /-->
+
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1280px"},"className":"groups-site-front-main"} -->
 <main class="wp-block-group groups-site-front-main" id="main" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--edge-space)">
 


### PR DESCRIPTION
## Summary
- **#227**: Adds the `groups/group-stats` block to the front page template between the hero section and the upcoming events section, surfacing member count, events held, and other social proof stats.
- **#228**: Wires up `Post_Event_Cron` for daily auto-transition of ended events (`event-scheduled`/`event-active` to `event-past`), sends a "Thanks for attending" email to confirmed attendees the day after an event ends, and adds the `post-event-thanks` email template.
- Adds `event-past` as a valid transition from `event-scheduled` so the cron can transition events that were never manually marked active.

## Test plan
- [ ] Verify front page renders the group stats block between hero and events sections
- [ ] Confirm `groups_post_event_check` cron is scheduled daily after plugin init
- [ ] Create a test event with `_event_end_utc` in the past and `event-scheduled` status; run `do_action('groups_post_event_check')` and verify it transitions to `event-past`
- [ ] Verify thank-you email is sent to confirmed attendees 24-48h after event end
- [ ] Check `post-event-thanks.html` template renders correctly with placeholder substitution

🤖 Generated with [Claude Code](https://claude.com/claude-code)