### PR TITLE
Add post-event lifecycle: auto-transition and thank-you emails

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"daa13708-4e03-4b1b-909b-a4cec9441f31","pid":4084061,"acquiredAt":1774064910100}

--- a/wp-content/plugins/wordpress-groups/email-templates/post-event-thanks.html
+++ b/wp-content/plugins/wordpress-groups/email-templates/post-event-thanks.html
@@ -1,0 +1,21 @@
+<tr>
+	<td style="padding: 32px 40px;">
+		<h2 style="margin: 0 0 16px; font-size: 24px; color: #1C1922;">Thanks for coming!</h2>
+		<p style="margin: 0 0 24px; font-size: 16px; line-height: 1.6; color: #47434F;">
+			Hi {{user_name}},
+		</p>
+		<p style="margin: 0 0 24px; font-size: 16px; line-height: 1.6; color: #47434F;">
+			Thank you for attending <strong>{{event_title}}</strong>. We hope you enjoyed it!
+		</p>
+		<p style="margin: 0 0 24px; font-size: 16px; line-height: 1.6; color: #47434F;">
+			Your participation makes our community stronger. We'd love to see you at the next event.
+		</p>
+		<table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin: 0 auto;">
+			<tr>
+				<td style="border-radius: 8px; background-color: #2D41A6;">
+					<a href="{{group_url}}" style="display: inline-block; padding: 14px 28px; font-size: 16px; font-weight: 600; color: #ffffff; text-decoration: none;">See Upcoming Events</a>
+				</td>
+			</tr>
+		</table>
+	</td>
+</tr>

--- a/wp-content/plugins/wordpress-groups/includes/class-plugin.php
+++ b/wp-content/plugins/wordpress-groups/includes/class-plugin.php
@@ -69,6 +69,8 @@ class Plugin {
 		Analytics\Aggregator::schedule_cron();
 		new Analytics\Dormancy_Detector();
 		Analytics\Dormancy_Detector::schedule_cron();
+		new Models\Event_Lifecycle();
+		Models\Event_Lifecycle::schedule_cron();
 		new Calendar\ICal_Export();
 		new Notifications\Scheduler();
 		new Notifications\Announcements();

--- a/wp-content/plugins/wordpress-groups/includes/models/class-event-lifecycle.php
+++ b/wp-content/plugins/wordpress-groups/includes/models/class-event-lifecycle.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Handles automatic event lifecycle transitions.
+ *
+ * @package Groups\Models
+ */
+
+namespace Groups\Models;
+
+use Groups\Notifications\Email_Notifier;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Transitions events to past status when their end time has passed,
+ * and sends post-event thank-you emails.
+ */
+class Event_Lifecycle {
+
+	const CRON_HOOK = 'groups_event_lifecycle_check';
+
+	/**
+	 * Register hooks.
+	 */
+	public function __construct() {
+		add_action( self::CRON_HOOK, [ $this, 'run' ] );
+	}
+
+	/**
+	 * Schedule the daily cron.
+	 */
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Run lifecycle checks across all group sites.
+	 */
+	public function run(): void {
+		$this->transition_past_events();
+		$this->send_post_event_emails();
+	}
+
+	/**
+	 * Transition events whose end time has passed to event-past.
+	 */
+	private function transition_past_events(): void {
+		$now = gmdate( 'Y-m-d H:i:s' );
+
+		$events = get_posts( [
+			'post_type'      => 'event',
+			'post_status'    => [ 'event-scheduled', 'event-active' ],
+			'posts_per_page' => 50,
+			'meta_query'     => [
+				[
+					'key'     => '_event_end_utc',
+					'value'   => $now,
+					'compare' => '<',
+					'type'    => 'DATETIME',
+				],
+			],
+		] );
+
+		foreach ( $events as $event ) {
+			wp_update_post( [
+				'ID'          => $event->ID,
+				'post_status' => 'event-past',
+			] );
+		}
+	}
+
+	/**
+	 * Send thank-you emails for events that ended yesterday.
+	 */
+	private function send_post_event_emails(): void {
+		$yesterday_start = gmdate( 'Y-m-d 00:00:00', strtotime( '-1 day' ) );
+		$yesterday_end   = gmdate( 'Y-m-d 23:59:59', strtotime( '-1 day' ) );
+
+		$events = get_posts( [
+			'post_type'      => 'event',
+			'post_status'    => 'event-past',
+			'posts_per_page' => 20,
+			'meta_query'     => [
+				[
+					'key'     => '_event_end_utc',
+					'value'   => [ $yesterday_start, $yesterday_end ],
+					'compare' => 'BETWEEN',
+					'type'    => 'DATETIME',
+				],
+			],
+		] );
+
+		foreach ( $events as $event ) {
+			// Skip if already sent.
+			if ( get_post_meta( $event->ID, '_event_thanks_sent', true ) ) {
+				continue;
+			}
+
+			$attendees = get_comments( [
+				'post_id'    => $event->ID,
+				'type'       => 'groups_rsvp',
+				'status'     => 'approve',
+				'meta_key'   => '_rsvp_status',
+				'meta_value' => 'attending',
+			] );
+
+			foreach ( $attendees as $rsvp ) {
+				if ( ! $rsvp->comment_author_email ) {
+					continue;
+				}
+
+				Email_Notifier::send(
+					$rsvp->comment_author_email,
+					sprintf(
+						/* translators: %s: event title */
+						__( 'Thanks for attending: %s', 'wordpress-groups' ),
+						get_the_title( $event->ID )
+					),
+					'post-event-thanks',
+					[
+						'user_name'   => $rsvp->comment_author,
+						'event_title' => get_the_title( $event->ID ),
+						'event_url'   => get_permalink( $event->ID ),
+						'group_name'  => get_bloginfo( 'name' ),
+						'group_url'   => home_url( '/' ),
+					]
+				);
+			}
+
+			update_post_meta( $event->ID, '_event_thanks_sent', 1 );
+		}
+	}
+}

--- a/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Email_Templates.php
+++ b/wp-content/plugins/wordpress-groups/tests/phpunit/notifications/Test_Email_Templates.php
@@ -317,6 +317,7 @@ class Test_Email_Templates extends WP_UnitTestCase {
 			'dormancy-alert',
 			'event-reminder',
 			'group-announcement',
+			'post-event-thanks',
 			'rsvp-confirmation',
 			'rsvp-promotion',
 			'welcome-organizer',


### PR DESCRIPTION
Closes #228. Auto-transitions past events and sends thank-you emails to attendees.