### PR TITLE
Add guest/anonymous RSVP for logged-out users

### DIFF
--- a/wp-content/plugins/wordpress-groups/blocks/rsvp-button/render.php
+++ b/wp-content/plugins/wordpress-groups/blocks/rsvp-button/render.php
@@ -117,6 +117,19 @@ $button_text = match ( $initial_state ) {
 					<span class="wp-block-groups-rsvp-button__label"><?php esc_html_e( 'Create Account', 'wordpress-groups' ); ?></span>
 				</a>
 			<?php endif; ?>
+			<div class="wp-block-groups-rsvp-button__guest-divider">
+				<span><?php esc_html_e( 'or RSVP as a guest', 'wordpress-groups' ); ?></span>
+			</div>
+			<form class="wp-block-groups-rsvp-button__guest-form" data-event-id="<?php echo esc_attr( $event_id ); ?>" data-api-url="<?php echo esc_url( rest_url( 'groups/v1/events/' . $event_id . '/rsvps/guest-rsvp' ) ); ?>">
+				<input type="text" name="guest_name" placeholder="<?php esc_attr_e( 'Your name', 'wordpress-groups' ); ?>" required aria-label="<?php esc_attr_e( 'Your name', 'wordpress-groups' ); ?>" />
+				<input type="email" name="guest_email" placeholder="<?php esc_attr_e( 'Your email', 'wordpress-groups' ); ?>" required aria-label="<?php esc_attr_e( 'Your email', 'wordpress-groups' ); ?>" />
+				<button type="submit" class="wp-block-groups-rsvp-button__btn wp-block-groups-rsvp-button__btn--guest">
+					<span class="wp-block-groups-rsvp-button__label"><?php esc_html_e( 'RSVP as Guest', 'wordpress-groups' ); ?></span>
+				</button>
+				<p class="wp-block-groups-rsvp-button__guest-note">
+					<?php esc_html_e( 'We\'ll send a confirmation to your email.', 'wordpress-groups' ); ?>
+				</p>
+			</form>
 		</div>
 	<?php else : ?>
 		<button

--- a/wp-content/plugins/wordpress-groups/blocks/rsvp-button/view.js
+++ b/wp-content/plugins/wordpress-groups/blocks/rsvp-button/view.js
@@ -255,11 +255,56 @@ function init() {
 	} );
 }
 
+/**
+ * Handle guest RSVP forms (no React — plain DOM).
+ */
+function initGuestForms() {
+	document.querySelectorAll( '.wp-block-groups-rsvp-button__guest-form' ).forEach( ( form ) => {
+		form.addEventListener( 'submit', async ( e ) => {
+			e.preventDefault();
+			const btn = form.querySelector( 'button[type="submit"]' );
+			const eventId = form.dataset.eventId;
+			const name = form.querySelector( 'input[name="guest_name"]' ).value;
+			const email = form.querySelector( 'input[name="guest_email"]' ).value;
+
+			btn.disabled = true;
+			btn.textContent = 'Submitting…';
+
+			try {
+				const resp = await window.fetch( form.dataset.apiUrl, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify( { event_id: parseInt( eventId, 10 ), email, name } ),
+				} );
+				const data = await resp.json();
+
+				if ( resp.ok ) {
+					form.innerHTML = '<p class="wp-block-groups-rsvp-button__guest-success" role="status">✓ ' +
+						( data.status === 'waitlisted' ? 'You\'re on the waitlist!' : 'You\'re confirmed!' ) +
+						' Check your email.</p>';
+				} else {
+					btn.disabled = false;
+					btn.textContent = 'RSVP as Guest';
+					const note = form.querySelector( '.wp-block-groups-rsvp-button__guest-note' );
+					if ( note ) {
+						note.textContent = data.message || 'Something went wrong.';
+						note.style.color = 'var(--wp--preset--color--error-700, #B91C1C)';
+					}
+				}
+			} catch {
+				btn.disabled = false;
+				btn.textContent = 'RSVP as Guest';
+			}
+		} );
+	} );
+}
+
 // Hydrate when the DOM is ready (skip during tests).
 if ( typeof document !== 'undefined' ) {
 	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', init );
+		document.addEventListener( 'DOMContentLoaded', () => { init(); initGuestForms(); } );
 	} else {
 		init();
+		initGuestForms();
 	}
 }

--- a/wp-content/plugins/wordpress-groups/includes/models/class-guest-rsvp.php
+++ b/wp-content/plugins/wordpress-groups/includes/models/class-guest-rsvp.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Guest RSVP support for logged-out users.
+ *
+ * Allows anonymous users to RSVP via email + token verification.
+ *
+ * @package Groups\Models
+ */
+
+namespace Groups\Models;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles email-based RSVP for non-authenticated users.
+ */
+class Guest_Rsvp {
+
+	/**
+	 * Create a guest RSVP for an event.
+	 *
+	 * @param int    $event_id Event post ID.
+	 * @param string $email    Guest's email address.
+	 * @param string $name     Guest's display name.
+	 * @return int|WP_Error Comment ID or error.
+	 */
+	public static function create( int $event_id, string $email, string $name ) {
+		$event = get_post( $event_id );
+		if ( ! $event || 'event' !== $event->post_type ) {
+			return new \WP_Error( 'invalid_event', __( 'Invalid event.', 'wordpress-groups' ) );
+		}
+
+		if ( ! is_email( $email ) ) {
+			return new \WP_Error( 'invalid_email', __( 'Please enter a valid email address.', 'wordpress-groups' ) );
+		}
+
+		$name = sanitize_text_field( $name );
+		if ( empty( $name ) ) {
+			return new \WP_Error( 'empty_name', __( 'Please enter your name.', 'wordpress-groups' ) );
+		}
+
+		// Check for existing RSVP with this email.
+		$existing = get_comments( [
+			'post_id'      => $event_id,
+			'type'         => 'groups_rsvp',
+			'author_email' => $email,
+			'number'       => 1,
+		] );
+
+		if ( ! empty( $existing ) ) {
+			$status = get_comment_meta( $existing[0]->comment_ID, '_rsvp_status', true );
+			if ( 'not_attending' !== $status ) {
+				return new \WP_Error( 'already_rsvped', __( 'This email is already registered for this event.', 'wordpress-groups' ) );
+			}
+			// Re-activate cancelled RSVP.
+			update_comment_meta( $existing[0]->comment_ID, '_rsvp_status', 'attending' );
+			return $existing[0]->comment_ID;
+		}
+
+		// Check capacity.
+		$limit = (int) get_post_meta( $event_id, '_event_attendee_limit', true );
+		if ( $limit > 0 ) {
+			$attending = Rsvp::get_count( $event_id, 'attending' );
+			$status    = $attending >= $limit ? 'waitlisted' : 'attending';
+		} else {
+			$status = 'attending';
+		}
+
+		// Generate verification token.
+		$token = wp_generate_password( 32, false );
+
+		$comment_id = wp_insert_comment( [
+			'comment_post_ID'      => $event_id,
+			'user_id'              => 0,
+			'comment_author'       => $name,
+			'comment_author_email' => $email,
+			'comment_type'         => 'groups_rsvp',
+			'comment_approved'     => 1,
+			'comment_content'      => '',
+		] );
+
+		if ( ! $comment_id ) {
+			return new \WP_Error( 'rsvp_failed', __( 'Could not create RSVP.', 'wordpress-groups' ) );
+		}
+
+		update_comment_meta( $comment_id, '_rsvp_status', $status );
+		update_comment_meta( $comment_id, '_rsvp_guest_count', 0 );
+		update_comment_meta( $comment_id, '_rsvp_token', wp_hash( $token ) );
+		update_comment_meta( $comment_id, '_rsvp_is_guest', 1 );
+
+		/**
+		 * Fires when a guest RSVP is created.
+		 *
+		 * @param int    $comment_id Comment ID.
+		 * @param int    $event_id   Event post ID.
+		 * @param string $email      Guest email.
+		 * @param string $status     RSVP status.
+		 * @param string $token      Raw verification token.
+		 */
+		do_action( 'groups_guest_rsvp_created', $comment_id, $event_id, $email, $status, $token );
+
+		return $comment_id;
+	}
+
+	/**
+	 * Cancel a guest RSVP using email + token.
+	 *
+	 * @param int    $event_id Event post ID.
+	 * @param string $email    Guest email.
+	 * @param string $token    Verification token.
+	 * @return bool|WP_Error True on success.
+	 */
+	public static function cancel( int $event_id, string $email, string $token ) {
+		$comment = self::verify( $event_id, $email, $token );
+		if ( is_wp_error( $comment ) ) {
+			return $comment;
+		}
+
+		$was_attending = 'attending' === get_comment_meta( $comment->comment_ID, '_rsvp_status', true );
+		update_comment_meta( $comment->comment_ID, '_rsvp_status', 'not_attending' );
+
+		if ( $was_attending ) {
+			Rsvp::promote_next( $event_id );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Verify a guest RSVP token.
+	 *
+	 * @param int    $event_id Event post ID.
+	 * @param string $email    Guest email.
+	 * @param string $token    Raw token.
+	 * @return WP_Comment|WP_Error The RSVP comment or error.
+	 */
+	public static function verify( int $event_id, string $email, string $token ) {
+		$comments = get_comments( [
+			'post_id'      => $event_id,
+			'type'         => 'groups_rsvp',
+			'author_email' => $email,
+			'number'       => 1,
+		] );
+
+		if ( empty( $comments ) ) {
+			return new \WP_Error( 'not_found', __( 'No RSVP found for this email.', 'wordpress-groups' ) );
+		}
+
+		$stored_hash = get_comment_meta( $comments[0]->comment_ID, '_rsvp_token', true );
+		if ( ! $stored_hash || ! hash_equals( $stored_hash, wp_hash( $token ) ) ) {
+			return new \WP_Error( 'invalid_token', __( 'Invalid verification token.', 'wordpress-groups' ) );
+		}
+
+		return $comments[0];
+	}
+}

--- a/wp-content/plugins/wordpress-groups/includes/rest/class-rsvp-controller.php
+++ b/wp-content/plugins/wordpress-groups/includes/rest/class-rsvp-controller.php
@@ -133,6 +133,37 @@ class Rsvp_Controller extends WP_REST_Controller {
 			]
 		);
 
+		// POST /events/{event_id}/guest-rsvp — anonymous/guest RSVP.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/guest-rsvp',
+			[
+				[
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'create_guest_rsvp' ],
+					'permission_callback' => '__return_true', // Public endpoint.
+					'args'                => [
+						'event_id' => [
+							'description' => __( 'The event ID.', 'wordpress-groups' ),
+							'type'        => 'integer',
+							'required'    => true,
+						],
+						'email'    => [
+							'description' => __( 'Guest email address.', 'wordpress-groups' ),
+							'type'        => 'string',
+							'required'    => true,
+							'format'      => 'email',
+						],
+						'name'     => [
+							'description' => __( 'Guest display name.', 'wordpress-groups' ),
+							'type'        => 'string',
+							'required'    => true,
+						],
+					],
+				],
+			]
+		);
+
 		// POST /events/{event_id}/attendance — mark attendance (organizer only).
 		register_rest_route(
 			$this->namespace,
@@ -642,5 +673,35 @@ class Rsvp_Controller extends WP_REST_Controller {
 		];
 
 		return $this->add_additional_fields_schema( $this->schema );
+	}
+
+	/**
+	 * Create a guest RSVP (no authentication required).
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function create_guest_rsvp( $request ) {
+		$event_id = absint( $request->get_param( 'event_id' ) );
+		$email    = sanitize_email( $request->get_param( 'email' ) );
+		$name     = sanitize_text_field( $request->get_param( 'name' ) );
+
+		$result = \Groups\Models\Guest_Rsvp::create( $event_id, $email, $name );
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_Error(
+				$result->get_error_code(),
+				$result->get_error_message(),
+				[ 'status' => 400 ]
+			);
+		}
+
+		return new \WP_REST_Response(
+			[
+				'id'     => $result,
+				'status' => get_comment_meta( $result, '_rsvp_status', true ),
+			],
+			201
+		);
 	}
 }


### PR DESCRIPTION
Closes #230. Logged-out visitors can now RSVP with name + email. Token-based verification for cancellation.