### PR TITLE
Add Playwright E2E browser tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"start:blocks": "wp-scripts start --webpack-src-dir=wp-content/plugins/wordpress-groups/blocks --output-path=wp-content/plugins/wordpress-groups/build",
 		"build:blocks": "wp-scripts build --webpack-src-dir=wp-content/plugins/wordpress-groups/blocks --output-path=wp-content/plugins/wordpress-groups/build",
 		"test:js": "wp-scripts test-unit-js --config jest.config.js",
+		"test:e2e": "playwright test",
 		"env": "wp-env",
 		"env:setup": "bash bin/setup.sh",
 		"env:start": "wp-env start",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,26 @@
+/**
+ * Playwright E2E test configuration.
+ *
+ * Tests run against the wp-env local development environment.
+ * Start with: npm run env:start
+ * Run with: npx playwright test
+ */
+
+const { defineConfig } = require( '@playwright/test' );
+
+module.exports = defineConfig( {
+	testDir: './tests/e2e',
+	timeout: 30000,
+	retries: 1,
+	use: {
+		baseURL: process.env.WP_BASE_URL || 'http://localhost:8889',
+		screenshot: 'only-on-failure',
+		trace: 'retain-on-failure',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { browserName: 'chromium' },
+		},
+	],
+} );

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,0 +1,85 @@
+/**
+ * E2E smoke tests — verify critical pages load and key elements render.
+ *
+ * Run: npx playwright test
+ * Requires: npm run env:start
+ */
+
+const { test, expect } = require( '@playwright/test' );
+
+test.describe( 'Main directory site', () => {
+	test( 'homepage loads with group directory', async ( { page } ) => {
+		await page.goto( '/' );
+		await expect( page ).toHaveTitle( /WordPress Community Groups/ );
+		await expect( page.locator( 'body' ) ).toBeVisible();
+	} );
+} );
+
+test.describe( 'Melbourne group site', () => {
+	test( 'homepage loads', async ( { page } ) => {
+		await page.goto( '/melbourne/' );
+		await expect( page ).toHaveTitle( /WordPress Melbourne/ );
+	} );
+
+	test( 'events page loads', async ( { page } ) => {
+		await page.goto( '/melbourne/events/' );
+		await expect( page.locator( 'body' ) ).toBeVisible();
+	} );
+
+	test( 'members page loads', async ( { page } ) => {
+		await page.goto( '/melbourne/members/' );
+		await expect( page.locator( 'body' ) ).toBeVisible();
+	} );
+
+	test( 'single event page has RSVP button', async ( { page } ) => {
+		await page.goto( '/melbourne/' );
+		// Find first event link and click it.
+		const eventLink = page.locator( 'a[href*="/event/"]' ).first();
+		if ( await eventLink.isVisible() ) {
+			await eventLink.click();
+			// Should have RSVP-related content.
+			await expect( page.locator( '.wp-block-groups-rsvp-button' ) ).toBeVisible();
+		}
+	} );
+
+	test( 'guest RSVP form visible for logged-out users', async ( { page } ) => {
+		await page.goto( '/melbourne/' );
+		const eventLink = page.locator( 'a[href*="/event/"]' ).first();
+		if ( await eventLink.isVisible() ) {
+			await eventLink.click();
+			// Guest form should be visible for logged-out users.
+			const guestForm = page.locator( '.wp-block-groups-rsvp-button__guest-form' );
+			if ( await guestForm.isVisible() ) {
+				await expect( guestForm.locator( 'input[name="guest_name"]' ) ).toBeVisible();
+				await expect( guestForm.locator( 'input[name="guest_email"]' ) ).toBeVisible();
+			}
+		}
+	} );
+} );
+
+test.describe( 'Tokyo group site', () => {
+	test( 'homepage loads', async ( { page } ) => {
+		await page.goto( '/tokyo/' );
+		await expect( page ).toHaveTitle( /WordPress Tokyo/ );
+	} );
+} );
+
+test.describe( 'REST API', () => {
+	test( 'events endpoint returns JSON', async ( { request } ) => {
+		const response = await request.get( '/melbourne/wp-json/groups/v1/events' );
+		expect( response.ok() ).toBeTruthy();
+		const data = await response.json();
+		expect( Array.isArray( data ) ).toBeTruthy();
+	} );
+
+	test( 'groups directory endpoint returns JSON', async ( { request } ) => {
+		const response = await request.get( '/wp-json/groups/v1/groups' );
+		expect( response.ok() ).toBeTruthy();
+	} );
+
+	test( 'health endpoint requires auth', async ( { request } ) => {
+		const response = await request.get( '/wp-json/groups/v1/health' );
+		// Should be 401 for unauthenticated.
+		expect( response.status() ).toBe( 401 );
+	} );
+} );


### PR DESCRIPTION
Browser-based E2E tests for critical pages and user flows. Complements existing bash smoke tests.